### PR TITLE
disabling unity audio

### DIFF
--- a/unity/ProjectSettings/AudioManager.asset
+++ b/unity/ProjectSettings/AudioManager.asset
@@ -3,14 +3,17 @@
 --- !u!11 &1
 AudioManager:
   m_ObjectHideFlags: 0
+  serializedVersion: 2
   m_Volume: 1
   Rolloff Scale: 1
   Doppler Factor: 1
   Default Speaker Mode: 2
   m_SampleRate: 0
-  m_DSPBufferSize: 0
+  m_DSPBufferSize: 1024
   m_VirtualVoiceCount: 512
   m_RealVoiceCount: 32
   m_SpatializerPlugin: 
-  m_DisableAudio: 0
+  m_AmbisonicDecoderPlugin: 
+  m_DisableAudio: 1
   m_VirtualizeEffects: 1
+  m_RequestedDSPBufferSize: 0


### PR DESCRIPTION
I noticed when running a large number of experiments that the pulseaudio process on Linux would use up to 100% of a CPU.  This PR disables the Audio in thor. When I ran a build with the audio disabled pulseaudio uses no CPU.