### PR TITLE
accept grid_size as parameter for BFSController

### DIFF
--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -621,7 +621,7 @@ class BFSSearchPoint:
 
 class BFSController(Controller):
 
-    def __init__(self):
+    def __init__(self, grid_size=0.25):
         super(BFSController, self).__init__()
         self.rotations = [0, 90, 180, 270]
         self.horizons = [330, 0, 30]
@@ -629,7 +629,7 @@ class BFSController(Controller):
         self.queue = deque()
         self.seen_points = []
         self.grid_points = []
-        self.grid_size = 0.25
+        self.grid_size = grid_size
 
     def visualize_points(self, scene_name, wait_key=10):
         import cv2
@@ -817,7 +817,7 @@ class BFSController(Controller):
         self.seen_points = []
         self.grid_points = []
         event = self.reset(scene_name)
-        event = self.step(dict(action='Initialize', gridSize=0.25))
+        event = self.step(dict(action='Initialize', gridSize=self.grid_size))
         self.enqueue_points(event.metadata['agent']['position'])
         while self.queue:
             self.queue_step()


### PR DESCRIPTION
I took a look at this issue:
https://github.com/allenai/ai2thor/issues/29

I also needed a similar feature so I added the grid_size as a parameter. Currently for a project, I'm trying to write a layer to make this compatible in continuous space. The grid_size and the grid_points allow me to create some kind of a map of the environment which I'm planning on using for collision detection. I got down to grid_size of 0.05 but I'm running into some issues if I go lower than that.

Thank you for the great simulator! 