### PR TITLE
Erick/simobj filter distance 2

### DIFF
--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1355,6 +1355,7 @@ public class ServerAction
 	public float TimeToWaitForObjectsToComeToRest = 10.0f;
 	public float intensity;//used for light?
 	public float scale;
+    public string visibilityScheme;
 
     public SimObjType ReceptableSimObjType()
 	{
@@ -1364,6 +1365,13 @@ public class ServerAction
 		}
 		return (SimObjType)Enum.Parse(typeof(SimObjType), receptacleObjectType);
 	}
+
+    public VisibilityScheme GetVisibilityScheme() {
+        if (string.IsNullOrEmpty(visibilityScheme)) {
+            return VisibilityScheme.Collider;
+        }
+		return (VisibilityScheme)Enum.Parse(typeof(VisibilityScheme), visibilityScheme);
+    }
 
 	public SimObjType GetSimObjType()
 	{
@@ -1409,6 +1417,12 @@ public enum ServerActionErrorCode  {
 	InvalidAction,
     MissingArguments
 }
+
+public enum VisibilityScheme {
+    Collider,
+    Distance
+}
+
 
 
 [Serializable]

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -484,6 +484,7 @@ public class AgentManager : MonoBehaviour
     }
 
     private void LateUpdate() {
+
 		int completeCount = 0;
 		foreach (BaseFPSAgentController agent in this.agents) {
 			if (agent.actionComplete) {
@@ -1355,7 +1356,7 @@ public class ServerAction
 	public float TimeToWaitForObjectsToComeToRest = 10.0f;
 	public float intensity;//used for light?
 	public float scale;
-    public string visibilityScheme;
+    public string visibilityScheme = VisibilityScheme.Collider.ToString();
 
     public SimObjType ReceptableSimObjType()
 	{
@@ -1367,10 +1368,16 @@ public class ServerAction
 	}
 
     public VisibilityScheme GetVisibilityScheme() {
-        if (string.IsNullOrEmpty(visibilityScheme)) {
-            return VisibilityScheme.Collider;
+        VisibilityScheme result = VisibilityScheme.Collider;
+        try 
+        {
+            result = (VisibilityScheme)Enum.Parse(typeof(VisibilityScheme), visibilityScheme, true);
+        } 
+        catch (ArgumentException ex) { 
+            Debug.LogError("Error parsing visibilityScheme: '" + visibilityScheme + "' defaulting to Collider");
         }
-		return (VisibilityScheme)Enum.Parse(typeof(VisibilityScheme), visibilityScheme);
+
+		return result;
     }
 
 	public SimObjType GetSimObjType()

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1997,7 +1997,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                     }
 
                     //if this particular point is in view...
-                    if (CheckIfVisibilityPointInViewport(sop, point, agentCamera, false)) 
+                    if (CheckIfVisibilityPointInViewport(sop, point, agentCamera, sop.IsReceptacle)) 
                     {
                         visPointCount++;
                         #if !UNITY_EDITOR


### PR DESCRIPTION
Second try:

I rewrote the VisibleSimObs method to only examine the VisibilityPoints instead of using CapsuleColliders.  The benefit is around a 2x-10x speedup (when not using the filter) depending on the scene and where the agent is located. However, I am only using this approach when a filter is set, so the speedup is currently not realized by default.  My plan is to switch the existing visibility check to this one after I can do an exhaustive test of all scenes + points, comparing the old and new lists of objects that are reported as visible.