### PR TITLE
Changes gridSize to be a static variable

### DIFF
--- a/unity/Assets/Scripts/DiscreteRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/DiscreteRemoteFPSAgentController.cs
@@ -29,7 +29,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 		private Dictionary<int, Material[]> currentMaskMaterials;
 		private SimObj currentMaskObj;
 		private SimObj currentHandSimObj;
-		private float gridSize;
+		private static float gridSize;
 
 
 		private enum emitStates {Send, Wait, Received};
@@ -76,7 +76,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
 		public void Initialize(ServerAction action) {
 
-			this.gridSize = action.gridSize;
+			gridSize = action.gridSize;
 			StartCoroutine (checkInitializeAgentLocationAction ());
 		}
 
@@ -87,7 +87,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 			// move ahead
 			// move back
 			Debug.Log("trying to find nearest location on the grid");
-			float mult = 1 / gridSize;
+			float mult = Convert.ToSingle(Math.Max(1 / gridSize, 0.00001));
 			float grid_x1 = Convert.ToSingle(Math.Floor(this.transform.position.x * mult) / mult);
 			float grid_z1 = Convert.ToSingle(Math.Floor(this.transform.position.z * mult) / mult);
 
@@ -161,8 +161,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 		}
 
 		private void snapToGrid() {
-			float mult = 1 / this.gridSize;
-
+			float mult = Convert.ToSingle(Math.Max(1 / gridSize, 0.00001));
 			float gridX = Convert.ToSingle (Math.Round (this.transform.position.x * mult) / mult);
 			float gridZ = Convert.ToSingle (Math.Round (this.transform.position.z * mult) / mult);
 			this.transform.position = new Vector3 (gridX, transform.position.y, gridZ);
@@ -441,7 +440,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
 		virtual protected void moveCharacter(ServerAction action, int targetOrientation) {
 			resetHand ();
-			moveMagnitude = this.gridSize;
+			moveMagnitude = gridSize;
 			if (action.moveMagnitude > 0) {
 				moveMagnitude = action.moveMagnitude;
 			}

--- a/unity/Assets/Scripts/DiscreteRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/DiscreteRemoteFPSAgentController.cs
@@ -29,7 +29,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 		private Dictionary<int, Material[]> currentMaskMaterials;
 		private SimObj currentMaskObj;
 		private SimObj currentHandSimObj;
-		private static float gridSize;
+		private static float gridSize = 0.25;
 
 
 		private enum emitStates {Send, Wait, Received};
@@ -86,8 +86,14 @@ namespace UnityStandardAssets.Characters.FirstPerson
 			Vector3 startingPosition = this.transform.position;
 			// move ahead
 			// move back
+
 			Debug.Log("trying to find nearest location on the grid");
-			float mult = Convert.ToSingle(Math.Max(1 / gridSize, 0.00001));
+			if (gridSize <= 0 || gridSize > 5) {
+				Debug.Log ("grid size must be in the range (0,5]");
+				errorMessage = "grid size must be in the range (0,5]";
+				actionFinished (false);
+			}
+			float mult = 1 / gridSize;
 			float grid_x1 = Convert.ToSingle(Math.Floor(this.transform.position.x * mult) / mult);
 			float grid_z1 = Convert.ToSingle(Math.Floor(this.transform.position.z * mult) / mult);
 
@@ -161,7 +167,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 		}
 
 		private void snapToGrid() {
-			float mult = Convert.ToSingle(Math.Max(1 / gridSize, 0.00001));
+			float mult = 1 / gridSize;
 			float gridX = Convert.ToSingle (Math.Round (this.transform.position.x * mult) / mult);
 			float gridZ = Convert.ToSingle (Math.Round (this.transform.position.z * mult) / mult);
 			this.transform.position = new Vector3 (gridX, transform.position.y, gridZ);


### PR DESCRIPTION
Without this change, every time a new scene is loaded, the grid has to be reset because the Discrete object is created anew. Making it a static variable applies the change to any future scenes also loaded, but it can be changed later by calling initialize again.

This also adds in a check that the grid size is greater than some small value in case the user doesn't ever specify the grid size.