### PR TITLE
Fix BlockingIOError caused in Python2.7 and change print(warning) to warning

### DIFF
--- a/ai2thor/_version.py
+++ b/ai2thor/_version.py
@@ -1,3 +1,3 @@
 # Copyright Allen Institute for Artificial Intelligence 2017
 # GENERATED FILE - DO NOT EDIT
-__version__ = '2.2.0'
+__version__ = '2.1.1'

--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -909,7 +909,8 @@ class Controller(object):
             raise Exception("Screen resolution must be >= 300x300")
 
         if self.server_thread is not None:
-            print('start() method depreciated. The server has already started when Controller was initialized.')
+            import warnings
+            warnings.warn('start method depreciated. The server started when the Controller was initialized.')
 
             # Stops the current server and creates a new one. This is done so
             # that the arguments passed in will be used on the server.

--- a/tasks.py
+++ b/tasks.py
@@ -9,6 +9,7 @@ import subprocess
 import pprint
 from invoke import task
 import boto3
+import io
 
 
 S3_BUCKET = "ai2-thor"
@@ -664,7 +665,7 @@ def ci_build(context):
 
         fcntl.flock(lock_f, fcntl.LOCK_UN)
 
-    except BlockingIOError as e:
+    except io.BlockingIOError as e:
         pass
 
     lock_f.close()


### PR DESCRIPTION
Integrating GitHub actions with Python basically checks to make sure that everything _compiles_ using flake8. An error is caused when using `BlockingIOError`, since that was not introduced until Python3. However, the `io` module contains the `BlockingIOError` exception for both Python2 and Python3.

I ran tests locally to ensure everything works.
View log of original errors caused:
- [Windows CI](https://github.com/mattdeitke/ai2thor/commit/829f9f77e903535cda859401253c12af6fac866b/checks?check_suite_id=398810603)
- [Ubuntu CI](https://github.com/mattdeitke/ai2thor/commit/829f9f77e903535cda859401253c12af6fac866b/checks?check_suite_id=398810594)
- [Mac CI](https://github.com/mattdeitke/ai2thor/commit/829f9f77e903535cda859401253c12af6fac866b/checks?check_suite_id=398810625)

View solution log, which simply required using `io.BlockingIOError` instead of `BlockingIOError`:
- [Windows CI](https://github.com/mattdeitke/ai2thor/commit/842ff9d1d5546d96080629d84228f2f6c985f4ad/checks?check_suite_id=405481687)
- [Ubuntu CI](https://github.com/mattdeitke/ai2thor/commit/842ff9d1d5546d96080629d84228f2f6c985f4ad/checks?check_suite_id=405481679)
- [Mac CI](https://github.com/mattdeitke/ai2thor/commit/842ff9d1d5546d96080629d84228f2f6c985f4ad/checks?check_suite_id=405481671)