### PR TITLE
Adding a dummy quality setting to avoid unity bug where quality level 0 is ignored on startup.

### DIFF
--- a/ai2thor/_quality_settings.py
+++ b/ai2thor/_quality_settings.py
@@ -1,10 +1,11 @@
 # GENERATED FILE - DO NOT EDIT
 DEFAULT_QUALITY = 'Ultra'
-QUALITY_SETTINGS = {'High': 4,
- 'High WebGL': 7,
- 'Low': 1,
- 'Medium': 2,
- 'MediumCloseFitShadows': 3,
- 'Ultra': 6,
- 'Very High': 5,
- 'Very Low': 0}
+QUALITY_SETTINGS = {'DONOTUSE': 0,
+ 'High': 5,
+ 'High WebGL': 8,
+ 'Low': 2,
+ 'Medium': 3,
+ 'MediumCloseFitShadows': 4,
+ 'Ultra': 7,
+ 'Very High': 6,
+ 'Very Low': 1}

--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -614,6 +614,9 @@ class Controller(object):
 
         command = self.executable_path()
         fullscreen = 1 if self.fullscreen else 0
+        if QUALITY_SETTINGS[self.quality] == 0:
+            raise RuntimeError("Quality {} is associated with an index of 0. "
+                               "Due to a bug in unity, this quality setting would be ignored.".format(self.quality))
         command += " -screen-fullscreen %s -screen-quality %s -screen-width %s -screen-height %s" % (fullscreen, QUALITY_SETTINGS[self.quality], width, height)
         return shlex.split(command)
 

--- a/unity/ProjectSettings/QualitySettings.asset
+++ b/unity/ProjectSettings/QualitySettings.asset
@@ -7,6 +7,35 @@ QualitySettings:
   m_CurrentQuality: 6
   m_QualitySettings:
   - serializedVersion: 2
+    name: DONOTUSE
+    pixelLightCount: 0
+    shadows: 0
+    shadowResolution: 0
+    shadowProjection: 0
+    shadowCascades: 1
+    shadowDistance: 0
+    shadowNearPlaneOffset: 0
+    shadowCascade2Split: 0.33333334
+    shadowCascade4Split: {x: 0.06666667, y: 0.15571955, z: 0.46666664}
+    shadowmaskMode: 0
+    blendWeights: 1
+    textureQuality: 3
+    anisotropicTextures: 0
+    antiAliasing: 0
+    softParticles: 0
+    softVegetation: 1
+    realtimeReflectionProbes: 0
+    billboardsFaceCameraPosition: 0
+    vSyncCount: 0
+    lodBias: 1
+    maximumLODLevel: 0
+    particleRaycastBudget: 0
+    asyncUploadTimeSlice: 2
+    asyncUploadBufferSize: 4
+    resolutionScalingFixedDPIFactor: 0
+    excludedTargetPlatforms:
+    - Standalone
+  - serializedVersion: 2
     name: Very Low
     pixelLightCount: 0
     shadows: 0


### PR DESCRIPTION
Adding a dummy quality setting to avoid unity bug where quality level 0 is ignored on startup.