### PR TITLE
Receptacle snapshot

### DIFF
--- a/unity/Assets/Physics/Test_Scene_W.unity
+++ b/unity/Assets/Physics/Test_Scene_W.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4435984, g: 0.49291283, b: 0.5724829, a: 1}
+  m_IndirectSpecularColor: {r: 0.4435844, g: 0.49289918, b: 0.57247597, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 0
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 12
     m_Resolution: 2
     m_BakeResolution: 40
     m_AtlasSize: 1024
@@ -62,6 +62,7 @@ LightmapSettings:
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
     m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 0
@@ -76,10 +77,16 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVRFilteringMode: 1
+    m_PVREnvironmentMIS: 0
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -87,7 +94,9 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
-    m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -119,11 +128,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1432406719}
     m_Modifications:
-    - target: {fileID: 2367096899194431217, guid: 516db061633ca4ad5ac050fcb7316e73,
-        type: 3}
-      propertyPath: m_Name
-      value: Mug_3 (1)
-      objectReference: {fileID: 0}
     - target: {fileID: 2365502302183138545, guid: 516db061633ca4ad5ac050fcb7316e73,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -177,6 +181,16 @@ PrefabInstance:
     - target: {fileID: 2365502302183138545, guid: 516db061633ca4ad5ac050fcb7316e73,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2367096899194431217, guid: 516db061633ca4ad5ac050fcb7316e73,
+        type: 3}
+      propertyPath: m_Name
+      value: Mug_3 (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2367096899194431217, guid: 516db061633ca4ad5ac050fcb7316e73,
+        type: 3}
+      propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -238,6 +252,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4dcb85c8bd624de44bc7c48c19882f61, type: 3}
+--- !u!54 &29060487 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 54558992204188620, guid: 7d739dfee22b25a4898fd9d37ba43777,
+    type: 3}
+  m_PrefabInstance: {fileID: 1611559340}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &29542409
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -245,6 +265,14 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 431395055, guid: 5b3a2f458d83e4af9a41ecf71b1f80f8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1095528602, guid: 5b3a2f458d83e4af9a41ecf71b1f80f8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 224778784152956280, guid: 5b3a2f458d83e4af9a41ecf71b1f80f8,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -335,14 +363,6 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1095528602, guid: 5b3a2f458d83e4af9a41ecf71b1f80f8, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 431395055, guid: 5b3a2f458d83e4af9a41ecf71b1f80f8, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5b3a2f458d83e4af9a41ecf71b1f80f8, type: 3}
 --- !u!1 &31258828
@@ -392,6 +412,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -403,6 +424,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -436,6 +458,12 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 31258828}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!54 &37757726 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 5400000, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 2007864987}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &43005959
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -443,15 +471,47 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
-        type: 3}
-      propertyPath: SpawnedObjects.Array.size
+    - target: {fileID: 4523222967138746, guid: 3a963756b61df410c91df72a73d4efde, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4523222967138746, guid: 3a963756b61df410c91df72a73d4efde, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4523222967138746, guid: 3a963756b61df410c91df72a73d4efde, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4523222967138746, guid: 3a963756b61df410c91df72a73d4efde, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4523222967138746, guid: 3a963756b61df410c91df72a73d4efde, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4523222967138746, guid: 3a963756b61df410c91df72a73d4efde, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4523222967138746, guid: 3a963756b61df410c91df72a73d4efde, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4523222967138746, guid: 3a963756b61df410c91df72a73d4efde, type: 3}
+      propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
         type: 3}
+      propertyPath: SpawnedObjects.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
       propertyPath: RequiredObjects.Array.size
-      value: 0
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
         type: 3}
@@ -467,6 +527,11 @@ PrefabInstance:
         type: 3}
       propertyPath: ReceptaclesInScene.Array.size
       value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.size
+      value: 28
       objectReference: {fileID: 0}
     - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
         type: 3}
@@ -702,7 +767,7 @@ PrefabInstance:
         type: 3}
       propertyPath: RequiredObjects.Array.data[0]
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1994656996}
     - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
         type: 3}
       propertyPath: ReceptaclesInScene.Array.data[0]
@@ -792,17 +857,17 @@ PrefabInstance:
         type: 3}
       propertyPath: RequiredObjects.Array.data[1]
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1401852165}
     - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
         type: 3}
       propertyPath: RequiredObjects.Array.data[2]
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1809264728}
     - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
         type: 3}
       propertyPath: RequiredObjects.Array.data[3]
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 402445459}
     - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
         type: 3}
       propertyPath: RequiredObjects.Array.data[4]
@@ -817,22 +882,22 @@ PrefabInstance:
         type: 3}
       propertyPath: SpawnedObjects.Array.data[0]
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1994656996}
     - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
         type: 3}
       propertyPath: SpawnedObjects.Array.data[1]
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1401852165}
     - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
         type: 3}
       propertyPath: SpawnedObjects.Array.data[2]
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1809264728}
     - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
         type: 3}
       propertyPath: SpawnedObjects.Array.data[3]
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 402445459}
     - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
         type: 3}
       propertyPath: SpawnedObjects.Array.data[4]
@@ -1148,38 +1213,146 @@ PrefabInstance:
       propertyPath: RequiredObjects.Array.data[29]
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 4523222967138746, guid: 3a963756b61df410c91df72a73d4efde, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4523222967138746, guid: 3a963756b61df410c91df72a73d4efde, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4523222967138746, guid: 3a963756b61df410c91df72a73d4efde, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4523222967138746, guid: 3a963756b61df410c91df72a73d4efde, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4523222967138746, guid: 3a963756b61df410c91df72a73d4efde, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4523222967138746, guid: 3a963756b61df410c91df72a73d4efde, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4523222967138746, guid: 3a963756b61df410c91df72a73d4efde, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4523222967138746, guid: 3a963756b61df410c91df72a73d4efde, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[0]
+      value: 
+      objectReference: {fileID: 1053203998}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[1]
+      value: 
+      objectReference: {fileID: 37757726}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[2]
+      value: 
+      objectReference: {fileID: 402445463}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[3]
+      value: 
+      objectReference: {fileID: 168729280}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[4]
+      value: 
+      objectReference: {fileID: 29060487}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[5]
+      value: 
+      objectReference: {fileID: 1654886622}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[6]
+      value: 
+      objectReference: {fileID: 1809264732}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[7]
+      value: 
+      objectReference: {fileID: 1128449680}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[8]
+      value: 
+      objectReference: {fileID: 1185933854}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[9]
+      value: 
+      objectReference: {fileID: 1847814300}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[10]
+      value: 
+      objectReference: {fileID: 373488179}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[11]
+      value: 
+      objectReference: {fileID: 835511546}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[12]
+      value: 
+      objectReference: {fileID: 199169402}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[13]
+      value: 
+      objectReference: {fileID: 2127345942}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[14]
+      value: 
+      objectReference: {fileID: 547975501}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[15]
+      value: 
+      objectReference: {fileID: 1401852169}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[16]
+      value: 
+      objectReference: {fileID: 970411793}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[17]
+      value: 
+      objectReference: {fileID: 1471050543}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[18]
+      value: 
+      objectReference: {fileID: 5179632756194612157}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[19]
+      value: 
+      objectReference: {fileID: 5179632756249336848}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[20]
+      value: 
+      objectReference: {fileID: 5179632756511765528}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[21]
+      value: 
+      objectReference: {fileID: 5179632757303544367}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[22]
+      value: 
+      objectReference: {fileID: 5179632757323996267}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[23]
+      value: 
+      objectReference: {fileID: 6913389049082440819}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[24]
+      value: 
+      objectReference: {fileID: 6913389049197918380}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[25]
+      value: 
+      objectReference: {fileID: 6913389049200436265}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[26]
+      value: 
+      objectReference: {fileID: 6913389049979096687}
+    - target: {fileID: 114080650210219948, guid: 3a963756b61df410c91df72a73d4efde,
+        type: 3}
+      propertyPath: rbsInScene.Array.data[27]
+      value: 
+      objectReference: {fileID: 6913389050623182533}
     - target: {fileID: 114699917896503758, guid: 3a963756b61df410c91df72a73d4efde,
         type: 3}
       propertyPath: TestPosition.x
@@ -1214,11 +1387,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1432406719}
     m_Modifications:
-    - target: {fileID: 629410298267782516, guid: 2529fc1a396a4443fade9b51897cb9a5,
-        type: 3}
-      propertyPath: m_Name
-      value: Mug_2
-      objectReference: {fileID: 0}
     - target: {fileID: 626195691514342360, guid: 2529fc1a396a4443fade9b51897cb9a5,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1272,6 +1440,16 @@ PrefabInstance:
     - target: {fileID: 626195691514342360, guid: 2529fc1a396a4443fade9b51897cb9a5,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 629410298267782516, guid: 2529fc1a396a4443fade9b51897cb9a5,
+        type: 3}
+      propertyPath: m_Name
+      value: Mug_2
+      objectReference: {fileID: 0}
+    - target: {fileID: 629410298267782516, guid: 2529fc1a396a4443fade9b51897cb9a5,
+        type: 3}
+      propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -1389,6 +1567,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1400,6 +1579,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1482,6 +1662,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1493,6 +1674,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1526,18 +1708,30 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 136592543}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!54 &168729280 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 364434115796580898, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
+    type: 3}
+  m_PrefabInstance: {fileID: 1981485465}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &194607682 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 313136505743405468, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
     type: 3}
   m_PrefabInstance: {fileID: 1996989716}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 402445459}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!54 &199169402 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 54320104394206452, guid: 3f303f89bf65ffc429fb89712c2e0a5f,
+    type: 3}
+  m_PrefabInstance: {fileID: 803333374}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &202633491
 GameObject:
   m_ObjectHideFlags: 0
@@ -1585,6 +1779,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1596,6 +1791,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1690,11 +1886,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 114466295823916254, guid: 3822be90e0a28e44aa4f6284e85e848c,
-        type: 3}
-      propertyPath: uniqueID
-      value: Vase|-04.45|+00.52|-06.52
-      objectReference: {fileID: 0}
     - target: {fileID: 23210772457085404, guid: 3822be90e0a28e44aa4f6284e85e848c,
         type: 3}
       propertyPath: m_Materials.Array.size
@@ -1715,6 +1906,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[2]
       value: 
       objectReference: {fileID: 2100000, guid: 596382ea553524abca5e9b599243ef85, type: 2}
+    - target: {fileID: 114466295823916254, guid: 3822be90e0a28e44aa4f6284e85e848c,
+        type: 3}
+      propertyPath: uniqueID
+      value: Vase|-04.45|+00.52|-06.52
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3822be90e0a28e44aa4f6284e85e848c, type: 3}
 --- !u!4 &356174628 stripped
@@ -1722,6 +1918,12 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4389432026980930, guid: 4559363323cfe024caf98acf58621f62,
     type: 3}
   m_PrefabInstance: {fileID: 382167715}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &373488179 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 611655194511427308, guid: 2529fc1a396a4443fade9b51897cb9a5,
+    type: 3}
+  m_PrefabInstance: {fileID: 936583741}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &380468401
 GameObject:
@@ -1771,6 +1973,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1782,6 +1985,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -1878,6 +2082,24 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 2009698661640602963, guid: 4559363323cfe024caf98acf58621f62, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 4559363323cfe024caf98acf58621f62, type: 3}
+--- !u!1 &402445459 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 417596729295079306, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
+    type: 3}
+  m_PrefabInstance: {fileID: 1996989716}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &402445463 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 364434115796580898, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
+    type: 3}
+  m_PrefabInstance: {fileID: 1996989716}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &547975501 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 54446828772730858, guid: 3822be90e0a28e44aa4f6284e85e848c,
+    type: 3}
+  m_PrefabInstance: {fileID: 246746937}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &574566386
 GameObject:
   m_ObjectHideFlags: 0
@@ -1974,6 +2196,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1985,6 +2208,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -2065,6 +2289,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2076,6 +2301,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -2183,6 +2409,12 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1591380589}
   m_PrefabAsset: {fileID: 0}
+--- !u!54 &835511546 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 54446828772730858, guid: 3822be90e0a28e44aa4f6284e85e848c,
+    type: 3}
+  m_PrefabInstance: {fileID: 882300143}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &882300143
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2238,11 +2470,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 114466295823916254, guid: 3822be90e0a28e44aa4f6284e85e848c,
-        type: 3}
-      propertyPath: uniqueID
-      value: Vase|-04.45|+00.52|-06.52
-      objectReference: {fileID: 0}
     - target: {fileID: 23210772457085404, guid: 3822be90e0a28e44aa4f6284e85e848c,
         type: 3}
       propertyPath: m_Materials.Array.size
@@ -2263,6 +2490,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[2]
       value: 
       objectReference: {fileID: 2100000, guid: 596382ea553524abca5e9b599243ef85, type: 2}
+    - target: {fileID: 114466295823916254, guid: 3822be90e0a28e44aa4f6284e85e848c,
+        type: 3}
+      propertyPath: uniqueID
+      value: Vase|-04.45|+00.52|-06.52
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3822be90e0a28e44aa4f6284e85e848c, type: 3}
 --- !u!114 &891066421 stripped
@@ -2271,7 +2503,7 @@ MonoBehaviour:
     type: 3}
   m_PrefabInstance: {fileID: 43352868}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 1401852165}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
@@ -2284,11 +2516,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1432406719}
     m_Modifications:
-    - target: {fileID: 629410298267782516, guid: 2529fc1a396a4443fade9b51897cb9a5,
-        type: 3}
-      propertyPath: m_Name
-      value: Mug_2 (1)
-      objectReference: {fileID: 0}
     - target: {fileID: 626195691514342360, guid: 2529fc1a396a4443fade9b51897cb9a5,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -2344,8 +2571,30 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 629410298267782516, guid: 2529fc1a396a4443fade9b51897cb9a5,
+        type: 3}
+      propertyPath: m_Name
+      value: Mug_2 (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 629410298267782516, guid: 2529fc1a396a4443fade9b51897cb9a5,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2529fc1a396a4443fade9b51897cb9a5, type: 3}
+--- !u!54 &970411793 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 54949004892180622, guid: 4dcb85c8bd624de44bc7c48c19882f61,
+    type: 3}
+  m_PrefabInstance: {fileID: 3644221}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &1053203998 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 54720904359052188, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 2007864987}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1057093818
 GameObject:
   m_ObjectHideFlags: 0
@@ -2436,6 +2685,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2447,6 +2697,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -2480,6 +2731,12 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1113850094}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!54 &1128449680 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 54558992204188620, guid: 7d739dfee22b25a4898fd9d37ba43777,
+    type: 3}
+  m_PrefabInstance: {fileID: 1351232422}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1134749683
 GameObject:
   m_ObjectHideFlags: 0
@@ -2527,6 +2784,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2538,6 +2796,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -2582,10 +2841,9 @@ PrefabInstance:
       propertyPath: m_Name
       value: Toaster_2
       objectReference: {fileID: 0}
-    - target: {fileID: 114964990368791888, guid: b25f28ecad9b741578e19fe25017e648,
-        type: 3}
-      propertyPath: uniqueID
-      value: Toaster|-03.32|+00.52|-06.87
+    - target: {fileID: 1776411824363882, guid: b25f28ecad9b741578e19fe25017e648, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4674880789799020, guid: b25f28ecad9b741578e19fe25017e648, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2630,6 +2888,11 @@ PrefabInstance:
     - target: {fileID: 4674880789799020, guid: b25f28ecad9b741578e19fe25017e648, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114964990368791888, guid: b25f28ecad9b741578e19fe25017e648,
+        type: 3}
+      propertyPath: uniqueID
+      value: Toaster|-03.32|+00.52|-06.87
       objectReference: {fileID: 0}
     - target: {fileID: 5664695623436658363, guid: b25f28ecad9b741578e19fe25017e648,
         type: 3}
@@ -2684,8 +2947,15 @@ MonoBehaviour:
   HighFrictionImpulseOffset: 0.25
   readytobreak: 1
   broken: 0
+  Unbreakable: 0
   breakType: 0
   MaterialSwapObjects: []
+--- !u!54 &1185933854 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 54209804844597038, guid: f3b82190f5293454a82fdb2d7764feeb,
+    type: 3}
+  m_PrefabInstance: {fileID: 1262352002}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1204952704 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4269077010394320, guid: 3822be90e0a28e44aa4f6284e85e848c,
@@ -2877,6 +3147,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7d739dfee22b25a4898fd9d37ba43777, type: 3}
+--- !u!1 &1401852165 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 629410298267782516, guid: 2529fc1a396a4443fade9b51897cb9a5,
+    type: 3}
+  m_PrefabInstance: {fileID: 43352868}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &1401852169 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 611655194511427308, guid: 2529fc1a396a4443fade9b51897cb9a5,
+    type: 3}
+  m_PrefabInstance: {fileID: 43352868}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1412014322
 GameObject:
   m_ObjectHideFlags: 0
@@ -2924,6 +3206,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2935,6 +3218,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -3014,6 +3298,145 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!54 &1471050543 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 2313779041862687473, guid: 516db061633ca4ad5ac050fcb7316e73,
+    type: 3}
+  m_PrefabInstance: {fileID: 2131746}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1506975897
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1007505578412192, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 1087631662061420, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 1210376107497218, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 1299224718579974, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 1444839379146172, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 1472312850602016, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 1503841058622386, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 1522975336168356, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 1540253488722054, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 1558578511113574, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 1612146645191980, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 1656956919134518, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1737114822534182, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1737114822534182, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_NavMeshLayer
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1807231370777324, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 1897507843964904, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 1917105725634610, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1975065647330532, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 1983969004656600, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1983969004656600, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_Name
+      value: CoffeeMachine_ed06e3d1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4396138988545600, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.355
+      objectReference: {fileID: 0}
+    - target: {fileID: 4396138988545600, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.52
+      objectReference: {fileID: 0}
+    - target: {fileID: 4396138988545600, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.714
+      objectReference: {fileID: 0}
+    - target: {fileID: 4396138988545600, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.000006721121
+      objectReference: {fileID: 0}
+    - target: {fileID: 4396138988545600, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071062
+      objectReference: {fileID: 0}
+    - target: {fileID: 4396138988545600, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.0000031739476
+      objectReference: {fileID: 0}
+    - target: {fileID: 4396138988545600, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071075
+      objectReference: {fileID: 0}
+    - target: {fileID: 4396138988545600, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4396138988545600, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90.00001
+      objectReference: {fileID: 0}
+    - target: {fileID: 4396138988545600, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -0.001
+      objectReference: {fileID: 0}
+    - target: {fileID: 4396138988545600, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 989984b57554e434f9d8fe5540e77e56, type: 3}
 --- !u!1001 &1557378509
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3021,11 +3444,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1432406719}
     m_Modifications:
-    - target: {fileID: 2367096899194431217, guid: 516db061633ca4ad5ac050fcb7316e73,
-        type: 3}
-      propertyPath: m_Name
-      value: Mug_3
-      objectReference: {fileID: 0}
     - target: {fileID: 2365502302183138545, guid: 516db061633ca4ad5ac050fcb7316e73,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -3079,6 +3497,16 @@ PrefabInstance:
     - target: {fileID: 2365502302183138545, guid: 516db061633ca4ad5ac050fcb7316e73,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2367096899194431217, guid: 516db061633ca4ad5ac050fcb7316e73,
+        type: 3}
+      propertyPath: m_Name
+      value: Mug_3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2367096899194431217, guid: 516db061633ca4ad5ac050fcb7316e73,
+        type: 3}
+      propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -3176,12 +3604,14 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1605796248}
   m_Enabled: 1
-  serializedVersion: 8
+  serializedVersion: 10
   m_Type: 1
+  m_Shape: 0
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
   m_Range: 10
   m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
   m_CookieSize: 10
   m_Shadows:
     m_Type: 2
@@ -3191,6 +3621,24 @@ Light:
     m_Bias: 0.05
     m_NormalBias: 0.4
     m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
   m_Cookie: {fileID: 0}
   m_DrawHalo: 0
   m_Flare: {fileID: 0}
@@ -3198,12 +3646,15 @@ Light:
   m_CullingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+  m_RenderingLayerMask: 1
   m_Lightmapping: 4
   m_LightShadowCasterMode: 0
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &1605796250
@@ -3288,6 +3739,12 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 43352868}
   m_PrefabAsset: {fileID: 0}
+--- !u!54 &1654886622 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 54949004892180622, guid: 4dcb85c8bd624de44bc7c48c19882f61,
+    type: 3}
+  m_PrefabInstance: {fileID: 1591380589}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1660782935
 GameObject:
   m_ObjectHideFlags: 0
@@ -3335,6 +3792,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3346,6 +3804,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -3384,6 +3843,18 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4159845343020302, guid: 3f303f89bf65ffc429fb89712c2e0a5f,
     type: 3}
   m_PrefabInstance: {fileID: 803333374}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1809264728 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2367096899194431217, guid: 516db061633ca4ad5ac050fcb7316e73,
+    type: 3}
+  m_PrefabInstance: {fileID: 1557378509}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &1809264732 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 2313779041862687473, guid: 516db061633ca4ad5ac050fcb7316e73,
+    type: 3}
+  m_PrefabInstance: {fileID: 1557378509}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1829215904
 GameObject:
@@ -3432,6 +3903,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3443,6 +3915,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -3485,6 +3958,12 @@ GameObject:
 --- !u!4 &1847814296 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4674880789799020, guid: b25f28ecad9b741578e19fe25017e648,
+    type: 3}
+  m_PrefabInstance: {fileID: 1184720872}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &1847814300 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 54011342127949604, guid: b25f28ecad9b741578e19fe25017e648,
     type: 3}
   m_PrefabInstance: {fileID: 1184720872}
   m_PrefabAsset: {fileID: 0}
@@ -3535,6 +4014,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3546,6 +4026,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -3626,6 +4107,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3637,6 +4119,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -3717,6 +4200,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3728,6 +4212,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -3768,11 +4253,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1432406719}
     m_Modifications:
-    - target: {fileID: 417596729295079306, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
-        type: 3}
-      propertyPath: m_Name
-      value: Mug_1 (1)
-      objectReference: {fileID: 0}
     - target: {fileID: 414624972692400350, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -3828,8 +4308,24 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 417596729295079306, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
+        type: 3}
+      propertyPath: m_Name
+      value: Mug_1 (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 417596729295079306, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+--- !u!1 &1994656996 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 417596729295079306, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
+    type: 3}
+  m_PrefabInstance: {fileID: 2107238817}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1996989716
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3837,11 +4333,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1432406719}
     m_Modifications:
-    - target: {fileID: 417596729295079306, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
-        type: 3}
-      propertyPath: m_Name
-      value: Mug_1
-      objectReference: {fileID: 0}
     - target: {fileID: 414624972692400350, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -3895,6 +4386,16 @@ PrefabInstance:
     - target: {fileID: 414624972692400350, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 417596729295079306, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
+        type: 3}
+      propertyPath: m_Name
+      value: Mug_1
+      objectReference: {fileID: 0}
+    - target: {fileID: 417596729295079306, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
+        type: 3}
+      propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -3954,6 +4455,24 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5400000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
+      propertyPath: m_Drag
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
+      propertyPath: m_AngularDrag
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 54720904359052188, guid: 5e9e851c0e142814dac026a256ba2ac0,
+        type: 3}
+      propertyPath: m_Drag
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 54720904359052188, guid: 5e9e851c0e142814dac026a256ba2ac0,
+        type: 3}
+      propertyPath: m_AngularDrag
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
 --- !u!1 &2018252476
@@ -3990,6 +4509,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4001,6 +4521,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4108,6 +4629,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4119,6 +4641,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4152,18 +4675,267 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2038124398}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1001 &2107238817
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 126860556, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_NavMeshLayer
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 126860556, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1038569490963054, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1078868796801110, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1100917541672456, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1105956724151422, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1174436400599514, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1193507179265262, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1208141966259390, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1318335775249188, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1360955291644624, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1375384543151396, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1414431105101490, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1427308558961850, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1437871444623834, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1467967536706210, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1475378183830730, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1500926156108588, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1511649215508010, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1522550328166516, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1534231643576598, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1545468843417900, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1552222124760612, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1617773912263186, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1625138801565358, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1645224979380964, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1658470487919980, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1737139218873924, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1750018543023878, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1781258893916262, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1805531551021262, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1827417528159588, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1870125915231384, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1917441799512188, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1976871093856124, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1980085930575282, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1991567962080514, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1995926799953806, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 4374443654196878, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.7608144
+      objectReference: {fileID: 0}
+    - target: {fileID: 4374443654196878, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4374443654196878, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.6206057
+      objectReference: {fileID: 0}
+    - target: {fileID: 4374443654196878, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4374443654196878, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4374443654196878, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4374443654196878, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4374443654196878, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 414624972692400350, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.148
+      objectReference: {fileID: 0}
+    - target: {fileID: 414624972692400350, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 414624972692400350, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.52
+      objectReference: {fileID: 0}
+    - target: {fileID: 414624972692400350, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.645
+      objectReference: {fileID: 0}
+    - target: {fileID: 414624972692400350, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.00000080118235
+      objectReference: {fileID: 0}
+    - target: {fileID: 414624972692400350, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.70710665
+      objectReference: {fileID: 0}
+    - target: {fileID: 414624972692400350, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.0000004854482
+      objectReference: {fileID: 0}
+    - target: {fileID: 414624972692400350, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70710695
+      objectReference: {fileID: 0}
+    - target: {fileID: 414624972692400350, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -90.00001
+      objectReference: {fileID: 0}
+    - target: {fileID: 417596729295079306, guid: 82ba74a59a83b4fe495ea5288c87e1bb,
+        type: 3}
+      propertyPath: m_Name
+      value: Mug_77db6e4d
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 82ba74a59a83b4fe495ea5288c87e1bb, type: 3}
 --- !u!114 &2113941293 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2397173839254923697, guid: 516db061633ca4ad5ac050fcb7316e73,
     type: 3}
   m_PrefabInstance: {fileID: 1557378509}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 1809264728}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!54 &2127345942 stripped
+Rigidbody:
+  m_CorrespondingSourceObject: {fileID: 54161469001384240, guid: 4559363323cfe024caf98acf58621f62,
+    type: 3}
+  m_PrefabInstance: {fileID: 382167715}
+  m_PrefabAsset: {fileID: 0}
 --- !u!23 &1266946499687212618
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -4178,6 +4950,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4190,6 +4963,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4216,6 +4990,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4228,6 +5003,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4254,6 +5030,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4266,6 +5043,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4292,6 +5070,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4304,6 +5083,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4330,6 +5110,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4342,6 +5123,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4498,7 +5280,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &1266946499689150656
 GameObject:
   m_ObjectHideFlags: 0
@@ -4622,7 +5404,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &3841926831511087961
 GameObject:
   m_ObjectHideFlags: 0
@@ -4798,6 +5580,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4810,6 +5593,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4836,6 +5620,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4848,6 +5633,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4874,6 +5660,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4886,6 +5673,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4912,6 +5700,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4924,6 +5713,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4950,6 +5740,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4962,6 +5753,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -5064,7 +5856,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  uniqueID: BreadSliced|-00.78|+00.61|-03.77
+  objectID: BreadSliced|-00.78|+00.61|-03.77
   Type: 6
   PrimaryProperty: 3
   SecondaryProperties: 14000000
@@ -5090,11 +5882,16 @@ MonoBehaviour:
   HFrbdrag: 0
   HFrbangulardrag: 0
   salientMaterials: 08000000
+  MySpawnPoints: []
   CurrentTemperature: 0
   HowManySecondsUntilRoomTemp: 10
   inMotion: 0
+  numSimObjHit: 0
+  numFloorHit: 0
+  numStructureHit: 0
   lastVelocity: 0
   ContainedObjectReferences: []
+  CurrentlyContains: []
 --- !u!54 &5179632756194612157
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -5104,8 +5901,8 @@ Rigidbody:
   m_GameObject: {fileID: 5179632756194612130}
   serializedVersion: 2
   m_Mass: 0.09
-  m_Drag: 0
-  m_AngularDrag: 0.05
+  m_Drag: 1
+  m_AngularDrag: 1
   m_UseGravity: 1
   m_IsKinematic: 1
   m_Interpolate: 0
@@ -5183,8 +5980,8 @@ Rigidbody:
   m_GameObject: {fileID: 5179632756249336853}
   serializedVersion: 2
   m_Mass: 0.09
-  m_Drag: 0
-  m_AngularDrag: 0.05
+  m_Drag: 1
+  m_AngularDrag: 1
   m_UseGravity: 1
   m_IsKinematic: 1
   m_Interpolate: 0
@@ -5259,7 +6056,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  uniqueID: BreadSliced|-00.78|+00.61|-03.73
+  objectID: BreadSliced|-00.78|+00.61|-03.73
   Type: 6
   PrimaryProperty: 3
   SecondaryProperties: 14000000
@@ -5284,11 +6081,16 @@ MonoBehaviour:
   HFrbdrag: 0
   HFrbangulardrag: 0
   salientMaterials: 08000000
+  MySpawnPoints: []
   CurrentTemperature: 0
   HowManySecondsUntilRoomTemp: 10
   inMotion: 0
+  numSimObjHit: 0
+  numFloorHit: 0
+  numStructureHit: 0
   lastVelocity: 0
   ContainedObjectReferences: []
+  CurrentlyContains: []
 --- !u!4 &5179632756304991092
 Transform:
   m_ObjectHideFlags: 0
@@ -5506,8 +6308,8 @@ Rigidbody:
   m_GameObject: {fileID: 5179632756511765533}
   serializedVersion: 2
   m_Mass: 0.09
-  m_Drag: 0
-  m_AngularDrag: 0.05
+  m_Drag: 1
+  m_AngularDrag: 1
   m_UseGravity: 1
   m_IsKinematic: 1
   m_Interpolate: 0
@@ -5582,7 +6384,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  uniqueID: BreadSliced|-00.78|+00.61|-03.65
+  objectID: BreadSliced|-00.78|+00.61|-03.65
   Type: 6
   PrimaryProperty: 3
   SecondaryProperties: 14000000
@@ -5607,11 +6409,16 @@ MonoBehaviour:
   HFrbdrag: 0
   HFrbangulardrag: 0
   salientMaterials: 08000000
+  MySpawnPoints: []
   CurrentTemperature: 0
   HowManySecondsUntilRoomTemp: 10
   inMotion: 0
+  numSimObjHit: 0
+  numFloorHit: 0
+  numStructureHit: 0
   lastVelocity: 0
   ContainedObjectReferences: []
+  CurrentlyContains: []
 --- !u!4 &5179632756538838136
 Transform:
   m_ObjectHideFlags: 0
@@ -6766,7 +7573,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  uniqueID: BreadSliced|-00.78|+00.61|-03.68
+  objectID: BreadSliced|-00.78|+00.61|-03.68
   Type: 6
   PrimaryProperty: 3
   SecondaryProperties: 14000000
@@ -6791,11 +7598,16 @@ MonoBehaviour:
   HFrbdrag: 0
   HFrbangulardrag: 0
   salientMaterials: 08000000
+  MySpawnPoints: []
   CurrentTemperature: 0
   HowManySecondsUntilRoomTemp: 10
   inMotion: 0
+  numSimObjHit: 0
+  numFloorHit: 0
+  numStructureHit: 0
   lastVelocity: 0
   ContainedObjectReferences: []
+  CurrentlyContains: []
 --- !u!54 &5179632757303544367
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -6805,8 +7617,8 @@ Rigidbody:
   m_GameObject: {fileID: 5179632757303544364}
   serializedVersion: 2
   m_Mass: 0.09
-  m_Drag: 0
-  m_AngularDrag: 0.05
+  m_Drag: 1
+  m_AngularDrag: 1
   m_UseGravity: 1
   m_IsKinematic: 1
   m_Interpolate: 0
@@ -6969,7 +7781,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  uniqueID: BreadSliced|-00.78|+00.61|-03.71
+  objectID: BreadSliced|-00.78|+00.61|-03.71
   Type: 6
   PrimaryProperty: 3
   SecondaryProperties: 14000000
@@ -6994,11 +7806,16 @@ MonoBehaviour:
   HFrbdrag: 0
   HFrbangulardrag: 0
   salientMaterials: 08000000
+  MySpawnPoints: []
   CurrentTemperature: 0
   HowManySecondsUntilRoomTemp: 10
   inMotion: 0
+  numSimObjHit: 0
+  numFloorHit: 0
+  numStructureHit: 0
   lastVelocity: 0
   ContainedObjectReferences: []
+  CurrentlyContains: []
 --- !u!54 &5179632757323996267
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -7008,8 +7825,8 @@ Rigidbody:
   m_GameObject: {fileID: 5179632757323996264}
   serializedVersion: 2
   m_Mass: 0.09
-  m_Drag: 0
-  m_AngularDrag: 0.05
+  m_Drag: 1
+  m_AngularDrag: 1
   m_UseGravity: 1
   m_IsKinematic: 1
   m_Interpolate: 0
@@ -9354,7 +10171,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  uniqueID: BreadSliced|-00.49|+00.56|-03.74
+  objectID: BreadSliced|-00.49|+00.56|-03.74
   Type: 6
   PrimaryProperty: 3
   SecondaryProperties: 14000000
@@ -9384,11 +10201,16 @@ MonoBehaviour:
   HFrbdrag: 0
   HFrbangulardrag: 0
   salientMaterials: 08000000
+  MySpawnPoints: []
   CurrentTemperature: 0
   HowManySecondsUntilRoomTemp: 10
   inMotion: 0
+  numSimObjHit: 0
+  numFloorHit: 0
+  numStructureHit: 0
   lastVelocity: 0
   ContainedObjectReferences: []
+  CurrentlyContains: []
 --- !u!54 &6913389049082440819
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -9398,8 +10220,8 @@ Rigidbody:
   m_GameObject: {fileID: 6913389049082440812}
   serializedVersion: 2
   m_Mass: 0.08
-  m_Drag: 0
-  m_AngularDrag: 0.05
+  m_Drag: 1
+  m_AngularDrag: 1
   m_UseGravity: 1
   m_IsKinematic: 1
   m_Interpolate: 0
@@ -9739,8 +10561,8 @@ Rigidbody:
   m_GameObject: {fileID: 6913389049197918377}
   serializedVersion: 2
   m_Mass: 0.08
-  m_Drag: 0
-  m_AngularDrag: 0.05
+  m_Drag: 1
+  m_AngularDrag: 1
   m_UseGravity: 1
   m_IsKinematic: 1
   m_Interpolate: 0
@@ -9796,7 +10618,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  uniqueID: BreadSliced|-00.49|+00.57|-03.66
+  objectID: BreadSliced|-00.49|+00.57|-03.66
   Type: 6
   PrimaryProperty: 3
   SecondaryProperties: 14000000
@@ -9826,11 +10648,16 @@ MonoBehaviour:
   HFrbdrag: 0
   HFrbangulardrag: 0
   salientMaterials: 08000000
+  MySpawnPoints: []
   CurrentTemperature: 0
   HowManySecondsUntilRoomTemp: 10
   inMotion: 0
+  numSimObjHit: 0
+  numFloorHit: 0
+  numStructureHit: 0
   lastVelocity: 0
   ContainedObjectReferences: []
+  CurrentlyContains: []
 --- !u!114 &6913389049200436264
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -9843,7 +10670,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  uniqueID: BreadSliced|-00.49|+00.56|-03.78
+  objectID: BreadSliced|-00.49|+00.56|-03.78
   Type: 6
   PrimaryProperty: 3
   SecondaryProperties: 14000000
@@ -9879,11 +10706,16 @@ MonoBehaviour:
   HFrbdrag: 0
   HFrbangulardrag: 0
   salientMaterials: 08000000
+  MySpawnPoints: []
   CurrentTemperature: 0
   HowManySecondsUntilRoomTemp: 10
   inMotion: 0
+  numSimObjHit: 0
+  numFloorHit: 0
+  numStructureHit: 0
   lastVelocity: 0
   ContainedObjectReferences: []
+  CurrentlyContains: []
 --- !u!54 &6913389049200436265
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -9893,8 +10725,8 @@ Rigidbody:
   m_GameObject: {fileID: 6913389049200436266}
   serializedVersion: 2
   m_Mass: 0.08
-  m_Drag: 0
-  m_AngularDrag: 0.05
+  m_Drag: 1
+  m_AngularDrag: 1
   m_UseGravity: 1
   m_IsKinematic: 1
   m_Interpolate: 0
@@ -11575,7 +12407,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  uniqueID: BreadSliced|-00.49|+00.57|-03.62
+  objectID: BreadSliced|-00.49|+00.57|-03.62
   Type: 6
   PrimaryProperty: 3
   SecondaryProperties: 14000000
@@ -11605,11 +12437,16 @@ MonoBehaviour:
   HFrbdrag: 0
   HFrbangulardrag: 0
   salientMaterials: 08000000
+  MySpawnPoints: []
   CurrentTemperature: 0
   HowManySecondsUntilRoomTemp: 10
   inMotion: 0
+  numSimObjHit: 0
+  numFloorHit: 0
+  numStructureHit: 0
   lastVelocity: 0
   ContainedObjectReferences: []
+  CurrentlyContains: []
 --- !u!54 &6913389049979096687
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -11619,8 +12456,8 @@ Rigidbody:
   m_GameObject: {fileID: 6913389049979096680}
   serializedVersion: 2
   m_Mass: 0.08
-  m_Drag: 0
-  m_AngularDrag: 0.05
+  m_Drag: 1
+  m_AngularDrag: 1
   m_UseGravity: 1
   m_IsKinematic: 1
   m_Interpolate: 0
@@ -13098,7 +13935,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  uniqueID: BreadSliced|-00.49|+00.57|-03.70
+  objectID: BreadSliced|-00.49|+00.57|-03.70
   Type: 6
   PrimaryProperty: 3
   SecondaryProperties: 14000000
@@ -13128,11 +13965,16 @@ MonoBehaviour:
   HFrbdrag: 0
   HFrbangulardrag: 0
   salientMaterials: 08000000
+  MySpawnPoints: []
   CurrentTemperature: 0
   HowManySecondsUntilRoomTemp: 10
   inMotion: 0
+  numSimObjHit: 0
+  numFloorHit: 0
+  numStructureHit: 0
   lastVelocity: 0
   ContainedObjectReferences: []
+  CurrentlyContains: []
 --- !u!54 &6913389050623182533
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -13142,8 +13984,8 @@ Rigidbody:
   m_GameObject: {fileID: 6913389050623182534}
   serializedVersion: 2
   m_Mass: 0.08
-  m_Drag: 0
-  m_AngularDrag: 0.05
+  m_Drag: 1
+  m_AngularDrag: 1
   m_UseGravity: 1
   m_IsKinematic: 1
   m_Interpolate: 0

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1347,6 +1347,8 @@ public class ServerAction
 	public float g;
 	public float b;
 
+	//default time for objects to wait before returning actionFinished() if an action put them in motion
+	public float TimeToWaitForObjectsToComeToRest = 10.0f;
 	public float intensity;//used for light?
 	public float scale;
 

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -41,7 +41,6 @@ public class AgentManager : MonoBehaviour
 	private Color[] agentColors = new Color[]{Color.blue, Color.yellow, Color.green, Color.red, Color.magenta, Color.grey};
 	public int actionDuration = 3;
 	private BaseFPSAgentController primaryAgent;
-    //private JavaScriptInterface jsInterface;
     private PhysicsSceneManager physicsSceneManager;
     public int AdvancePhysicsStepCount = 0;
     private bool droneMode = false;
@@ -752,7 +751,7 @@ public class AgentManager : MonoBehaviour
 
 
 		#if UNITY_WEBGL
-            jsInterface = this.primaryAgent.GetComponent<JavaScriptInterface>();
+            JavaScriptInterface jsInterface = this.primaryAgent.GetComponent<JavaScriptInterface>();
             if (jsInterface != null) {
                 jsInterface.SendActionMetadata(serializeMetadataJson(multiMeta));
             }

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1060,7 +1060,14 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 }
                 ObjectMetadata meta = ObjectMetadataFromSimObjPhysics(simObj, visibleSimObjsHash.Contains(simObj));
                 if (meta.receptacle) {
-                    List<string> roid = simObj.Contains();
+                    
+                    List<string> containedObjectsAsID = new List<String>();
+                    foreach(GameObject go in simObj.ContainedGameObjects())
+                    {
+                        containedObjectsAsID.Add(go.GetComponent<SimObjPhysics>().ObjectID);
+                    }
+                    List<string> roid = containedObjectsAsID;//simObj.Contains();
+
                     foreach (string oid in roid) {
                         if (!parentReceptacles.ContainsKey(oid)) {
                             parentReceptacles[oid] = new List<string>();

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -54,6 +54,8 @@ namespace UnityStandardAssets.Characters.FirstPerson
 		[SerializeField]
 		protected float m_GravityMultiplier;
 		protected static float gridSize = 0.25f;
+        //time the checkIfObjectHasStoppedMoving coroutine waits for objects to stop moving
+        protected float TimeToWaitForObjectsToComeToRest = 0.0f;
         //determins default move distance for move actions
 		protected float moveMagnitude;
         //determines rotation increment of rotate functions
@@ -421,7 +423,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 	Time.timeScale = action.timeScale;
 				}
             } else {
-                errorMessage = "Time scale must be >0";
+                errorMessage = "Time scale must be > 0";
                 Debug.Log(errorMessage);
                 actionFinished(false);
                 return;
@@ -467,11 +469,15 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 actionFinished(false);
                 return;
             }
+
             else
             {
                 gridSize = action.gridSize;
                 StartCoroutine(checkInitializeAgentLocationAction());
             }
+
+            //initialize how long the default wait time for objects to stop moving is
+            this.TimeToWaitForObjectsToComeToRest = action.TimeToWaitForObjectsToComeToRest;
             	
             // Debug.Log("Object " + action.controllerInitialization.ToString() + " dict "  + (action.controllerInitialization.variableInitializations == null));//+ string.Join(";", action.controllerInitialization.variableInitializations.Select(x => x.Key + "=" + x.Value).ToArray()));
 

--- a/unity/Assets/Scripts/Contains.cs
+++ b/unity/Assets/Scripts/Contains.cs
@@ -34,25 +34,12 @@ public class Contains : MonoBehaviour
     //this is an object reference to the sim object that is linked to this receptacle box
 	public GameObject myParent = null;
 
-	//if the sim object is one of these properties, do not add it to the Currently Contains list.
-	private List<SimObjPrimaryProperty> PropertiesToIgnore = new List<SimObjPrimaryProperty>(new SimObjPrimaryProperty[] {SimObjPrimaryProperty.Wall,
-		SimObjPrimaryProperty.Floor, SimObjPrimaryProperty.Ceiling, SimObjPrimaryProperty.Static}); //should we ignore SimObjPrimaryProperty.Static?
+	//can use this list to filter out certain objects with properties, currently unused
+	// private List<SimObjPrimaryProperty> PropertiesToIgnore = new List<SimObjPrimaryProperty>(new SimObjPrimaryProperty[] {SimObjPrimaryProperty.Wall,
+	// 	SimObjPrimaryProperty.Floor, SimObjPrimaryProperty.Ceiling, SimObjPrimaryProperty.Static}); //should we ignore SimObjPrimaryProperty.Static?
 
-	// public bool occupied
-	// {
-	// 	get
-	// 	{
-	// 		return isOccupied();
-	// 	}
-
-	// 	set
-	// 	{
-	// 		occupied = value;
-	// 	}
-	// }
-
+	//DEBUG STUFF FOR VISUALIZATION
     //private List<Vector3> validpointlist = new List<Vector3>();
-
 	//world coordinates of the Corners of this object's receptacles in case we need it for something
 	//public List<Vector3> Corners = new List<Vector3>();
 
@@ -70,12 +57,6 @@ public class Contains : MonoBehaviour
 	}
 	void Start()
 	{
-		//XXX debug for setting up scenes, delete or comment out when done setting up scenes
-		//if(MyObjects == null)
-		//{
-		//	Debug.Log(this.name + " Missing MyObjects List");
-		//}
-
 		//check that all objects with receptacles components have the correct Receptacle secondary property
 		#if UNITY_EDITOR
 		SimObjPhysics go = gameObject.GetComponentInParent<SimObjPhysics>();
@@ -107,79 +88,17 @@ public class Contains : MonoBehaviour
 		// }
 	}
 
-	private void FixedUpdate()
-	{
-		//clear the currently contains list so that if things were Initial Random Spawned in, the receptacle
-		//trigger boxes correctly re-populate with the current objects via OnTriggerStay. We need this here
-		//because OnTriggerExit will miss correctly editing the list if objects are teleported around like with
-		//the Initial Random Spawn Function! 
-		//CurrentlyContains.Clear();
-		//occupied = false;
+	protected bool hasAncestor(GameObject child, GameObject potentialAncestor) {
+		if (child == potentialAncestor) {
+			return true;
+		} else if (child.transform.parent != null) {
+			return hasAncestor(child.transform.parent.gameObject, potentialAncestor);
+		} else {
+			return false;
+		}
 	}
 
-	public void OnTriggerEnter(Collider other)
-	{
-		//from the collider, see if the thing hit is a sim object physics
-		//don't detect other trigger colliders to prevent nested objects from containing each other
-		// if (other.GetComponentInParent<SimObjPhysics>() && !other.isTrigger)
-		// {
-			
-		// 	SimObjPhysics sop = other.GetComponentInParent<SimObjPhysics>();
-
-		// 	if(sop.transform == gameObject.GetComponentInParent<SimObjPhysics>().transform)
-		// 	{
-		// 		//don't add myself
-		// 		return;
-		// 	}
-
-		// 	//ignore any sim objects that shouldn't be added to the CurrentlyContains list
-		// 	if (PropertiesToIgnore.Contains(sop.PrimaryProperty))
-		// 	{
-		// 		return;
-		// 	}
-
-		// 	//don't add any parent objects in case this is a child sim object
-		// 	if(sop.transform == myParent.transform)
-		// 	{
-		// 		return;
-		// 	}
-
-		// 	//check each "other" object, see if it is currently in the CurrentlyContains list, and make sure it is NOT one of this object's doors/drawer
-		// 	if (!CurrentlyContains.Contains(sop))//&& !MyObjects.Contains(sop.transform.gameObject))
-		// 	{
-		// 		occupied = true;
-		// 		CurrentlyContains.Add(sop);
-		// 	}
-		// }
-	}
-
-	public void OnTriggerExit(Collider other)
-	{
-		// //remove objects if they leave the ReceptacleTriggerBox
-		// if (other.GetComponentInParent<SimObjPhysics>())
-		// {
-		// 	SimObjPhysics sop = other.GetComponentInParent<SimObjPhysics>();
-
-		// 	//if the object was removed from the receptacle by anything other than the Agent picking it up
-		// 	if(!sop.transform.GetComponentInParent<PhysicsRemoteFPSAgentController>())
-		// 	{
-		// 		//make sure to only remove and unparent stuff that is actually contained - prevent errors like the SinkBasin being unparanted when a mug is removed from it
-		// 		if(CurrentlyContains.Contains(sop))
-		// 		//if(sop.Type != SimObjType.SinkBasin && sop.Type != SimObjType.BathtubBasin)
-		// 		{
-		// 			//check if initial random spawn is currently happening, if it is DO NOT DO THIS
-		// 			// GameObject topObject = GameObject.Find("Objects");
-		// 			// sop.transform.SetParent(topObject.transform);
-		// 		}
-
-		// 	}
-
-		// 	occupied = false;
-		// 	//print(other.GetComponentInParent<SimObjPhysics>().transform.name);
-		// 	CurrentlyContains.Remove(sop);
-		// }
-	}
-	public BoxCollider coll;
+	//public BoxCollider coll;
 
 	//return a list of sim objects currently inside this trigger box as GameObjects
 	public List<GameObject> CurrentlyContainedGameObjects()
@@ -189,53 +108,30 @@ public class Contains : MonoBehaviour
 		BoxCollider b = this.GetComponent<BoxCollider>();
 
 		//debug
-		coll = b;
+		//coll = b;
 
 		//get center of this box in world space
 		Vector3 worldCenter = b.transform.TransformPoint(b.center);
 
-        //Check if colliders are at correct spots
+        //DEBUG: Check if colliders are at correct spots
         //Debug.Log(transform.parent.name + "'s collider is now at (" + b.transform.position.x + ", " + b.transform.position.y + ", " + b.transform.position.z + ").");
-
-		// Vector3 worldCenter = b.transform.position;
-		//worldCenter = transform.InverseTransformPoint(worldCenter) + b.center;
 
 		//size of this receptacle box, but we need to scale by transform
 		Vector3 worldHalfExtents = b.transform.TransformVector(b.transform.InverseTransformDirection(b.size * 0.5f));
 
-        //Test if OverlapBox has the correct dimensions using surrogate geometry (DOES NOT WORK IN TANDEM WITH DEBUG.LOG REPORTS ON OVERLAPS, for some reason)
-        //GameObject surrogateGeo = GameObject.CreatePrimitive(PrimitiveType.Cube);
-        //surrogateGeo.name = transform.parent.gameObject + "_dimensions";
-        //surrogateGeo.transform.position = worldCenter;
-        //surrogateGeo.transform.rotation = b.transform.rotation;
-        //surrogateGeo.transform.localScale = worldHalfExtents * 2;
-
-        //surrogateGeo.transform.parent = b.transform;
-        //Destroy(surrogateGeo.GetComponent<Collider>());
-
-        Debug.Log(transform.parent.name + "'s ReceptacleTriggerBox is at worldCenter (" + worldCenter.x + ", " + worldCenter.y + ", " + worldCenter.z + ", " + ") and worldHalfExtents (" + worldHalfExtents.x + ", " + worldHalfExtents.y + ", " + worldHalfExtents.z + ", " + ").");
-
 		//ok now create an overlap box using these values and return all contained objects
 		foreach (Collider col in Physics.OverlapBox(worldCenter, worldHalfExtents, b.transform.rotation))
 		{
-            //Report which colliders are contained by which ReceptacleTriggerBoxes (DOES NOT WORK IN TANDEM WITH SURROGATE GEOMETRY, for some reason)
-            //if (col.transform.parent.parent == null)
-            //{
-            //    Debug.Log("The " + transform.parent.name + " has " + col.transform.parent.name + "'s " + col.name + " inside of it.");
-            //}
-            //else
-            //{
-            //    Debug.Log("The " + transform.parent.name + " has " + col.transform.parent.parent.name + "'s " + col.transform.name + " inside of it.");
-            //}
-
             //ignore triggers
             if (col.GetComponentInParent<SimObjPhysics>() && !col.isTrigger)
 			{
 				//grab reference to game object this collider is part of
 				SimObjPhysics sop = col.GetComponentInParent<SimObjPhysics>();
 
-                //don't add any colliders from our parent object
-                if (sop.transform != gameObject.GetComponentInParent<SimObjPhysics>().transform)
+                //don't add any colliders from our parent object, so things like a 
+				//shelf or drawer nested inside another shelving unit or dresser sim object
+				//don't contain the object they are nested inside
+                if (!hasAncestor(this.transform.gameObject, sop.transform.gameObject))
 				{
 					//don't add repeat objects in case there were multiple
 					//colliders from the same object
@@ -251,65 +147,41 @@ public class Contains : MonoBehaviour
 	}
 
 	//return if this container object is occupied by any object(s) inside the trigger collider
+	//used by ObjectSpecificReceptacle, so objects like stove burners, coffee machine, etc.
 	public bool isOccupied()
 	{
-		print("isOccupied is being called");
 		bool result = false;
 		if(CurrentlyContainedGameObjects().Count > 0)
 		result = true;
 
-		print("isOccupied result: " + result);
 		return result;
 	}
 
-	//////////////////////////////////////////////////////////////////
-	//report back what is currently inside this receptacle
+	//report back what is currently inside this receptacle as list of SimObjPhysics
 	public List<SimObjPhysics> CurrentlyContainedObjects()
 	{
-        List<SimObjPhysics> cleanedList = new List<SimObjPhysics>(CurrentlyContains);
+        List<SimObjPhysics> toSimObjPhysics = new List<SimObjPhysics>();
 
-        foreach(SimObjPhysics sop in CurrentlyContains)
+        foreach(GameObject g in CurrentlyContainedGameObjects())
         {
-            if(sop.GetComponent<SliceObject>())
-            {
-                if(sop.GetComponent<SliceObject>().IsSliced())
-                cleanedList.Remove(sop);
-            }
+            toSimObjPhysics.Add(g.GetComponent<SimObjPhysics>());
         }
 
-        CurrentlyContains = cleanedList;
-		return CurrentlyContains;
+     	return toSimObjPhysics;
 	}
 
 	//report back a list of object ids of objects currently inside this receptacle
 	public List<string> CurrentlyContainedObjectIDs()
 	{
-        List<SimObjPhysics> cleanedList = new List<SimObjPhysics>(CurrentlyContains);
+        List<string> ids = new List<string>();
 
-		List<string> ids = new List<string>();
-
-		foreach (SimObjPhysics sop in CurrentlyContains)
-		{
-            if(sop.GetComponent<SliceObject>())
-            {
-                if(sop.GetComponent<SliceObject>().IsSliced())
-                {
-                    cleanedList.Remove(sop);
-                }
-            }
-		}
-
-        CurrentlyContains = cleanedList;
-
-        foreach (SimObjPhysics sop in CurrentlyContains)
+        foreach(GameObject g in CurrentlyContainedGameObjects())
         {
-            ids.Add(sop.ObjectID);
+            ids.Add(g.GetComponent<SimObjPhysics>().ObjectID);
         }
 
 		return ids;
 	}
-
-////////////////////////////////////////////////////////////////
 
 	//returns a grid of points above the target receptacle
 	public List<Vector3> GetValidSpawnPointsFromTopOfTriggerBox()
@@ -589,27 +461,27 @@ public class Contains : MonoBehaviour
 		// 	}
 		// }
 
-		if(coll != null)
-		{
-			Color prevColor = Gizmos.color;
-			Matrix4x4 prevMatrix = Gizmos.matrix;
+		// if(coll != null)
+		// {
+		// 	Color prevColor = Gizmos.color;
+		// 	Matrix4x4 prevMatrix = Gizmos.matrix;
 
-			Gizmos.color = Color.red;
-			//Gizmos.matrix = transform.localToWorldMatrix;
-			Gizmos.matrix = coll.transform.localToWorldMatrix;
+		// 	Gizmos.color = Color.red;
+		// 	//Gizmos.matrix = transform.localToWorldMatrix;
+		// 	Gizmos.matrix = coll.transform.localToWorldMatrix;
 
-			Vector3 boxPosition = coll.transform.position;
-			//Vector3 boxPosition = coll.transform.TransformPoint(coll.center);
+		// 	Vector3 boxPosition = coll.transform.position;
+		// 	//Vector3 boxPosition = coll.transform.TransformPoint(coll.center);
 
-			// convert from world position to local position 
-			boxPosition = transform.InverseTransformPoint(boxPosition) + coll.center;
+		// 	// convert from world position to local position 
+		// 	boxPosition = transform.InverseTransformPoint(boxPosition) + coll.center;
 
-			Gizmos.DrawWireCube(boxPosition, coll.size);
+		// 	Gizmos.DrawWireCube(boxPosition, coll.size);
 
-			// restore previous Gizmos settings
-			Gizmos.color = prevColor;
-			Gizmos.matrix = prevMatrix;
-		}
+		// 	// restore previous Gizmos settings
+		// 	Gizmos.color = prevColor;
+		// 	Gizmos.matrix = prevMatrix;
+		// }
 
 	}
     #endif

--- a/unity/Assets/Scripts/Contains.cs
+++ b/unity/Assets/Scripts/Contains.cs
@@ -193,23 +193,49 @@ public class Contains : MonoBehaviour
 
 		//get center of this box in world space
 		Vector3 worldCenter = b.transform.TransformPoint(b.center);
+
+        //Check if colliders are at correct spots
+        //Debug.Log(transform.parent.name + "'s collider is now at (" + b.transform.position.x + ", " + b.transform.position.y + ", " + b.transform.position.z + ").");
+
 		// Vector3 worldCenter = b.transform.position;
-		// worldCenter = transform.InverseTransformPoint(worldCenter) + b.center;
+		//worldCenter = transform.InverseTransformPoint(worldCenter) + b.center;
 
 		//size of this receptacle box, but we need to scale by transform
-		Vector3 worldHalfExtents = b.transform.TransformVector(b.size * 0.5f);
+		Vector3 worldHalfExtents = b.transform.TransformVector(b.transform.InverseTransformDirection(b.size * 0.5f));
+
+        //Test if OverlapBox has the correct dimensions using surrogate geometry (DOES NOT WORK IN TANDEM WITH DEBUG.LOG REPORTS ON OVERLAPS, for some reason)
+        //GameObject surrogateGeo = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        //surrogateGeo.name = transform.parent.gameObject + "_dimensions";
+        //surrogateGeo.transform.position = worldCenter;
+        //surrogateGeo.transform.rotation = b.transform.rotation;
+        //surrogateGeo.transform.localScale = worldHalfExtents * 2;
+
+        //surrogateGeo.transform.parent = b.transform;
+        //Destroy(surrogateGeo.GetComponent<Collider>());
+
+        Debug.Log(transform.parent.name + "'s ReceptacleTriggerBox is at worldCenter (" + worldCenter.x + ", " + worldCenter.y + ", " + worldCenter.z + ", " + ") and worldHalfExtents (" + worldHalfExtents.x + ", " + worldHalfExtents.y + ", " + worldHalfExtents.z + ", " + ").");
 
 		//ok now create an overlap box using these values and return all contained objects
 		foreach (Collider col in Physics.OverlapBox(worldCenter, worldHalfExtents, b.transform.rotation))
 		{
-			//ignore triggers
-			if(col.GetComponentInParent<SimObjPhysics>() && !col.isTrigger)
+            //Report which colliders are contained by which ReceptacleTriggerBoxes (DOES NOT WORK IN TANDEM WITH SURROGATE GEOMETRY, for some reason)
+            //if (col.transform.parent.parent == null)
+            //{
+            //    Debug.Log("The " + transform.parent.name + " has " + col.transform.parent.name + "'s " + col.name + " inside of it.");
+            //}
+            //else
+            //{
+            //    Debug.Log("The " + transform.parent.name + " has " + col.transform.parent.parent.name + "'s " + col.transform.name + " inside of it.");
+            //}
+
+            //ignore triggers
+            if (col.GetComponentInParent<SimObjPhysics>() && !col.isTrigger)
 			{
 				//grab reference to game object this collider is part of
 				SimObjPhysics sop = col.GetComponentInParent<SimObjPhysics>();
 
-				//don't add any colliders from our parent object
-				if(sop.transform != gameObject.GetComponentInParent<SimObjPhysics>().transform)
+                //don't add any colliders from our parent object
+                if (sop.transform != gameObject.GetComponentInParent<SimObjPhysics>().transform)
 				{
 					//don't add repeat objects in case there were multiple
 					//colliders from the same object

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -908,7 +908,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         ServerAction action = new ServerAction();
                         action.action = "PlaceObjectAtPoint";
                         action.position = GameObject.Find("TestPosition").transform.position;
-                        action.objectId = "GarbageCan|+02.63|00.00|-01.48";
+                        action.objectId = "Book|+00.15|+01.10|+00.62";
                         PhysicsController.ProcessControlCommand(action);
                         break;
                     }
@@ -2296,7 +2296,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
                         action.objectPoses[0] = new ObjectPose();
 
-                        action.objectPoses[0].objectName = "Potato_bb7defe9";
+                        action.objectPoses[0].objectName = "Book_3d15d052";
                         action.objectPoses[0].position = new Vector3(0, 0, 0);
                         action.objectPoses[0].rotation = new Vector3(0, 0, 0);
 

--- a/unity/Assets/Scripts/ObjectSpecificReceptacle.cs
+++ b/unity/Assets/Scripts/ObjectSpecificReceptacle.cs
@@ -28,35 +28,25 @@ public class ObjectSpecificReceptacle : MonoBehaviour
 		return result;
 	}
 
+	///REPLACE THIS CHECK WITH NEW CONTAINS CHECK
 	public bool isFull()
 	{
+		print("isFull being called");
 		SimObjPhysics sop = gameObject.GetComponent<SimObjPhysics>();
 
 		foreach (GameObject rtb in sop.ReceptacleTriggerBoxes)
 		{
-			if(rtb.GetComponent<Contains>().occupied)
+			if(rtb.GetComponent<Contains>().isOccupied())
 			{
-				//print("osr is occupied, return true");
+				print("osr is occupied, return true");
 				full = true;
 				return true;
 			}
 		}
 
+		print("osr is not occupied, return false");
 		full = false;
 		return false;
-		// List<string> containsList = new List<string>(sop)Contains());
-
-		// //print(containsList.Count);
-		// if(containsList.Count > 0)
-		// {
-		// 	full = true;
-		// }
-
-		// else
-		// {
-		// 	full = false;
-		// }
-		// return full;
 	}
 	
 	// Use this for initialization
@@ -73,15 +63,15 @@ public class ObjectSpecificReceptacle : MonoBehaviour
 	// Update is called once per frame
 	void Update () 
 	{
-		// if(Input.GetKeyDown(KeyCode.T))
-		// {
-		// 	isFull();
-		// }
+		if(Input.GetKeyDown(KeyCode.Alpha7))
+		{
+			isFull();
+		}
 		//isFull();
 	}
 
 	void LateUpdate()
 	{
-		isFull();
+		//isFull();
 	}
 }

--- a/unity/Assets/Scripts/ObjectSpecificReceptacle.cs
+++ b/unity/Assets/Scripts/ObjectSpecificReceptacle.cs
@@ -28,23 +28,19 @@ public class ObjectSpecificReceptacle : MonoBehaviour
 		return result;
 	}
 
-	///REPLACE THIS CHECK WITH NEW CONTAINS CHECK
 	public bool isFull()
 	{
-		print("isFull being called");
 		SimObjPhysics sop = gameObject.GetComponent<SimObjPhysics>();
 
 		foreach (GameObject rtb in sop.ReceptacleTriggerBoxes)
 		{
 			if(rtb.GetComponent<Contains>().isOccupied())
 			{
-				print("osr is occupied, return true");
 				full = true;
 				return true;
 			}
 		}
 
-		print("osr is not occupied, return false");
 		full = false;
 		return false;
 	}
@@ -60,18 +56,4 @@ public class ObjectSpecificReceptacle : MonoBehaviour
 		#endif
 	}
 	
-	// Update is called once per frame
-	void Update () 
-	{
-		if(Input.GetKeyDown(KeyCode.Alpha7))
-		{
-			isFull();
-		}
-		//isFull();
-	}
-
-	void LateUpdate()
-	{
-		//isFull();
-	}
 }

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -2020,14 +2020,14 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             if(sop != null)
             {
-                print("here?");
-                print("useTimeout?: " + useTimeout);
+                // print("here?");
+                // print("useTimeout?: " + useTimeout);
                 Rigidbody rb = sop.GetComponentInChildren<Rigidbody>();
                 bool stoppedMoving = false;
 
                 while(Time.time - startTime < waitTime)
                 {
-                    print("in while loop");
+                    // print("in while loop");
                     if(sop == null)
                     break;
 
@@ -2037,7 +2037,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     //ok the accel is basically zero, so it has stopped moving
                     if(Mathf.Abs(accel) <= 0.001f)
                     {
-                        print("accel world");
+                        // print("accel world");
                         //force the rb to stop moving just to be safe
                         rb.velocity = Vector3.zero;
                         rb.angularVelocity = Vector3.zero;
@@ -2071,9 +2071,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                     #if UNITY_EDITOR
                     print("yield timed out");
-                    // print("didHandTouchSomething: " + feedback.didHandTouchSomething);
-                    // print("object id: " + feedback.objectId);
-                    // print("armslength: " + feedback.armsLength);
+                    print("didHandTouchSomething: " + feedback.didHandTouchSomething);
+                    print("object id: " + feedback.objectId);
+                    print("armslength: " + feedback.armsLength);
                     #endif
 
                     //force objec to stop moving 

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1981,6 +1981,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     actionFinished(true, feedback);
                 }
 
+                //why is this here?
                 else
                 {
                     actionFinished(true);
@@ -2002,14 +2003,15 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             sopApplyForce(action, sop, 0.0f);
         }
 
-        //used to check if an specified sim object has come to rest, max time of 40 seconds
+        //used to check if an specified sim object has come to rest
+        //set useTimeout bool to use a faster time out
         private IEnumerator checkIfObjectHasStoppedMoving(SimObjPhysics sop, float length, bool useTimeout = false)
         {
             //yield for the physics update to make sure this yield is consistent regardless of framerate
             yield return new WaitForFixedUpdate();
 
             float startTime = Time.time;
-            float waitTime = 2.0f;
+            float waitTime = TimeToWaitForObjectsToComeToRest;
 
             if(useTimeout)
             {
@@ -2018,11 +2020,14 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             if(sop != null)
             {
+                print("here?");
+                print("useTimeout?: " + useTimeout);
                 Rigidbody rb = sop.GetComponentInChildren<Rigidbody>();
                 bool stoppedMoving = false;
 
                 while(Time.time - startTime < waitTime)
                 {
+                    print("in while loop");
                     if(sop == null)
                     break;
 
@@ -2032,12 +2037,12 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     //ok the accel is basically zero, so it has stopped moving
                     if(Mathf.Abs(accel) <= 0.001f)
                     {
-                        stoppedMoving = true;
-
+                        print("accel world");
                         //force the rb to stop moving just to be safe
                         rb.velocity = Vector3.zero;
                         rb.angularVelocity = Vector3.zero;
-
+                        rb.Sleep();
+                        stoppedMoving = true;
                         break;
                     }
 
@@ -2055,7 +2060,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 }
 
                 //we are past the wait time threshold, so force object to stop moving before
-                //returning actionFinished (true)
+                rb.velocity = Vector3.zero;
+                rb.angularVelocity = Vector3.zero;
+                rb.Sleep();
 
                 //return to metadatawrapper.actionReturn if an object was touched during this interaction
                 if(length != 0.0f)
@@ -2072,6 +2079,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     //force objec to stop moving 
                     rb.velocity = Vector3.zero;
                     rb.angularVelocity = Vector3.zero;
+                    rb.Sleep();
+
                     actionFinished(true, feedback);
                 }
 
@@ -4508,7 +4517,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         {
             if (target.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.Receptacle)) 
             {
-                foreach (SimObjPhysics sop in target.ReceptacleObjects) 
+                foreach (SimObjPhysics sop in target.SimObjectsContainedByReceptacle) 
                 {
                     //for every object that is contained by this object...first make sure it's pickupable so we don't like, grab a Chair if it happened to be in the receptacle box or something
                     //turn off the colliders (so contained object doesn't block movement), leaving Trigger Colliders active (this is important to maintain visibility!)
@@ -4999,7 +5008,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             if (freezeContained) {
                 target = ancestorSimObjPhysics(coo.gameObject);
                 objectIdToOldParent = new Dictionary<string, Transform>();
-                foreach (string objectId in target.Contains()) {
+                foreach (string objectId in target.GetAllSimObjectsInReceptacleTriggersByObjectID()) {
                     SimObjPhysics toReParent = physicsSceneManager.ObjectIdToSimObjPhysics[objectId];
                     objectIdToOldParent[toReParent.ObjectID] = toReParent.transform.parent;
                     toReParent.transform.parent = coo.transform;
@@ -5103,7 +5112,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 foreach (CanOpen_Object coo in coos) {
                     SimObjPhysics target = ancestorSimObjPhysics(coo.gameObject);
                     targets.Add(target);
-                    foreach (string objectId in target.Contains()) {
+                    foreach (string objectId in target.GetAllSimObjectsInReceptacleTriggersByObjectID()) {
                         SimObjPhysics toReParent = physicsSceneManager.ObjectIdToSimObjPhysics[objectId];
                         objectIdToOldParent[toReParent.ObjectID] = toReParent.transform.parent;
                         toReParent.transform.parent = coo.transform;
@@ -5589,7 +5598,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
 
             if (target) {
-                List<string> ids = target.Contains();
+                List<string> ids = target.GetAllSimObjectsInReceptacleTriggersByObjectID();
 
             #if UNITY_EDITOR
                 foreach (string s in ids) 
@@ -5840,12 +5849,12 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             if (physicsSceneManager.ObjectIdToSimObjPhysics.ContainsKey(action.objectId)) {
                 SimObjPhysics sop = physicsSceneManager.ObjectIdToSimObjPhysics[action.objectId];
                 if (!ReceptacleRestrictions.SpawnOnlyOutsideReceptacles.Contains(sop.ObjType)) {
-                    foreach (SimObjPhysics containedSop in sop.ReceptacleObjects) {
+                    foreach (SimObjPhysics containedSop in sop.SimObjectsContainedByReceptacle) {
                         UpdateDisplayGameObject(containedSop.gameObject, false);
                     }
                 }
                 UpdateDisplayGameObject(sop.gameObject, false);
-                sop.Contains();
+                sop.GetAllSimObjectsInReceptacleTriggersByObjectID();
 
                 actionFinished(true);
             } else {
@@ -5858,7 +5867,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             if (physicsSceneManager.ObjectIdToSimObjPhysics.ContainsKey(action.objectId)) {
                 SimObjPhysics sop = physicsSceneManager.ObjectIdToSimObjPhysics[action.objectId];
                 if (!ReceptacleRestrictions.SpawnOnlyOutsideReceptacles.Contains(sop.ObjType)) {
-                    foreach (SimObjPhysics containedSop in sop.ReceptacleObjects) {
+                    foreach (SimObjPhysics containedSop in sop.SimObjectsContainedByReceptacle) {
                         UpdateDisplayGameObject(containedSop.gameObject, true);
                     }
                 }
@@ -7821,7 +7830,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             HashSet<string> objectIdsContained = new HashSet<string>();
             foreach (SimObjPhysics so in physicsSceneManager.ObjectIdToSimObjPhysics.Values) {
                 if (objectIsOfIntoType(so)) {
-                    foreach (string id in so.Contains()) {
+                    foreach (string id in so.GetAllSimObjectsInReceptacleTriggersByObjectID()) {
                         objectIdsContained.Add(id);
                     }
                 }
@@ -8000,7 +8009,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             HashSet<string> objectIdsContained = new HashSet<string>();
             foreach (SimObjPhysics so in physicsSceneManager.ObjectIdToSimObjPhysics.Values) {
                 if (objectIsOfIntoType(so)) {
-                    foreach (string id in so.Contains()) {
+                    foreach (string id in so.GetAllSimObjectsInReceptacleTriggersByObjectID()) {
                         objectIdsContained.Add(id);
                     }
                 }

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -2020,14 +2020,11 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             if(sop != null)
             {
-                // print("here?");
-                // print("useTimeout?: " + useTimeout);
                 Rigidbody rb = sop.GetComponentInChildren<Rigidbody>();
                 bool stoppedMoving = false;
 
                 while(Time.time - startTime < waitTime)
                 {
-                    // print("in while loop");
                     if(sop == null)
                     break;
 
@@ -2037,7 +2034,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     //ok the accel is basically zero, so it has stopped moving
                     if(Mathf.Abs(accel) <= 0.001f)
                     {
-                        // print("accel world");
                         //force the rb to stop moving just to be safe
                         rb.velocity = Vector3.zero;
                         rb.angularVelocity = Vector3.zero;

--- a/unity/Assets/Scripts/PhysicsSceneManager.cs
+++ b/unity/Assets/Scripts/PhysicsSceneManager.cs
@@ -240,6 +240,8 @@ public class PhysicsSceneManager : MonoBehaviour
 			{
 				ReceptaclesInScene.Add(sop);
 
+				#if UNITY_EDITOR
+				//debug if some of these receptacles were not set up correctly
 				foreach (GameObject go in sop.ReceptacleTriggerBoxes)
 				{
 					if (go == null) {
@@ -247,9 +249,9 @@ public class PhysicsSceneManager : MonoBehaviour
 						continue;
 					}
 					Contains c = go.GetComponent<Contains>();
-                    c.CurrentlyContainedObjects().Clear();
-                    c.GetComponent<Collider>().enabled = false;
-                    c.GetComponent<Collider>().enabled = true;
+                    // c.CurrentlyContainedObjects().Clear();
+                    // c.GetComponent<Collider>().enabled = false;
+                    // c.GetComponent<Collider>().enabled = true;
                     if (c == null) {
 						Debug.LogWarning(sop.gameObject + " is missing a contains script on one of its receptacle boxes.");
 						continue;
@@ -258,6 +260,7 @@ public class PhysicsSceneManager : MonoBehaviour
 						go.GetComponent<Contains>().myParent = sop.transform.gameObject;
 					}
 				}
+				#endif
 			}
 		}
 

--- a/unity/Assets/Scripts/SimObjPhysics.cs
+++ b/unity/Assets/Scripts/SimObjPhysics.cs
@@ -181,21 +181,20 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj
 		}
 	}
 
-	//get all the ObjectID strings of all objects contained by this receptacle object
 	public List<string> ReceptacleObjectIds
 	{
 		get
 		{
-			return this.Contains();
+			return this.GetAllSimObjectsInReceptacleTriggersByObjectID();
 		}
 	}
 
 	//get all objects contained by this receptacle object as a list of SimObjPhysics
-	public List<SimObjPhysics> ReceptacleObjects
+	public List<SimObjPhysics> SimObjectsContainedByReceptacle
 	{
 		get
 		{
-			return this.ContainsGameObject();
+			return this.GetAllSimObjectsInReceptacleTriggers();
 		}
 
 	}
@@ -916,42 +915,8 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj
         myrb.AddForce(dir * magnitude);
     }
 
-	////////////////////////////////////////////////////////////////////////////////
-
-	//XXX: Replace with new Overlap Box check
-	//returns a game object list of all sim objects contained by this object if it is a receptacle
-	public List<GameObject> Contains_GameObject()
-	{
-		List<SimObjSecondaryProperty> sspList = new List<SimObjSecondaryProperty>(SecondaryProperties);
-
-		List<GameObject> objs = new List<GameObject>();
-
-		//is this object a receptacle?
-		if (sspList.Contains(SimObjSecondaryProperty.Receptacle))
-		{
-			//this is a receptacle, now populate objs list of contained objets to return below
-			if (ReceptacleTriggerBoxes != null)
-			{
-				//do this once per ReceptacleTriggerBox referenced by this object
-				foreach (GameObject rtb in ReceptacleTriggerBoxes)
-				{
-					//now go through every object each ReceptacleTriggerBox is keeping track of and add their string ObjectID to objs
-					foreach (SimObjPhysics sop in rtb.GetComponent<Contains>().CurrentlyContainedObjects())
-					{
-						//don't add repeats
-						if (!objs.Contains(sop.gameObject))
-							objs.Add(sop.gameObject);
-					}
-				}
-			}
-		}
-
-		return objs;
-	}
-
-	//XXX: Replace with new Overlap Box check
-	//if this is a receptacle object, return list of references to all objects currently contained
-	public List<SimObjPhysics> ContainsGameObject()
+	//return all sim objects contained by this object if it is a receptacle
+	public List<SimObjPhysics> GetAllSimObjectsInReceptacleTriggers()
 	{
 		List<SimObjPhysics> objs = new List<SimObjPhysics>();
 
@@ -976,49 +941,31 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj
 		return objs;
 	}
 
-	//XXX: Replace with new Overlap Box check
-	//if this is a receptacle object, check what is inside the Receptacle
-	//make sure to return array of strings so that this info can be put into MetaData
-	public List<string> Contains()
+	//return all sim objects by object ID contained by this object if it is a receptacle
+	public List<string> GetAllSimObjectsInReceptacleTriggersByObjectID()
 	{
 		List<string> objs = new List<string>();
 
-		//is this object a receptacle?
-		if (IsReceptacle)
+		if(DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.Receptacle))
 		{
-			//this is a receptacle, now populate objs list of contained objets to return below
-			if (ReceptacleTriggerBoxes != null)
+			if(ReceptacleTriggerBoxes != null)
 			{
-				//do this once per ReceptacleTriggerBox referenced by this object
-				foreach (GameObject rtb in ReceptacleTriggerBoxes)
+				foreach (GameObject go in ReceptacleTriggerBoxes)
 				{
-					//now go through every object each ReceptacleTriggerBox is keeping track of and add their string ObjectID to objs
-					foreach (string id in rtb.GetComponent<Contains>().CurrentlyContainedObjectIDs())
+					foreach(string s in go.GetComponent<Contains>().CurrentlyContainedObjectIDs())
 					{
-						//don't add repeats
-						if (!objs.Contains(id))
-							objs.Add(id);
+						if(!objs.Contains(s))
+						{
+                            //print(sop.transform.name);
+							objs.Add(s);
+						}
 					}
 				}
-
-				return objs;
-			}
-
-			else
-			{
-				Debug.Log("No Receptacle Trigger Box!");
-				return objs;
 			}
 		}
 
-		else
-		{
-			Debug.Log(gameObject.name + " is not a Receptacle!");
-			return objs;
-		}
+		return objs;
 	}
-
-	////////////////////////////////////////////////////////////////////////////////
 
 	public List<GameObject> ContainedGameObjects()
 	{


### PR DESCRIPTION
There are two main changes with this pull:

1) Receptacle Behavior - receptacles used to update their contents with each fixed update using a series of OnTrigger calls. This has now been replaced with Physics Overlap Boxes that snapshot the contents of the receptacle whenever an actionFinished() call is made. This should improve physics performance somewhat (hopefully a lot) due to minimizing the number of fixed update checks are happening across all receptacle objects.

2) New (undocumented for now?) Initialization parameter to allow more control over how long actions yield to return when waiting for an object to come to rest- Previously all actions that could move an object in a way that it should wait for the object to come to rest before returning actionFinished() defaulted to 2 second wait window. This is good for efficiency but could cause inaccuracies because some objects won't stop moving after only 2 seconds, leading to an actionFinished() call that is not synced up with how the world state actually is. 

**Example of Current Wait for Rest Behavior:** drop apple, wait 2 seconds, apple is not finished moving until 10 seconds. The result of this will be the actionFinished() fires at 2 seconds, giving a snapshot of the state of the apple and scene at t = 2, but once t = 10 the apple will be in an entirely new location not reflected in the metadata.

This change allows users to specify how long they want to yield for physics resolution via the `TimeToWaitForObjectsToComeToRest` float that can be specified on init. An additional change with this, is for more consistency, when the wait time is up all objects will be forced to stop moving and immediately go to rigidbody sleep, halting movement. This means that a new behavior will happen given the example above:

**Example of New Wait for Rest Behavior:** drop apple, wait 2 seconds, apple normally would not finish moving until 10 seconds. After 2 seconds, actionFinished() is called but the apple becomes frozen wherever it was at t = 2. This will make the metadata reflect the scene state without being desynced, but may cause situations like a bouncing ball after 2 seconds being frozen in midair if it happened to be midair at t = 2. To counteract this, users will be able to set the wait time to longer, like 20 seconds, to ensure the ball finishes bouncing. I think this default behavior, while less realistic, is more desirable than the current behavior where the object just becomes desynced so that the last returned metadata is just not accurate at all. Notably, if an object would come to rest sooner than the specified wait time, the action will short circuit and immediately return without having to wait the entire wait time.