### PR TITLE
adding state field and state machine to manage frame emitting instead…

### DIFF
--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -436,6 +436,9 @@ class Controller(object):
                     DeprecationWarning
                 )
 
+            if 'fastActionEmit' in self.initialization_parameters and self.server_class != ai2thor.fifo_server.FifoServer:
+                warnings.warn("fastAtionEmit is only available with the FifoServer");
+
             if 'continuousMode' in self.initialization_parameters:
                 warnings.warn(
                     "Warning: 'continuousMode' is deprecated and will be ignored,"

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -80,6 +80,25 @@ def test_small_aspect():
     event = controller.step(dict(action='Initialize', gridSize=0.25))
     assert event.frame.shape == (64, 128, 3)
 
+@pytest.mark.parametrize("controller", [fifo_controller])
+def test_fast_emit(controller):
+    event = controller.step(dict(action='RotateRight'))
+    event_fast_emit = controller.step(dict(action='TestFastEmit', rvalue='foo'))
+    # assert that when actionFastEmit is off that the objects are different
+    assert id(event.metadata['objects']) !=  id(event_fast_emit.metadata['objects'])
+
+    fast_controller = UnityTestController(server_class=FifoServer, fastActionEmit=True)
+    event = fast_controller.step(dict(action='RotateRight'))
+    event_fast_emit = fast_controller.step(dict(action='TestFastEmit', rvalue='foo'))
+    event_no_fast_emit = fast_controller.step(dict(action='LookUp'))
+    event_no_fast_emit_2 = fast_controller.step(dict(action='RotateRight'))
+
+    assert event.metadata['actionReturn'] is None
+    assert event_fast_emit.metadata['actionReturn'] == 'foo' 
+    assert id(event.metadata['objects']) ==  id(event_fast_emit.metadata['objects'])
+    assert id(event.metadata['objects']) !=  id(event_no_fast_emit.metadata['objects'])
+    assert id(event_no_fast_emit_2.metadata['objects']) !=  id(event_no_fast_emit.metadata['objects'])
+
 @pytest.mark.parametrize("controller", [wsgi_controller, fifo_controller])
 def test_lookdown(controller):
 

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -80,13 +80,7 @@ def test_small_aspect():
     event = controller.step(dict(action='Initialize', gridSize=0.25))
     assert event.frame.shape == (64, 128, 3)
 
-@pytest.mark.parametrize("controller", [fifo_controller])
-def test_fast_emit(controller):
-    event = controller.step(dict(action='RotateRight'))
-    event_fast_emit = controller.step(dict(action='TestFastEmit', rvalue='foo'))
-    # assert that when actionFastEmit is off that the objects are different
-    assert id(event.metadata['objects']) !=  id(event_fast_emit.metadata['objects'])
-
+def test_fast_emit():
     fast_controller = UnityTestController(server_class=FifoServer, fastActionEmit=True)
     event = fast_controller.step(dict(action='RotateRight'))
     event_fast_emit = fast_controller.step(dict(action='TestFastEmit', rvalue='foo'))
@@ -98,6 +92,14 @@ def test_fast_emit(controller):
     assert id(event.metadata['objects']) ==  id(event_fast_emit.metadata['objects'])
     assert id(event.metadata['objects']) !=  id(event_no_fast_emit.metadata['objects'])
     assert id(event_no_fast_emit_2.metadata['objects']) !=  id(event_no_fast_emit.metadata['objects'])
+
+@pytest.mark.parametrize("controller", [fifo_controller])
+def test_fast_emit_disabled(controller):
+    event = controller.step(dict(action='RotateRight'))
+    event_fast_emit = controller.step(dict(action='TestFastEmit', rvalue='foo'))
+    # assert that when actionFastEmit is off that the objects are different
+    assert id(event.metadata['objects']) !=  id(event_fast_emit.metadata['objects'])
+
 
 @pytest.mark.parametrize("controller", [wsgi_controller, fifo_controller])
 def test_lookdown(controller):

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -46,6 +46,7 @@ public class AgentManager : MonoBehaviour
     private serverTypes serverType;
     private AgentState agentState = AgentState.Emit;
     private bool fastActionEmit;
+    private HashSet<string> agentManagerActions = new HashSet<string>{"Reset", "Initialize", "AddThirdPartyCamera", "UpdateThirdPartyCamera"};
 
 
 	public Bounds sceneBounds = new Bounds(
@@ -917,18 +918,9 @@ public class AgentManager : MonoBehaviour
         this.renderImage = controlCommand.renderImage == null ? true : controlCommand.renderImage;
         this.activeAgentId = controlCommand.agentId == null ? 0 : controlCommand.agentId;
 
-		if (controlCommand.action == "Reset") {
+		if (agentManagerActions.Contains(controlCommand.action.ToString())) {
             this.agentState = AgentState.Processing;
-			this.Reset (controlCommand.ToObject(typeof(ServerAction)));
-		} else if (controlCommand.action == "Initialize") {
-            this.agentState = AgentState.Processing;
-			this.Initialize(controlCommand.ToObject(typeof(ServerAction)));
-		} else if (controlCommand.action == "AddThirdPartyCamera") {
-            this.agentState = AgentState.Processing;
-			this.AddThirdPartyCamera(controlCommand.ToObject(typeof(ServerAction)));
-		} else if (controlCommand.action == "UpdateThirdPartyCamera") {
-            this.agentState = AgentState.Processing;
-			this.UpdateThirdPartyCamera(controlCommand.ToObject(typeof(ServerAction)));
+            ActionDispatcher.Dispatch(this, controlCommand);
 		} else {
             //we only allow renderObjectImage to be flipped on
             //on a per step() basis, since by default the param is null

--- a/unity/Assets/Scripts/DebugDiscreteAgentController.cs
+++ b/unity/Assets/Scripts/DebugDiscreteAgentController.cs
@@ -78,7 +78,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 // }
 
                 //if we press enter, select the input field
-                if (PhysicsController.actionComplete) {
+                if (PhysicsController.ReadyForCommand) {
                     if (Input.GetKeyDown(KeyCode.Return))
                     {
                         UnityEngine.EventSystems.EventSystem.current.SetSelectedGameObject(InputFieldObj);

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -127,13 +127,9 @@ namespace UnityStandardAssets.Characters.FirstPerson
         #if UNITY_EDITOR
         public void Execute(string command)
         {
-            if ((PhysicsController.enabled && !PhysicsController.actionComplete) ||
-                (StochasticController != null && StochasticController.enabled && !StochasticController.actionComplete)
+            if ((PhysicsController.enabled && PhysicsController.IsProcessing) ||
+                (StochasticController != null && StochasticController.enabled && StochasticController.IsProcessing)
             ) {
-                Debug.Log("Cannot execute command while last action has not completed.");
-            }
-
-            if (StochasticController.enabled && !StochasticController.actionComplete) {
                 Debug.Log("Cannot execute command while last action has not completed.");
             }
 
@@ -166,7 +162,6 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         // action.renderClassImage = true;
                         // action.renderObjectImage = true;
                         // action.renderFlowImage = true;
-						PhysicsController.actionComplete = false;
                         // action.rotateStepDegrees = 30;
                         //action.ssao = "default";
                         //action.snapToGrid = true;
@@ -214,7 +209,6 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
                         action.gridSize = 0.25f;
                         action.visibilityDistance = 1.0f;
-						PhysicsController.actionComplete = false;
                         action.fieldOfView = 60;
                         action.rotateStepDegrees = 45;
                         action.agentMode = "bot";
@@ -462,7 +456,6 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         // action.renderObjectImage = true;
                         // action.renderFlowImage = true;
 
-						PhysicsController.actionComplete = false;
                         action.action = "Initialize";
                         action.agentMode = "drone";
                         action.agentControllerType = "drone";
@@ -735,7 +728,6 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         action.renderObjectImage = true;
                         action.renderFlowImage = true;
 
-						PhysicsController.actionComplete = false;
                         //action.ssao = "default";
 
                         action.action = "Initialize";

--- a/unity/Assets/Scripts/DiscreteHidenSeekAgentController.cs
+++ b/unity/Assets/Scripts/DiscreteHidenSeekAgentController.cs
@@ -151,7 +151,7 @@ public int objectVariation;
                 highlightController.UpdateHighlightedObject(Input.mousePosition);
                 highlightController.MouseControls();
 
-                if (PhysicsController.actionComplete) {
+                if (PhysicsController.ReadyForCommand) {
                         handMode = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
                         float WalkMagnitude = 0.25f;
                         if (!handMode && !hidingPhase) {
@@ -267,7 +267,7 @@ public int objectVariation;
                                 }
                             }
                         }
-                        if ((Input.GetKeyDown(KeyCode.LeftControl) || Input.GetKeyDown(KeyCode.C) || Input.GetKeyDown(KeyCode.RightControl) ) && PhysicsController.actionComplete) {
+                        if ((Input.GetKeyDown(KeyCode.LeftControl) || Input.GetKeyDown(KeyCode.C) || Input.GetKeyDown(KeyCode.RightControl) ) && PhysicsController.ReadyForCommand) {
                             ServerAction action = new ServerAction();
                             if (this.PhysicsController.isStanding()) {
                                 action.action = "Crouch";

--- a/unity/Assets/Scripts/DiscretePointClickAgentController.cs
+++ b/unity/Assets/Scripts/DiscretePointClickAgentController.cs
@@ -49,7 +49,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 highlightController.UpdateHighlightedObject(Input.mousePosition);
                 highlightController.MouseControls();
 
-                if (PhysicsController.actionComplete) {
+                if (PhysicsController.ReadyForCommand) {
                         float WalkMagnitude = 0.25f;
                         if (!handMode) {
                             if(Input.GetKeyDown(KeyCode.W))

--- a/unity/Assets/Scripts/DroneFPSAgentController.cs
+++ b/unity/Assets/Scripts/DroneFPSAgentController.cs
@@ -15,7 +15,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
         public GameObject basketTrigger;
         public DroneObjectLauncher DroneObjectLauncher;
         public List<SimObjPhysics> caught_object = new List<SimObjPhysics>();
-        public bool hasFixedUpdateHappened = true;//track if the fixed physics update has happened
+        private bool hasFixedUpdateHappened = true;//track if the fixed physics update has happened
         protected Vector3 thrust;
         public float dronePositionRandomNoiseSigma = 0f;
         //count of fixed updates for use in droneCurrentTime
@@ -24,6 +24,16 @@ namespace UnityStandardAssets.Characters.FirstPerson
         void Update () 
         {
             
+        }
+
+        protected override void resumePhysics() {
+            if (Time.timeScale == 0 && !Physics.autoSimulation && physicsSceneManager.physicsSimulationPaused)
+            {
+                Time.timeScale = this.autoResetTimeScale;
+                Physics.autoSimulation = true;
+                physicsSceneManager.physicsSimulationPaused = false;
+                this.hasFixedUpdateHappened = false;
+            }
         }
 
         public override void Start()
@@ -88,6 +98,10 @@ namespace UnityStandardAssets.Characters.FirstPerson
             //here, the in-editor axisAlignedBoundingBox metadata for drone objects seems to be offset by some number of updates.
             //it's unclear whether this is only an in-editor debug draw issue, or the actual metadata for the axis
             //aligned box is messed up, but yeah.
+
+            if (this.agentState == AgentState.PendingFixedUpdate) {
+                this.agentState = AgentState.ActionComplete;
+            }
             if (hasFixedUpdateHappened)
             {   
                 Time.timeScale = 0;
@@ -560,5 +574,6 @@ namespace UnityStandardAssets.Characters.FirstPerson
         {
             Instantiate(DroneObjectLauncher, position, Quaternion.identity);
         }
+
     }
 }

--- a/unity/Assets/Scripts/FifoServer.cs
+++ b/unity/Assets/Scripts/FifoServer.cs
@@ -119,6 +119,7 @@ namespace FifoServer {
         ClassesImage = 0x08,
         IDsImage = 0x09,
         ThirdPartyCameraImage = 0x0a,
+        MetadataPatch = 0x0b,
         EndOfMessage = 0xff
     }
 

--- a/unity/Assets/Scripts/ObjectHighlightController.cs
+++ b/unity/Assets/Scripts/ObjectHighlightController.cs
@@ -112,7 +112,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             // Interact action for mouse left-click when nothing is picked up
             if (Input.GetKeyDown(KeyCode.Mouse0))
             {
-                if (this.PhysicsController.WhatAmIHolding() == null && this.PhysicsController.actionComplete)
+                if (this.PhysicsController.WhatAmIHolding() == null && this.PhysicsController.ReadyForCommand)
                 {
                     var closestObj = this.highlightedObject;
                     if (closestObj != null)
@@ -143,13 +143,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         }
                     }
                 }
-                else if (this.PhysicsController.actionComplete)
+                else if (this.PhysicsController.ReadyForCommand)
                 {
                     this.mouseDownThrow = true;
                     this.timerAtPress = Time.time;
                 }
 
-                if (highlightWhileHolding && this.highlightedObject != null && this.PhysicsController.WhatAmIHolding() != this.highlightedObject.gameObject && this.PhysicsController.actionComplete) {
+                if (highlightWhileHolding && this.highlightedObject != null && this.PhysicsController.WhatAmIHolding() != this.highlightedObject.gameObject && this.PhysicsController.ReadyForCommand) {
                      var closestObj = this.highlightedObject;
                     if (closestObj != null)
                     {
@@ -239,7 +239,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         var clampedForceTime = Mathf.Min(diff * diff, MaxChargeThrowSeconds);
                         var force = clampedForceTime * MaxThrowForce / MaxChargeThrowSeconds;
 
-                        if (this.PhysicsController.actionComplete && (!this.highlightWhileHolding || (highlightedObject != null && this.PhysicsController.WhatAmIHolding() == highlightedObject.gameObject)))
+                        if (this.PhysicsController.ReadyForCommand && (!this.highlightWhileHolding || (highlightedObject != null && this.PhysicsController.WhatAmIHolding() == highlightedObject.gameObject)))
                         {
                             ServerAction action;
                             if (ThrowEnabled) {

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -24,6 +24,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         //face swap stuff here
         public Material[] ScreenFaces; //0 - neutral, 1 - Happy, 2 - Mad, 3 - Angriest
         public MeshRenderer MyFaceMesh;
+        public int AdvancePhysicsStepCount;
 
         public GameObject[] TargetCircles = null;
 
@@ -149,7 +150,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             //using VisibleSimObjs(action), so be aware of that
 
             #if UNITY_EDITOR || UNITY_WEBGL
-            if (this.actionComplete) {
+            if (this.agentState == AgentState.ActionComplete) {
                 ServerAction action = new ServerAction();
                 VisibleSimObjPhysics = VisibleSimObjs(action); //GetAllVisibleSimObjPhysics(m_Camera, maxVisibleDistance);
             }
@@ -1950,7 +1951,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             //pass in the timeStep to advance the physics simulation
             Physics.Simulate(action.timeStep);
-            agentManager.AdvancePhysicsStepCount++;
+            this.AdvancePhysicsStepCount++;
             actionFinished(true);
         }
 


### PR DESCRIPTION
This PR refactors away all the readyToEmit and actionComplete flags in favor of a state machine.  The states are:

Processing -> ActionComplete -> Emit (for physics>
Processing -> PendingFIxedUpdate -> ActionComplete -> Emit (drone)

This also dose away with the droneMode flag since the drone specific code could be moved to the  drone agent class.

The primary motivation for this refactor was to support render free emits.  This means that we can emit a patched metadata to the python side without actually have to run the entire render loop.  This allows us to make calls to the Unity side at a rate of 6000 - 8000 requests/s.  I only modified one action to use this so far, but we should be able to move anything that doesn't modify the scene and is just querying the environment to use this.