### PR TITLE
Fix Unity Development build method documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ pip install invoke
 invoke local-build
 ```
 
-This will create a build beneath the directory 'unity/builds/local-build/thor-local-OSXIntel64.app'. To use this build in your code, make the following change:
+This will create a build beneath the directory 'unity/builds/thor-local-OSXIntel64.app'. To use this build in your code, make the following change:
 
 ```python
-controller = ai2thor.controller.Controller()
-controller.local_executable_path = "<BASE_DIR>/unity/builds/local-build/thor-local-OSXIntel64.app/Contents/MacOS/thor-local-OSXIntel64"
-controller.start()
+controller = ai2thor.controller.Controller(
+    local_executable_path="<BASE_DIR>/unity/builds/thor-local-OSXIntel64.app/Contents/MacOS/thor-local-OSXIntel64"
+)
 ```
 
 ## Browser Build


### PR DESCRIPTION
- **Remove start call**: With the start method depreciated and `local_executable_path` as a parameter for the `Controller` constructor, the previously documented code is not optimal since it would be calling `start` twice. (However, it would still work!)

- **Remove local-build**: After running `invoke local-build`, the previous path was **incorrect** and needed to remove **local-build**. The method that defines the path is in **tasks.py** defined [**here**](https://github.com/allenai/ai2thor/blob/master/tasks.py#L47), and does NOT contain `/local-build/`.