### PR TITLE
Physics Determinism Test

### DIFF
--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -392,7 +392,7 @@ class Controller(object):
             local_build = True
 
         self.last_event = None
-        self.current_scene_name = None
+        self.scene = None
         self._scenes_in_build = None
         self.killing_unity = False
         self.quality = quality
@@ -504,10 +504,10 @@ class Controller(object):
 
         return self._scenes_in_build
 
-    def reset(self, scene=''):
+    def reset(self, scene=None):
         # Case for just resetting the current scene
-        if scene == '' and self.current_scene_name is not None:
-            scene = self.current_scene_name
+        if scene is None and self.scene is not None:
+            scene = self.scene
 
         if re.match(r'^FloorPlan[0-9]+$', scene):
             scene = scene + "_physics"
@@ -530,7 +530,7 @@ class Controller(object):
         
         self.last_event = self.step(action='Initialize', **self.initialization_parameters)
 
-        self.current_scene_name = scene
+        self.scene = scene
 
         return self.last_event
 

--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -392,6 +392,7 @@ class Controller(object):
             local_build = True
 
         self.last_event = None
+        self.current_scene_name = None
         self._scenes_in_build = None
         self.killing_unity = False
         self.quality = quality
@@ -503,7 +504,11 @@ class Controller(object):
 
         return self._scenes_in_build
 
-    def reset(self, scene='FloorPlan_Train1_1'):
+    def reset(self, scene=''):
+        # Case for just resetting the current scene
+        if scene == '' and self.current_scene_name is not None:
+            scene = self.current_scene_name
+
         if re.match(r'^FloorPlan[0-9]+$', scene):
             scene = scene + "_physics"
 
@@ -524,6 +529,8 @@ class Controller(object):
         self.last_event = self.server.receive()
         
         self.last_event = self.step(action='Initialize', **self.initialization_parameters)
+
+        self.current_scene_name = scene
 
         return self.last_event
 

--- a/ai2thor/util/metrics.py
+++ b/ai2thor/util/metrics.py
@@ -2,7 +2,6 @@ from pprint import pprint
 import json
 import math
 import copy
-import numpy as np
 
 
 def vector_distance(v0, v1):

--- a/ai2thor/util/metrics.py
+++ b/ai2thor/util/metrics.py
@@ -2,6 +2,7 @@ from pprint import pprint
 import json
 import math
 import copy
+import numpy as np
 
 
 def vector_distance(v0, v1):

--- a/ai2thor/util/trials.py
+++ b/ai2thor/util/trials.py
@@ -1,0 +1,65 @@
+import numpy as np
+import math
+
+
+class TrialMetric(object):
+    def init_trials(self, num_trials, metadata):
+        ...
+
+    def update_with_trial(self, trial_index, metadata):
+        ...
+
+
+class ObjectPositionVarianceAverage(TrialMetric):
+    """
+    Metric that computes the average of the variance of all objects in a scene across multiple runs.
+    """
+    def __init__(self):
+        self.trials = []
+        self.object_ids = []
+
+    def init_trials(self, num_trials, metadata):
+        objects = metadata["objects"]
+        self.object_ids = sorted([o['objectId'] for o in objects])
+        num_objects = len(self.object_ids)
+        self.trials = np.empty([num_trials, num_objects, 3])
+
+    def update_with_trial(self, trial_index, metadata):
+        objects = metadata["objects"]
+        object_pos_map = {o['objectId']: vec_to_np_array(o['position']) for o in objects}
+        for object_index in range(len(self.object_ids)):
+            object_id = self.object_ids[object_index]
+            self.trials[trial_index][object_index] = object_pos_map[object_id]
+
+    def compute(self, n=None):
+        return np.mean(np.var(self.trials[:n], axis=0))
+
+
+def vec_to_np_array(vec):
+    return np.array([vec['x'], vec['y'], vec['z']])
+
+
+def trial_runner(controller, number, metric, compute_running_metric=False):
+    """
+    Generator that wraps metric capture from controller metadata for a number of trials
+    :param controller: ai2thor controller
+    :param number: int number of trials to collect metrics from
+    :param metric: TrialMetric the metric to use
+    :param compute_running_metric: bool whether or not to compute the metric after every trial
+    :return: tuple(controller, float) with the controller and the metric after every trial
+    """
+
+    metric.init_trials(number, controller.last_event.metadata)
+
+    for trial_index in range(number):
+        try:
+            yield controller, metric.compute(n=trial_index) if compute_running_metric else math.nan
+            metric.update_with_trial(trial_index, controller.last_event.metadata)
+            controller.reset()
+        except RuntimeError as e:
+            print(
+                e,
+                "Last action status: {}".format(controller.last_event.meatadata['actionSuccess']),
+                controller.last_event.meatadata['errorMessage']
+            )
+    yield controller, metric.compute()

--- a/tasks.py
+++ b/tasks.py
@@ -2853,24 +2853,25 @@ def reachable_pos(ctx, scene, editor_mode=False, local_build=False):
     print("After teleport: {}".format(evt.metadata['agent']['position']))
 
 @task
-def test_trial_runner(ctx):
+def get_physics_determinism(ctx, scene="FloorPlan1_physics", agent_mode="arm"):
     import ai2thor.controller
-    SCENE_NAME = "FloorPlan1_physics"
+    import random
     num_trials = 10
-
     width = 300
     height = 300
     fov = 100
 
-    def act(controller):
-        controller.step(action='MoveAhead')
+    def act(controller, actions, n):
+        for i in range(n):
+            action = random.choice(actions)
+            controller.step(dict(action=action))
 
     controller = ai2thor.controller.Controller(
         local_executable_path=None,
-        scene=SCENE_NAME, gridSize=0.25,
+        scene=scene, gridSize=0.25,
         width=width,
         height=height,
-        agentMode='arm',
+        agentMode=agent_mode,
         fieldOfView=fov,
         agentControllerType='mid-level',
         server_class=ai2thor.fifo_server.FifoServer,
@@ -2879,7 +2880,20 @@ def test_trial_runner(ctx):
 
     from ai2thor.util.trials import trial_runner, ObjectPositionVarianceAverage
 
-    for controller, metric in trial_runner(controller, num_trials, ObjectPositionVarianceAverage()):
-        print("running metric: {}".format(metric))
-        controller.step(action='MoveAhead')
-    print(" final {} ".format(metric))
+    move_actions = ["MoveAhead", "MoveBack", "MoveLeft", "MoveRight"]
+    rotate_actions = ["RotateRight", "RotateLeft"]
+    look_actions = ["LookUp", "LookDown"]
+    all_actions = move_actions + rotate_actions + look_actions
+
+    sample_number = 100
+    action_tuples = [
+        ("move", move_actions, sample_number),
+        ("rotate", rotate_actions, sample_number),
+        ("look", look_actions, sample_number),
+        ("all", all_actions, sample_number),
+    ]
+
+    for action_name, actions, n in action_tuples:
+        for controller, metric in trial_runner(controller, num_trials, ObjectPositionVarianceAverage()):
+            act(controller, actions, n)
+        print(" actions: '{}', object_position_variance_average: {} ".format(action_name, metric))

--- a/tasks.py
+++ b/tasks.py
@@ -2853,10 +2853,10 @@ def reachable_pos(ctx, scene, editor_mode=False, local_build=False):
     print("After teleport: {}".format(evt.metadata['agent']['position']))
 
 @task
-def get_physics_determinism(ctx, scene="FloorPlan1_physics", agent_mode="arm"):
+def get_physics_determinism(ctx, scene="FloorPlan1_physics", agent_mode="arm", n=100, samples=100):
     import ai2thor.controller
     import random
-    num_trials = 10
+    num_trials = n
     width = 300
     height = 300
     fov = 100
@@ -2885,7 +2885,7 @@ def get_physics_determinism(ctx, scene="FloorPlan1_physics", agent_mode="arm"):
     look_actions = ["LookUp", "LookDown"]
     all_actions = move_actions + rotate_actions + look_actions
 
-    sample_number = 100
+    sample_number = samples
     action_tuples = [
         ("move", move_actions, sample_number),
         ("rotate", rotate_actions, sample_number),

--- a/tasks.py
+++ b/tasks.py
@@ -2839,8 +2839,6 @@ def reachable_pos(ctx, scene, editor_mode=False, local_build=False):
 
     print(evt.metadata["actionReturn"])
 
-
-
     evt = controller.step(
         dict(
             action="TeleportFull",
@@ -2855,14 +2853,8 @@ def reachable_pos(ctx, scene, editor_mode=False, local_build=False):
     print("After teleport: {}".format(evt.metadata['agent']['position']))
 
 @task
-def test_det(ctx):
-    import ai2thor.util.metrics as metrics
+def test_trial_runner(ctx):
     import ai2thor.controller
-    import numpy as np
-    import math
-    from pprint import pprint
-    BASE_DIR = "unity/builds"
-    BASE_ADR = "{}/thor-local-OSXIntel64.app/Contents/MacOS/AI2-Thor".format(BASE_DIR)
     SCENE_NAME = "FloorPlan1_physics"
     num_trials = 10
 
@@ -2872,9 +2864,6 @@ def test_det(ctx):
 
     def act(controller):
         controller.step(action='MoveAhead')
-
-    def vec_to_np_array(vec):
-        return np.array([vec['x'], vec['y'], vec['z']])
 
     controller = ai2thor.controller.Controller(
         local_executable_path=None,
@@ -2888,93 +2877,9 @@ def test_det(ctx):
         visibilityScheme='Distance'
     )
 
-    # class ObjectPositionVarianceAverage(object):
-    #     def __init__(self):
-    #         print("init")
-    #         self.trials = []
-    #         self.object_ids = []
-    #
-    #     def init_trials(self, num_trials, metadata):
-    #         objects = metadata["objects"]
-    #         self.object_ids = sorted([o['objectId'] for o in objects])
-    #         num_objects = len(object_ids)
-    #         self.trials = np.empty([num_trials, num_objects, 3])
-    #
-    #     def update_trial(self, trial_index, metadata):
-    #         objects = metadata["objects"]
-    #         object_pos_map = {o['objectId']: vec_to_np_array(o['position']) for o in objects}
-    #         for object_index in range(len(object_ids)):
-    #             object_id = self.object_ids[object_index]
-    #             self.trials[trial_index][object_index] = object_pos_map[object_id]
-    #
-    #     def compute(self, n=None):
-    #         return np.mean(np.var(trials[:n], axis=0))
-    #
-    #
-    # def run_trials(controller, number, metric, compute_running_metric=False):
-    #
-    #     # objects = controller.last_event.metadata["objects"]
-    #     # object_ids = sorted([o['objectId'] for o in objects])
-    #     #
-    #     # num_objects = len(object_ids)
-    #     #
-    #     # trials = np.empty([num_trials, num_objects, 3])
-    #
-    #     metric.init_trials(number, controller.last_event.metadata)
-    #
-    #     for trial_index in range(number):
-    #         try:
-    #             print('before')
-    #             yield controller, metric.compute(n=trial_index) if compute_running_metric else math.nan
-    #
-    #             metric.update_with_trial(trial_index, controller.last_event.metadata)
-    #
-    #             # objects = controller.last_event.metadata['objects']
-    #             # object_pos_map = {o['objectId']: vec_to_np_array(o['position']) for o in objects}
-    #             #
-    #             # for object_index in range(len(object_ids)):
-    #             #     object_id = object_ids[object_index]
-    #             #     trials[trial_index][object_index] = object_pos_map[object_id]
-    #
-    #             controller.reset()
-    #             print('after')
-    #         except RuntimeError as e:
-    #             print(e)
-    #
-    #     yield controller, metric.compute()
-    #     print("end")
-
-
-    objects = controller.last_event.metadata["objects"]
-
-    object_pos_map = {o['objectId']: o['position'] for o in objects }
-    object_ids = sorted(object_pos_map.keys())
-
-    num_objects = len(object_ids)
-
-    trials = np.empty([num_trials, num_objects, 3])
-
-    for trial_index in range(num_trials):
-        act(controller)
-        objects = controller.last_event.metadata['objects']
-        object_pos_map = {o['objectId']: vec_to_np_array(o['position']) for o in objects}
-
-        for object_index in range(len(object_ids)):
-            object_id = object_ids[object_index]
-            trials[trial_index][object_index] = object_pos_map[object_id]
-
-        controller.reset(scene=SCENE_NAME)
-
-
-    # var = np.var(trials, axis=0);
-    # print("mean {} var {} mmena {}".format(np.mean(trials, axis=0), var, np.mean(var)))
-    # trials = np.empty([num_trials, num_objects, 3])
-    variance = np.mean(np.var(trials, axis=0))
-    print(variance)
-
     from ai2thor.util.trials import trial_runner, ObjectPositionVarianceAverage
 
-    for controller, metric in trial_runner(controller, 10, ObjectPositionVarianceAverage()):
+    for controller, metric in trial_runner(controller, num_trials, ObjectPositionVarianceAverage()):
         print("running metric: {}".format(metric))
         controller.step(action='MoveAhead')
     print(" final {} ".format(metric))


### PR DESCRIPTION
* Adds trial runner as a generic sequence generator that gathers a metric after running controller code
* Adds a object position variance average metric used for physics determinism
* Task for testing determinism of basic actions

Results for 120 trials on a 100 random actions of each category:
```
inv get-physics-determinism -s=FloorPlan212_physics -n=120 --samples=samples

actions: 'move', object_position_variance_average: 1.0702238729969497e-11 
actions: 'rotate', object_position_variance_average: 3.6856343950937414e-12 
actions: 'look', object_position_variance_average: 4.872177661890314e-12 
actions: 'all', object_position_variance_average: 0.00029112702368825385 