### PR TITLE
seenPoints for reachablePositions and shortestPath

### DIFF
--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -288,6 +288,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             };
 
             HashSet<Vector3> goodPoints = new HashSet<Vector3>();
+            HashSet<Vector3> seenPoints = new HashSet<Vector3>();
             int layerMask = 1 << 8;
             int stepsTaken = 0;
             while (pointsQueue.Count != 0) {
@@ -297,6 +298,12 @@ namespace UnityStandardAssets.Characters.FirstPerson
                     goodPoints.Add(p);
                     HashSet<Collider> objectsAlreadyColliding = new HashSet<Collider>(objectsCollidingWithAgent());
                     foreach (Vector3 d in directions) {
+                        Vector3 newPosition = p + d * gridSize * gridMultiplier;
+                        if (seenPoints.Contains(newPosition)) {
+                            continue;
+                        }
+                        seenPoints.Add(newPosition);
+
                         RaycastHit[] hits = capsuleCastAllForAgent(
                             cc,
                             sw,
@@ -316,7 +323,6 @@ namespace UnityStandardAssets.Characters.FirstPerson
                                 break;
                             }
                         }
-                        Vector3 newPosition = p + d * gridSize * gridMultiplier;
                         bool inBounds = agentManager.SceneBounds.Contains(newPosition);
                         if (errorMessage == "" && !inBounds) {
                             errorMessage = "In " +
@@ -2902,6 +2908,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             Quaternion originalRot = transform.rotation;
 
             HashSet<Vector3> goodPoints = new HashSet<Vector3>();
+            HashSet<Vector3> seenPoints = new HashSet<Vector3>();
             int layerMask = 1 << 8;
             int stepsTaken = 0;
             pos = Vector3.negativeInfinity;
@@ -2926,6 +2933,12 @@ namespace UnityStandardAssets.Characters.FirstPerson
                     
                     HashSet<Collider> objectsAlreadyColliding = new HashSet<Collider>(objectsCollidingWithAgent());
                     foreach (Vector3 d in directions) {
+                        Vector3 newPosition = p + d * gridSize * gridMultiplier;
+                        if (seenPoints.Contains(newPosition)) {
+                            continue;
+                        }
+                        seenPoints.Add(newPosition);
+
                         RaycastHit[] hits = capsuleCastAllForAgent(
                             cc,
                             sw,
@@ -2945,7 +2958,6 @@ namespace UnityStandardAssets.Characters.FirstPerson
                                 break;
                             }
                         }
-                        Vector3 newPosition = p + d * gridSize * gridMultiplier;
                         bool inBounds = agentManager.SceneBounds.Contains(newPosition);
                         if (errorMessage == "" && !inBounds) {
                             errorMessage = "In " +


### PR DESCRIPTION

adding a seenPoints hashset to keep track of which points have been visited during the BFS for shortestPath and reachablePositions

I feel pretty confident about this, but want to be sure that this doesn't introduce any errors.  The output for both reachablePositions and shortestPath were identical when I tested this with and without the seenPoints hashset.  The benefit I saw is that the number of steps taken went from around 400-> 100 for reachable positions (FloorPlan28) and 190 -> 66 for shortestPath (FloorPlan28 mug).