### PR TITLE
Adding agent capsule to be included in Arm Collision

### DIFF
--- a/unity/Assets/Scripts/IK_Robot_Arm_Controller.cs
+++ b/unity/Assets/Scripts/IK_Robot_Arm_Controller.cs
@@ -34,6 +34,8 @@ public class IK_Robot_Arm_Controller : MonoBehaviour
     private CapsuleCollider[] ArmCapsuleColliders;
     [SerializeField]
     private BoxCollider[] ArmBoxColliders;
+    [SerializeField]
+    private CapsuleCollider[] agentCapsuleCollider;
 
     private float originToShoulderLength = 0f;
 
@@ -95,8 +97,14 @@ public class IK_Robot_Arm_Controller : MonoBehaviour
     public HashSet<Collider> currentArmCollisions() {
         HashSet<Collider> colliders = new HashSet<Collider>();
 
+        //add the AgentCapsule to the ArmCapsuleColliders for the capsule collider check
+        List<CapsuleCollider> capsules = new List<CapsuleCollider>();
+        capsules.AddRange(ArmCapsuleColliders);
+        capsules.AddRange(agentCapsuleCollider);
+
+
         //create overlap box/capsule for each collider and check the result I guess
-        foreach (CapsuleCollider c in ArmCapsuleColliders)
+        foreach (CapsuleCollider c in capsules)
         {
             Vector3 center = c.transform.TransformPoint(c.center);
             float radius = c.radius;

--- a/unity/Assets/Standard Assets/Characters/FirstPersonCharacter/Prefabs/FPSController.prefab
+++ b/unity/Assets/Standard Assets/Characters/FirstPersonCharacter/Prefabs/FPSController.prefab
@@ -4549,6 +4549,16 @@ PrefabInstance:
       propertyPath: m_LocalPosition.x
       value: -0.00009362633
       objectReference: {fileID: 0}
+    - target: {fileID: 7403840772400382841, guid: 6d6864c30f4f772439f94c8f5aff1ac7,
+        type: 3}
+      propertyPath: agentCapsuleCollider.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7403840772400382841, guid: 6d6864c30f4f772439f94c8f5aff1ac7,
+        type: 3}
+      propertyPath: agentCapsuleCollider.Array.data[0]
+      value: 
+      objectReference: {fileID: 136752831871764314}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6d6864c30f4f772439f94c8f5aff1ac7, type: 3}
 --- !u!1 &6541060884949338445 stripped


### PR DESCRIPTION
Simple workaround to add back agent's capsule into collision test, necessary for continuous move.