### PR TITLE
Erick/simobj filter

### DIFF
--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -138,12 +138,14 @@ def test_simobj_filter(controller):
     objects = controller.last_event.metadata['objects']
     unfiltered_object_ids = sorted([o['objectId'] for o in objects])
     filter_object_ids = sorted([o['objectId'] for o in objects[0:3]])
-    from pprint import pprint
-    pprint(filter_object_ids)
     e = controller.step(dict(action='SetObjectFilter', objectIds=filter_object_ids))
     assert len(e.metadata['objects']) == len(filter_object_ids)
     filtered_object_ids =sorted([o['objectId'] for o in e.metadata['objects']])
     assert filtered_object_ids == filter_object_ids
+
+    e = controller.step(dict(action='SetObjectFilter', objectIds=[]))
+    assert len(e.metadata['objects']) == 0
+
     e = controller.step(dict(action='ResetObjectFilter'))
     reset_filtered_object_ids =sorted([o['objectId'] for o in e.metadata['objects']])
     assert unfiltered_object_ids == reset_filtered_object_ids

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -132,6 +132,22 @@ def test_rotate_left(controller):
     assert e.metadata['agent']['rotation']['x'] == 0.0
     assert e.metadata['agent']['rotation']['z'] == 0.0
 
+@pytest.mark.parametrize("controller", [wsgi_controller, fifo_controller])
+def test_simobj_filter(controller):
+
+    objects = controller.last_event.metadata['objects']
+    unfiltered_object_ids = sorted([o['objectId'] for o in objects])
+    filter_object_ids = sorted([o['objectId'] for o in objects[0:3]])
+    from pprint import pprint
+    pprint(filter_object_ids)
+    e = controller.step(dict(action='SetObjectFilter', objectIds=filter_object_ids))
+    assert len(e.metadata['objects']) == len(filter_object_ids)
+    filtered_object_ids =sorted([o['objectId'] for o in e.metadata['objects']])
+    assert filtered_object_ids == filter_object_ids
+    e = controller.step(dict(action='ResetObjectFilter'))
+    reset_filtered_object_ids =sorted([o['objectId'] for o in e.metadata['objects']])
+    assert unfiltered_object_ids == reset_filtered_object_ids
+
 
 @pytest.mark.parametrize("controller", [wsgi_controller, fifo_controller])
 def test_add_third_party_camera(controller):


### PR DESCRIPTION
Allow users to filter all or some of the outbound objects in the metadata.  This has shown to result in a dramatic performance increase.  Using the FifoServer (new backend) and filtering all objects we go from 82 FPS to 172 FPS (Pass action).  Using WSGI we go from 22 FPS to 27 FPS (this is due to the poorer performance of the existing WSGI backend and JSON.net).  Users will want to filter all objects when training a point nav task and can filter down to one or two objects for object nav tasks.