### PR TITLE
integrate new ManipulateArm() command from IKSolver into continuous m…

### DIFF
--- a/unity/Assets/RobotArmTest/FK_IK_Solver.cs
+++ b/unity/Assets/RobotArmTest/FK_IK_Solver.cs
@@ -15,7 +15,8 @@ public class FK_IK_Solver : MonoBehaviour
     float p1x, p1y, p1z, p2x, p2y, p2z, p3x, p3y, p3z, overlapA, overlapB, overlapC, overlapD, overlapParameter, overlapRadius;
     Vector3 overlapCenter, hintProjection, elbowPosition;
 
-    void Start()
+    // this must be Awake vs Start since when the Arm is activated, Start() will not have been called
+    void Awake()
     {
         bone1Length = (armShoulder.position - armRoot.position).magnitude;
         bone2Length = (armElbow.position - armShoulder.position).magnitude;

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1360,7 +1360,6 @@ public class ServerAction
 	public bool makeAgentsVisible = true;
 	public float timeScale = 1.0f;
 	public float? fixedDeltaTime;
-    public bool waitForFixedUpdate = true;
 	public int targetFrameRate;
     public float dronePositionRandomNoiseSigma = 0.00f;
 	public string objectType;

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -582,6 +582,12 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 if (whichMode == "arm") {
                     IKArm.SetActive(true);
                     Arm = this.GetComponentInChildren<IK_Robot_Arm_Controller>();
+                    var armTarget = Arm.transform.Find("robot_arm_FK_IK_rig").Find("IK_rig").Find("IK_pos_rot_manipulator");
+                    Vector3 pos = armTarget.transform.localPosition;
+                    pos.z = 0.4f; // pulls the arm in from being fully extended
+                    armTarget.transform.localPosition = pos;
+                    var ikSolver = this.GetComponentInChildren<FK_IK_Solver>();
+                    ikSolver.ManipulateArm();
                 }
             }
 

--- a/unity/Assets/Scripts/ContinuousMovement.cs
+++ b/unity/Assets/Scripts/ContinuousMovement.cs
@@ -29,7 +29,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         Quaternion targetRotation,
         float fixedDeltaTime,
         float radiansPerSecond,
-        bool waitForFixedUpdate,
         bool returnToStartPropIfFailed = false
     ) {
         var degreesPerSecond = radiansPerSecond * 180.0f / Mathf.PI;
@@ -42,19 +41,14 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             (t) => t.rotation,
             //  Set
             (t, target) => t.rotation = target,
-            // AddTo
-            (t, target) => t.rotation = Quaternion.RotateTowards(t.rotation, target, fixedDeltaTime * degreesPerSecond),
-            // Resets/Rollbacks if collides
-            (initialRotation, lastRotation, target) => 
-                returnToStartPropIfFailed? 
-                    initialRotation : 
-                    Quaternion.RotateTowards(lastRotation, target, -fixedDeltaTime * degreesPerSecond),
+            // Next
+            (t, target) => Quaternion.RotateTowards(t.rotation, target, fixedDeltaTime * degreesPerSecond),
             // Direction function for quaternion should just output target quaternion, since RotateTowards is used for addToProp
             (target, current) => target,
             // Distance Metric
             (target, current) => Quaternion.Angle(current, target),
-            waitForFixedUpdate,
-            fixedDeltaTime
+            fixedDeltaTime,
+            returnToStartPropIfFailed
         );
     }
 
@@ -65,34 +59,29 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         Vector3 targetPosition,
         float fixedDeltaTime,
         float unitsPerSecond,
-        bool waitForFixedUpdate,
         bool returnToStartPropIfFailed = false,
         bool localPosition = false
     ) {
-        Func<Func<Transform, Vector3>, Action<Transform, Vector3>, Action<Transform, Vector3>,IEnumerator> moveClosure = 
-            (get, set, add) => updateTransformPropertyFixedUpdate(
+        Func<Func<Transform, Vector3>, Action<Transform, Vector3>, Func<Transform, Vector3, Vector3>,IEnumerator> moveClosure = 
+            (get, set, next) => updateTransformPropertyFixedUpdate(
                 controller,
                 collisionListener,
                 moveTransform,
                 targetPosition,
                 get,
                 set,
-                add,
-                (initialPosition, lastPosition, direction) => 
-                    returnToStartPropIfFailed? 
-                        initialPosition : 
-                        lastPosition - (direction * unitsPerSecond * fixedDeltaTime),
+                next,
                 (target, current) => (target - current).normalized,
                 (target, current) => Vector3.SqrMagnitude(target - current),
-                waitForFixedUpdate,
-                fixedDeltaTime
+                fixedDeltaTime,
+                returnToStartPropIfFailed
         );
 
         if (localPosition) {
             return moveClosure(
                 (t) => t.localPosition,
                 (t, pos) => t.localPosition = pos,
-                (t, direction) => t.localPosition += direction * unitsPerSecond * fixedDeltaTime
+                (t, direction) => t.localPosition + direction * unitsPerSecond * fixedDeltaTime
             );
         }
         else {
@@ -100,7 +89,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             return moveClosure(
                 (t) => t.position,
                 (t, pos) => t.position = pos,
-                (t, direction) => t.position += direction * unitsPerSecond * fixedDeltaTime
+                (t, direction) => t.position + direction * unitsPerSecond * fixedDeltaTime
             );
         }
     }
@@ -112,21 +101,20 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         T target,
         Func<Transform, T> getProp,
         Action<Transform, T> setProp,
-        Action<Transform, T> addToProp,
-        Func<T, T, T, T> resetProperty,
+        Func<Transform, T, T> nextProp,
         // We could remove this one, but it is a speedup to not compute direction for position update calls at every addToProp call and just outside while
         Func<T, T, T> getDirection,
         Func<T, T, float> distanceMetric,
-        bool waitForFixedUpdate,
         float fixedDeltaTime,
+        bool returnToStartPropIfFailed,
         double epsilon = 1e-3
     )
     {
         T originalProperty = getProp(moveTransform);
         var previousProperty = originalProperty;
 
-        YieldInstruction yieldInstruction = waitForFixedUpdate ? (YieldInstruction)new WaitForFixedUpdate() : (YieldInstruction)new WaitForEndOfFrame();
         var arm = controller.GetComponentInChildren<IK_Robot_Arm_Controller>();
+        var ikSolver = arm.gameObject.GetComponentInChildren<FK_IK_Solver>();
 
         // commenting out the WaitForEndOfFrame here since we shoudn't need 
         // this as we already wait for a frame to pass when we execute each action
@@ -134,36 +122,48 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
         var currentProperty = getProp(moveTransform);
         float currentDistance = distanceMetric(target, currentProperty);
-        float startingDistance = currentDistance;
 
         T directionToTarget = getDirection(target, currentProperty);
 
         var currentColliders = arm.currentArmCollisions();
 
-        while ( currentDistance > epsilon && CollisionListener.StaticCollisions(currentColliders).Count == 0 && currentDistance <= startingDistance) {
+        while ( currentDistance > epsilon && CollisionListener.StaticCollisions(currentColliders).Count == 0) {
 
             previousProperty = getProp(moveTransform);
 
-            addToProp(moveTransform, directionToTarget);
+            T next = nextProp(moveTransform, directionToTarget);
+            float nextDistance = distanceMetric(target, next);
+
+            // allows for snapping behaviour to target when the target is close
+            if (nextDistance <= epsilon ||
+
+                // if nextDistance is too large then it will overshoot, in this case we snap to the target
+                // this can happen if the speed it set high
+                nextDistance > distanceMetric(target, getProp(moveTransform))) 
+            {
+                setProp(moveTransform, target);
+            } else {
+                setProp(moveTransform, next);
+            }
+
+            // this will be a NOOP for Rotate/Move/Height actions
+            ikSolver.ManipulateArm();
 
             if (!Physics.autoSimulation) {
                 Physics.Simulate(fixedDeltaTime);
             }
 
-            yield return yieldInstruction;
+            yield return new WaitForEndOfFrame();
 
             currentColliders = arm.currentArmCollisions();
-
 
             currentDistance = distanceMetric(target, getProp(moveTransform));
         }
 
-        // // DISABLING JUMP since it can lead to clipping
-        // if (currentDistance <= epsilon && !collisionListener.ShouldHalt()) {
-        //    // Maybe switch to this?
-        //    // addPosition(moveTransform, targetDirection * currentDistance);
-        //    setProp(moveTransform, target);
-        // }
+        T resetProp = previousProperty;
+        if (returnToStartPropIfFailed) {
+            resetProp = originalProperty;
+        }
 
         continuousMoveFinish(
             controller,
@@ -171,8 +171,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             moveTransform, 
             setProp, 
             target, 
-            resetProperty(originalProperty, previousProperty, directionToTarget), 
-            currentDistance > startingDistance
+            resetProp
         );
     }
 
@@ -182,9 +181,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         Transform moveTransform,
         System.Action<Transform, T> setProp,
         T target,
-        T resetProp,
-        bool overshoot = false
-       
+        T resetProp
     ) {
         var actionSuccess = true;
         var debugMessage = "";
@@ -214,16 +211,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 }
 
                 actionSuccess = false;
-        } else if (overshoot) {
-            Debug.Log("stopping - target was overshot");
-            debugMessage =  $" Has overshot the target ${typeof(T).ToString()}";
-            actionSuccess = false;
         }
         controller.actionFinished(actionSuccess, debugMessage);
     }
 
-        
-
     }
-
 }

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -2998,7 +2998,6 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         action.action = "MoveMidLevelArm";
                         action.speed = 1.0f;
                         action.disableRendering = false;
-                        action.waitForFixedUpdate = false;
                         //action.returnToStart = true;
                         if (splitcommand.Length > 4)
                         {
@@ -3084,7 +3083,6 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         ServerAction action = new ServerAction();
                         action.action = "MoveMidLevelArmHeight";
                         action.disableRendering = false;
-                        action.waitForFixedUpdate = false;
 
                         if(splitcommand.Length > 1)
                         {

--- a/unity/Assets/Scripts/IK_Robot_Arm_Controller.cs
+++ b/unity/Assets/Scripts/IK_Robot_Arm_Controller.cs
@@ -200,7 +200,6 @@ public class IK_Robot_Arm_Controller : MonoBehaviour
         PhysicsRemoteFPSAgentController controller,
         Vector3 target, 
         float unitsPerSecond,
-        bool waitForFixedUpdate,
         float fixedDeltaTime = 0.02f,
         bool returnToStartPositionIfFailed = false, 
         string whichSpace = "arm", 
@@ -262,7 +261,6 @@ public class IK_Robot_Arm_Controller : MonoBehaviour
                 targetWorldPos,
                 disableRendering ? fixedDeltaTime : Time.fixedDeltaTime,
                 unitsPerSecond,
-                waitForFixedUpdate,
                 returnToStartPositionIfFailed,
                 false
         );
@@ -284,7 +282,6 @@ public class IK_Robot_Arm_Controller : MonoBehaviour
         PhysicsRemoteFPSAgentController controller, 
         float height, 
         float unitsPerSecond, 
-        bool waitForFixedUpdate,
         float fixedDeltaTime = 0.02f, 
         bool returnToStartPositionIfFailed = false,
         bool disableRendering = false) {
@@ -312,7 +309,6 @@ public class IK_Robot_Arm_Controller : MonoBehaviour
                 target,
                 disableRendering ? fixedDeltaTime : Time.fixedDeltaTime,
                 unitsPerSecond,
-                waitForFixedUpdate,
                 returnToStartPositionIfFailed,
                 true
         );
@@ -336,7 +332,6 @@ public class IK_Robot_Arm_Controller : MonoBehaviour
         float degreesPerSecond, 
         bool disableRendering = false, 
         float fixedDeltaTime = 0.02f, 
-        bool waitForFixedUpdate = false,
         bool returnToStartPositionIfFailed = false
     )
     {
@@ -348,7 +343,6 @@ public class IK_Robot_Arm_Controller : MonoBehaviour
             armTarget.transform.rotation * targetQuat,
             disableRendering ? fixedDeltaTime : Time.fixedDeltaTime,
             degreesPerSecond,
-            waitForFixedUpdate,
             returnToStartPositionIfFailed
         );
 

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -9168,7 +9168,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     this,
                     action.position, 
                     action.speed, 
-                    action.waitForFixedUpdate,
                     action.fixedDeltaTime.GetValueOrDefault(Time.fixedDeltaTime), 
                     action.returnToStart, 
                     action.coordinateSpace, 
@@ -9210,7 +9209,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     this, 
                     action.y, 
                     action.speed, 
-                    action.waitForFixedUpdate,
                     action.fixedDeltaTime.GetValueOrDefault(Time.fixedDeltaTime), 
                     action.returnToStart, 
                     action.disableRendering
@@ -9253,7 +9251,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 }
 
                 //arm.SetStopMotionOnContact(action.stopArmMovementOnContact);
-                arm.rotateHand(this, target, action.speed, action.disableRendering, action.fixedDeltaTime.GetValueOrDefault(Time.fixedDeltaTime), action.waitForFixedUpdate, action.returnToStart);
+                arm.rotateHand(this, target, action.speed, action.disableRendering, action.fixedDeltaTime.GetValueOrDefault(Time.fixedDeltaTime), action.returnToStart);
             }
             else {
                 actionFinished(false, "Agent does not have kinematic arm or is not enabled. Make sure there is a '" + typeof(IK_Robot_Arm_Controller).Name + "' component as a child of this agent.");
@@ -9381,7 +9379,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     this.transform.rotation * Quaternion.Euler(0.0f, degrees, 0.0f),
                     disableRendering ? fixedDeltaTime : Time.fixedDeltaTime,
                     speed,
-                    waitForFixedUpdate,
                     returnToStart
             );
 


### PR DESCRIPTION

This changes the following:

* restores the snapping to target
* removes waitForFixedUpdate param
* integrates Eli's solver into ContinuousMovement
* Removes the resetProperty Func in favor of using setProperty() - this works now that we detect collisions immediately after impact
* Prevent overshooting by calculating the nextProp value and snapping to the target if it is closer than the nextProp.