### PR TITLE
Added conversion for TeleportFull horizon values.

### DIFF
--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -62,6 +62,17 @@ namespace UnityStandardAssets.Characters.FirstPerson
 		protected float[] headingAngles = new float[] { 0.0f, 90.0f, 180.0f, 270.0f };
 		protected float[] horizonAngles = new float[] { 60.0f, 30.0f, 0.0f, 330.0f };
 
+		//When passing in the TeleportFull action's horizon value, these are the only values that should be allowed
+		//they will be translated to the actual horizonAngles used above, as 30 should rotate the agent's camera 30 degrees up, but actually the
+		//value 330 or -30 about the x axis is what will angle the camera up... so yeah this is just to make it less confusing for the user
+		protected Dictionary<int, float> validHorizonAngleValues = new Dictionary<int, float>()
+		{
+			{30, -30.0f},
+			{0, 0.0f},
+			{-30, 30.0f},
+			{-60, 60.0f},
+		};
+
 		//allow agent to push sim objects that can move, for physics
 		protected bool PushMode = false;
 		protected int actionCounter;

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -348,6 +348,21 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         break;
                     }
 
+                case "tele":
+                    {
+                        ServerAction action = new ServerAction();
+                        action.action = "TeleportFull";
+
+                        action.x = 1.5f;
+                        action.y = 1f;
+                        action.z = -1.75f;
+
+                        action.horizon = 0;
+
+                        PhysicsController.ProcessControlCommand(action);
+                        break;
+                    }
+
                 case "put":
                     {
                         ServerAction action = new ServerAction();

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1052,6 +1052,21 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
         public void TeleportFull(ServerAction action) {
 			targetTeleport = new Vector3 (action.x, action.y, action.z);
+            float targetHorizon;
+
+            //check to make sure valid horizon angles are passed in
+            if(!validHorizonAngleValues.ContainsKey(action.horizon))
+            {
+                errorMessage = "Horizon angle value invalid! Please use a valid angle (30 to look up 30 degrees, 0 to look stright ahead, -30 to look down 30 degrees, -60 to look down 60 degrees)";
+                actionFinished(false);
+                return;
+            }
+
+            //grab the actual value needed to rotate the x axis based on the horizon key value
+            else
+            {
+                targetHorizon = validHorizonAngleValues[action.horizon];
+            }
 
             if (action.forceAction) {
                 DefaultAgentHand(action);
@@ -1062,7 +1077,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 } else {
                     m_Camera.transform.localPosition = crouchingLocalCameraPosition;
                 }
-                m_Camera.transform.localEulerAngles = new Vector3 (action.horizon, 0.0f, 0.0f);
+                m_Camera.transform.localEulerAngles = new Vector3 (targetHorizon, 0.0f, 0.0f);
             } else {
                 if (!sceneBounds.Contains(targetTeleport)) {
                     errorMessage = "Teleport target out of scene bounds.";
@@ -1089,7 +1104,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 } else {
                     m_Camera.transform.localPosition = crouchingLocalCameraPosition;
                 }
-                m_Camera.transform.localEulerAngles = new Vector3 (action.horizon, 0.0f, 0.0f);
+                m_Camera.transform.localEulerAngles = new Vector3 (targetHorizon, 0.0f, 0.0f);
 
                 bool agentCollides = isAgentCapsuleColliding();
                 bool handObjectCollides = isHandObjectColliding();


### PR DESCRIPTION
Users now can use 30, 0, -30, -60 as expected rather than dealing with Unity's weird x axis rotation orientation nonsense