### PR TITLE
Front-end support for height x width < 300x300

### DIFF
--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -863,8 +863,8 @@ class Controller(object):
                           " parameter instead.")
             height = player_screen_height
 
-        if height < 300 or width < 300:
-            raise Exception("Screen resolution must be >= 300x300")
+        if height <= 0 or width <= 0:
+            raise Exception("Screen resolution must be > 0x0")
 
         if self.server_thread is not None:
             import warnings
@@ -923,6 +923,9 @@ class Controller(object):
 
         # receive the first request
         self.last_event = queue_get(self.request_queue, self.unity_proc)
+
+        if height < 300 or width < 300:
+            self.last_event = self.step('ChangeResolution', x=width, y=height)
 
         return self.last_event
 

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -56,6 +56,12 @@ def test_rectangle_aspect():
     event = controller.step(dict(action='Initialize', gridSize=0.25))
     assert event.frame.shape == (300, 600, 3)
 
+def test_small_aspect():
+    controller = UnityTestController(width=128, height=64)
+    controller.reset('FloorPlan28')
+    event = controller.step(dict(action='Initialize', gridSize=0.25))
+    assert event.frame.shape == (64, 128, 3)
+    
 def test_lookdown():
 
     e = controller.step(dict(action='RotateLook', rotation=0, horizon=0))


### PR DESCRIPTION
It's been tested and works well for a variety of initializations. Tests can simply be run with
```python
from ai2thor.controller import Controller
c = Controller(width=64, height=64)
c.last_event.frame.shape
```

Also raised in #87.