### PR TITLE
Improvements to `PlaceObjectAtPoint`, `TeleportObject`, and `InitialRandomSpawn`.

### DIFF
--- a/unity/Assets/Scripts/ActionDispatcher.cs
+++ b/unity/Assets/Scripts/ActionDispatcher.cs
@@ -212,7 +212,7 @@ public static class ActionDispatcher {
         }  else {
             for(int i = 0; i < methodParams.Length; i++) {
                 System.Reflection.ParameterInfo pi = methodParams[i];
-                // allows for passing in a ServerAtion as a dynamic to ProcessControlCommand
+                // allows for passing in a ServerAction as a dynamic to ProcessControlCommand
                 if (serverCommand.GetType() == pi.ParameterType){
                     arguments[i] = serverCommand;
                 } else if (serverCommand.ContainsKey(pi.Name)) {

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1271,7 +1271,7 @@ public class ServerAction
 	public string receptacleObjectId;
 	public float gridSize;
 	public string[] excludeObjectIds;
-        public string [] objectIds;
+    public string [] objectIds;
 	public string objectId;
 	public int agentId;
 	public int thirdPartyCameraId;

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1547,26 +1547,6 @@ namespace UnityStandardAssets.Characters.FirstPerson
             actionFinished(true);
         }
 
-        public void SimulatePhysicsForSeconds(float seconds, float deltaTime = 0.01f) {
-            if (seconds < 0.0f || deltaTime <= 0.0f) {
-                errorMessage = $"Seconds must be non-negative ({seconds}) and deltaTime must be positive ({deltaTime}).";
-                actionFinished(false);
-                return;
-            }
-            bool oldPhysicsAutoSim = Physics.autoSimulation;
-
-            Physics.autoSimulation = false;
-            while (seconds > 0.0f) {
-                float timeStep = Math.Min(deltaTime, seconds);
-                Physics.Simulate(timeStep);
-                seconds -= timeStep;
-            }
-
-            Physics.autoSimulation = oldPhysicsAutoSim;
-
-            actionFinished(true);
-        }
-
 		// Handle collisions - CharacterControllers don't apply physics innately, see "PushMode" check below
         // XXX: this will be used for truly continuous movement over time, for now this is unused
 		protected void OnControllerColliderHit(ControllerColliderHit hit)
@@ -1804,7 +1784,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             }
             TeleportFull(action);
         }
-        
+
         protected T[] flatten2DimArray<T>(T[, ] array) {
             int nrow = array.GetLength(0);
             int ncol = array.GetLength(1);
@@ -1852,20 +1832,20 @@ namespace UnityStandardAssets.Characters.FirstPerson
         }
 
         //*** Maybe make this better */
-        // This function should be called before and after doing a visibility check (before with 
+        // This function should be called before and after doing a visibility check (before with
         // enableColliders == false and after with it equaling true). It, in particular, will
         // turn off/on all the colliders on agents which should not block visibility for the current agent
-        // (invisible agents for example). 
-        protected void updateAllAgentCollidersForVisibilityCheck(bool enableColliders) 
+        // (invisible agents for example).
+        protected void updateAllAgentCollidersForVisibilityCheck(bool enableColliders)
         {
-            foreach (BaseFPSAgentController agent in this.agentManager.agents) 
+            foreach (BaseFPSAgentController agent in this.agentManager.agents)
             {
                 bool overlapping = (transform.position - agent.transform.position).magnitude < 0.001f;
-                if (overlapping || agent == this || !agent.IsVisible) 
+                if (overlapping || agent == this || !agent.IsVisible)
                 {
-                    foreach (Collider c in agent.GetComponentsInChildren<Collider>()) 
+                    foreach (Collider c in agent.GetComponentsInChildren<Collider>())
                     {
-                        if (ItemInHand == null || !hasAncestor(c.transform.gameObject, ItemInHand)) 
+                        if (ItemInHand == null || !hasAncestor(c.transform.gameObject, ItemInHand))
                         {
                             c.enabled = enableColliders;
                         }
@@ -1919,12 +1899,12 @@ namespace UnityStandardAssets.Characters.FirstPerson
         private bool isSimObjVisible(Camera agentCamera, SimObjPhysics sop, float maxDistance, Plane[] planes) {
             bool visible = false;
             //check against all visibility points, accumulate count. If at least one point is visible, set object to visible
-            if (sop.VisibilityPoints != null && sop.VisibilityPoints.Length > 0) 
+            if (sop.VisibilityPoints != null && sop.VisibilityPoints.Length > 0)
             {
                 Transform[] visPoints = sop.VisibilityPoints;
                 int visPointCount = 0;
 
-                foreach (Transform point in visPoints) 
+                foreach (Transform point in visPoints)
                 {
                     bool outsidePlane = false;
                     for(int i = 0; i < planes.Length; i++){
@@ -1932,7 +1912,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                             outsidePlane = true;
                             break;
                         }
-                    } 
+                    }
 
                     if (outsidePlane) {
                         continue;
@@ -1940,13 +1920,13 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
 
                     float xdelta = Math.Abs(this.transform.position.x - point.position.x);
-                    if (xdelta > maxDistance) 
+                    if (xdelta > maxDistance)
                     {
                         continue;
                     }
 
                     float zdelta = Math.Abs(this.transform.position.z - point.position.z);
-                    if (zdelta > maxDistance) 
+                    if (zdelta > maxDistance)
                     {
                         continue;
                     }
@@ -1958,14 +1938,14 @@ namespace UnityStandardAssets.Characters.FirstPerson
                     }
 
                     double distance = Math.Sqrt((xdelta * xdelta) + (zdelta * zdelta));
-                    if (distance > maxDistance) 
+                    if (distance > maxDistance)
                     {
                         continue;
                     }
 
                     //if this particular point is in view...
                     if (CheckIfVisibilityPointRaycast(sop, point, agentCamera, false) ||
-                        CheckIfVisibilityPointRaycast(sop, point, agentCamera, true)) 
+                        CheckIfVisibilityPointRaycast(sop, point, agentCamera, true))
                     {
                         visPointCount++;
                         #if !UNITY_EDITOR
@@ -1977,7 +1957,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 }
 
                 //if we see at least one vis point, the object is "visible"
-                if (visPointCount > 0) 
+                if (visPointCount > 0)
                 {
                     #if UNITY_EDITOR
                     sop.isVisible = true;
@@ -1985,8 +1965,8 @@ namespace UnityStandardAssets.Characters.FirstPerson
                     visible = true;
                 }
             }
-            
-            else 
+
+            else
             {
                 Debug.Log("Error! Set at least 1 visibility point on SimObjPhysics " + sop + ".");
             }
@@ -2002,20 +1982,20 @@ namespace UnityStandardAssets.Characters.FirstPerson
         }
 
 
-        public SimObjPhysics[] VisibleSimObjs(ServerAction action) 
+        public SimObjPhysics[] VisibleSimObjs(ServerAction action)
         {
             List<SimObjPhysics> simObjs = new List<SimObjPhysics>();
 
             //go through array of sim objects visible to the camera
-            foreach (SimObjPhysics so in VisibleSimObjs(action.forceVisible)) 
+            foreach (SimObjPhysics so in VisibleSimObjs(action.forceVisible))
             {
 
-                if (!string.IsNullOrEmpty(action.objectId) && action.objectId != so.ObjectID) 
+                if (!string.IsNullOrEmpty(action.objectId) && action.objectId != so.ObjectID)
                 {
                     continue;
                 }
 
-                if (!string.IsNullOrEmpty(action.objectType) && action.GetSimObjType() != so.Type) 
+                if (!string.IsNullOrEmpty(action.objectType) && action.GetSimObjType() != so.Type)
                 {
                     continue;
                 }
@@ -2028,19 +2008,19 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
         //pass in forceVisible bool to force grab all objects of type sim obj
         //if not, gather all visible sim objects maxVisibleDistance away from camera view
-        public SimObjPhysics[] VisibleSimObjs(bool forceVisible) 
+        public SimObjPhysics[] VisibleSimObjs(bool forceVisible)
         {
-            if (forceVisible) 
+            if (forceVisible)
             {
                 return GameObject.FindObjectsOfType(typeof(SimObjPhysics)) as SimObjPhysics[];
-            } 
+            }
 
-            else 
+            else
             {
                 return GetAllVisibleSimObjPhysics(m_Camera, maxVisibleDistance);
             }
         }
-        protected SimObjPhysics[] GetAllVisibleSimObjPhysics(Camera agentCamera, float maxDistance) 
+        protected SimObjPhysics[] GetAllVisibleSimObjPhysics(Camera agentCamera, float maxDistance)
         {
             if (this.visibilityScheme == VisibilityScheme.Collider) {
                 return GetAllVisibleSimObjPhysicsCollider(agentCamera, maxDistance);
@@ -2049,12 +2029,12 @@ namespace UnityStandardAssets.Characters.FirstPerson
             }
         }
 
-        // this is a faster version of the visibility check, but is not entirely 
+        // this is a faster version of the visibility check, but is not entirely
         // consistent with the collider based method.  In particular, if an object
         // is within range of the maxVisibleDistance, but obscurred only within this
         // range and is visibile outside of the range, it will get reported as invisible
         // by the new scheme, but visible in the current scheme.
-        private SimObjPhysics[] GetAllVisibleSimObjPhysicsDistance(Camera agentCamera, float maxDistance) 
+        private SimObjPhysics[] GetAllVisibleSimObjPhysicsDistance(Camera agentCamera, float maxDistance)
         {
             List<SimObjPhysics> visible = new List<SimObjPhysics>();
             IEnumerable<SimObjPhysics> simObjs = null;
@@ -2068,7 +2048,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             Plane[] planes = GeometryUtility.CalculateFrustumPlanes(agentCamera);
             foreach(var sop in simObjs)
             {
-                if(isSimObjVisible(agentCamera, sop, this.maxVisibleDistance, planes)) 
+                if(isSimObjVisible(agentCamera, sop, this.maxVisibleDistance, planes))
                 {
                     visible.Add(sop);
                 }
@@ -2076,12 +2056,12 @@ namespace UnityStandardAssets.Characters.FirstPerson
             return visible.ToArray();
         }
 
-        private SimObjPhysics[] GetAllVisibleSimObjPhysicsCollider(Camera agentCamera, float maxDistance) 
+        private SimObjPhysics[] GetAllVisibleSimObjPhysicsCollider(Camera agentCamera, float maxDistance)
         {
             List<SimObjPhysics> currentlyVisibleItems = new List<SimObjPhysics>();
 
-            #if UNITY_EDITOR        
-            foreach (KeyValuePair<string, SimObjPhysics> pair in physicsSceneManager.ObjectIdToSimObjPhysics) 
+            #if UNITY_EDITOR
+            foreach (KeyValuePair<string, SimObjPhysics> pair in physicsSceneManager.ObjectIdToSimObjPhysics)
             {
                 // Set all objects to not be visible
                 pair.Value.isVisible = false;
@@ -2104,12 +2084,12 @@ namespace UnityStandardAssets.Characters.FirstPerson
             Vector3 point0, point1;
             float radius;
             agentCapsuleCollider.ToWorldSpaceCapsule(out point0, out point1, out radius);
-            if (point0.y <= point1.y) 
+            if (point0.y <= point1.y)
             {
                 point1.y += maxDistance;
-            } 
+            }
 
-            else 
+            else
             {
                 point0.y += maxDistance;
             }
@@ -2120,26 +2100,26 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
             Collider[] colliders_in_view = Physics.OverlapCapsule(point0, point1, maxDistance, 1 << 8, QueryTriggerInteraction.Collide);
 
-            if (colliders_in_view != null) 
+            if (colliders_in_view != null)
             {
                 HashSet<SimObjPhysics> testedSops = new HashSet<SimObjPhysics>();
-                foreach (Collider item in colliders_in_view) 
+                foreach (Collider item in colliders_in_view)
                 {
                     SimObjPhysics sop = ancestorSimObjPhysics(item.gameObject);
-                    //now we have a reference to our sim object 
+                    //now we have a reference to our sim object
                     if ((sop != null && !testedSops.Contains(sop)) && (filter == null || filter.Contains(sop)))
                     {
                         testedSops.Add(sop);
                         //check against all visibility points, accumulate count. If at least one point is visible, set object to visible
-                        if (sop.VisibilityPoints != null && sop.VisibilityPoints.Length > 0) 
+                        if (sop.VisibilityPoints != null && sop.VisibilityPoints.Length > 0)
                         {
                             Transform[] visPoints = sop.VisibilityPoints;
                             int visPointCount = 0;
 
-                            foreach (Transform point in visPoints) 
+                            foreach (Transform point in visPoints)
                             {
                                 //if this particular point is in view...
-                                if (CheckIfVisibilityPointInViewport(sop, point, agentCamera, false)) 
+                                if (CheckIfVisibilityPointInViewport(sop, point, agentCamera, false))
                                 {
                                     visPointCount++;
                                     #if !UNITY_EDITOR
@@ -2151,18 +2131,18 @@ namespace UnityStandardAssets.Characters.FirstPerson
                             }
 
                             //if we see at least one vis point, the object is "visible"
-                            if (visPointCount > 0) 
+                            if (visPointCount > 0)
                             {
                                 #if UNITY_EDITOR
                                 sop.isVisible = true;
                                 #endif
-                                if (!currentlyVisibleItems.Contains(sop)) 
+                                if (!currentlyVisibleItems.Contains(sop))
                                 {
                                     currentlyVisibleItems.Add(sop);
                                 }
                             }
                         }
-                        else 
+                        else
                         {
                             Debug.Log("Error! Set at least 1 visibility point on SimObjPhysics " + sop + ".");
                         }
@@ -2176,53 +2156,53 @@ namespace UnityStandardAssets.Characters.FirstPerson
             //receptacle trigger box. Oh boy!
             Collider[] invisible_colliders_in_view = Physics.OverlapCapsule(point0, point1, maxDistance, 1 << 9, QueryTriggerInteraction.Collide);
 
-            if (invisible_colliders_in_view != null) 
+            if (invisible_colliders_in_view != null)
             {
-                foreach (Collider item in invisible_colliders_in_view) 
+                foreach (Collider item in invisible_colliders_in_view)
                 {
-                    if (item.tag == "Receptacle") 
+                    if (item.tag == "Receptacle")
                     {
                         SimObjPhysics sop;
 
                         sop = item.GetComponentInParent<SimObjPhysics>();
 
-                        //now we have a reference to our sim object 
+                        //now we have a reference to our sim object
                         if (sop && (filter == null || filter.Contains(sop)))
                         {
                             //check against all visibility points, accumulate count. If at least one point is visible, set object to visible
-                            if (sop.VisibilityPoints.Length > 0) 
+                            if (sop.VisibilityPoints.Length > 0)
                             {
                                 Transform[] visPoints = sop.VisibilityPoints;
                                 int visPointCount = 0;
 
-                                foreach (Transform point in visPoints) 
+                                foreach (Transform point in visPoints)
                                 {
                                     //if this particular point is in view...
-                                    if (CheckIfVisibilityPointInViewport(sop, point, agentCamera, true)) 
+                                    if (CheckIfVisibilityPointInViewport(sop, point, agentCamera, true))
                                     {
                                         visPointCount++;
                                     }
                                 }
 
                                 //if we see at least one vis point, the object is "visible"
-                                if (visPointCount > 0) 
+                                if (visPointCount > 0)
                                 {
                                     #if UNITY_EDITOR
                                     sop.isVisible = true;
                                     #endif
-                                    if (!currentlyVisibleItems.Contains(sop)) 
+                                    if (!currentlyVisibleItems.Contains(sop))
                                     {
                                         currentlyVisibleItems.Add(sop);
                                     }
                                 }
-                            } 
-                            else 
+                            }
+                            else
                             {
                                 Debug.Log("Error! Set at least 1 visibility point on SimObjPhysics prefab!");
                             }
 
                         }
-                    } 
+                    }
                 }
             }
 
@@ -2259,18 +2239,18 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
             //check raycast against both visible and invisible layers, to check against ReceptacleTriggerBoxes which are normally
             //ignored by the other raycast
-            if (includeInvisible) 
+            if (includeInvisible)
             {
-                if (Physics.Raycast(agentCamera.transform.position, point.position - agentCamera.transform.position, out hit, raycastDistance, mask)) 
+                if (Physics.Raycast(agentCamera.transform.position, point.position - agentCamera.transform.position, out hit, raycastDistance, mask))
                 {
-                    if (hit.transform != sop.transform) 
+                    if (hit.transform != sop.transform)
                     {
                         result = false;
                     }
 
                     //if this line is drawn, then this visibility point is in camera frame and not occluded
                     //might want to use this for a targeting check as well at some point....
-                    else 
+                    else
                     {
                         result = true;
                         sop.isInteractable = true;
@@ -2283,17 +2263,17 @@ namespace UnityStandardAssets.Characters.FirstPerson
             }
 
             //only check against the visible layer, ignore the invisible layer
-            //so if an object ONLY has colliders on it that are not on layer 8, this raycast will go through them 
-            else 
+            //so if an object ONLY has colliders on it that are not on layer 8, this raycast will go through them
+            else
             {
-                if (Physics.Raycast(agentCamera.transform.position, point.position - agentCamera.transform.position, out hit, raycastDistance, (1 << 8) | (1 << 10))) 
+                if (Physics.Raycast(agentCamera.transform.position, point.position - agentCamera.transform.position, out hit, raycastDistance, (1 << 8) | (1 << 10)))
                 {
-                    if (hit.transform != sop.transform) 
+                    if (hit.transform != sop.transform)
                     {
-                        //we didn't directly hit the sop we are checking for with this cast, 
+                        //we didn't directly hit the sop we are checking for with this cast,
                         //check if it's because we hit something see-through
                         SimObjPhysics hitSop = hit.transform.GetComponent<SimObjPhysics>();
-                        if (hitSop != null && hitSop.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanSeeThrough)) 
+                        if (hitSop != null && hitSop.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanSeeThrough))
                         {
                             //we hit something see through, so now find all objects in the path between
                             //the sop and the camera
@@ -2302,38 +2282,38 @@ namespace UnityStandardAssets.Characters.FirstPerson
                                 raycastDistance, (1 << 8), QueryTriggerInteraction.Ignore);
 
                             float[] hitDistances = new float[hits.Length];
-                            for (int i = 0; i < hitDistances.Length; i++) 
+                            for (int i = 0; i < hitDistances.Length; i++)
                             {
                                 hitDistances[i] = hits[i].distance; //Vector3.Distance(hits[i].transform.position, m_Camera.transform.position);
                             }
 
                             Array.Sort(hitDistances, hits);
 
-                            foreach (RaycastHit h in hits) 
+                            foreach (RaycastHit h in hits)
                             {
 
-                                if (h.transform == sop.transform) 
+                                if (h.transform == sop.transform)
                                 {
                                     //found the object we are looking for, great!
                                     result = true;
                                     break;
-                                } 
-                                
-                                else 
+                                }
+
+                                else
                                 {
                                     // Didn't find it, continue on only if the hit object was translucent
                                     SimObjPhysics sopHitOnPath = null;
                                     sopHitOnPath = h.transform.GetComponentInParent<SimObjPhysics>();
-                                    if (sopHitOnPath == null || !sopHitOnPath.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanSeeThrough)) 
+                                    if (sopHitOnPath == null || !sopHitOnPath.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanSeeThrough))
                                     {
                                         break;
                                     }
                                 }
                             }
                         }
-                    } 
-                    
-                    else 
+                    }
+
+                    else
                     {
                         //if this line is drawn, then this visibility point is in camera frame and not occluded
                         //might want to use this for a targeting check as well at some point....
@@ -2369,7 +2349,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             }
 
             #if UNITY_EDITOR
-            if (result == true) 
+            if (result == true)
             {
                 Debug.DrawLine(agentCamera.transform.position, point.position, Color.cyan);
             }

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -2392,7 +2392,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             bool allowFloor = false
         ) {
             if (numPlacementAttempts <= 0) {
-                errorMessage = "numPlacementAttempts must a positive integer.";
+                errorMessage = "numPlacementAttempts must be a positive integer.";
                 actionFinished(false);
                 return;
             }

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1548,6 +1548,26 @@ namespace UnityStandardAssets.Characters.FirstPerson
             actionFinished(true);
         }
 
+        public void SimulatePhysicsForSeconds(float seconds, float deltaTime = 0.01f) {
+            if (seconds < 0.0f || deltaTime <= 0.0f) {
+                errorMessage = "$Seconds must be non-negative ({seconds}) and deltaTime must be positive ({deltaTiime}).";
+                actionFinished(false);
+                return;
+            }
+            bool oldPhysicsAutoSim = Physics.autoSimulation;
+
+            Physics.autoSimulation = false;
+            while (seconds > 0.0f) {
+                float timeStep = Math.Min(deltaTime, seconds);
+                Physics.Simulate(timeStep);
+                seconds -= timeStep;
+            }
+
+            Physics.autoSimulation = oldPhysicsAutoSim;
+
+            actionFinished(true);
+        }
+
 		// Handle collisions - CharacterControllers don't apply physics innately, see "PushMode" check below
         // XXX: this will be used for truly continuous movement over time, for now this is unused
 		protected void OnControllerColliderHit(ControllerColliderHit hit)

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1550,7 +1550,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
         public void SimulatePhysicsForSeconds(float seconds, float deltaTime = 0.01f) {
             if (seconds < 0.0f || deltaTime <= 0.0f) {
-                errorMessage = "$Seconds must be non-negative ({seconds}) and deltaTime must be positive ({deltaTiime}).";
+                errorMessage = $"Seconds must be non-negative ({seconds}) and deltaTime must be positive ({deltaTiime}).";
                 actionFinished(false);
                 return;
             }

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1549,7 +1549,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
         public void SimulatePhysicsForSeconds(float seconds, float deltaTime = 0.01f) {
             if (seconds < 0.0f || deltaTime <= 0.0f) {
-                errorMessage = $"Seconds must be non-negative ({seconds}) and deltaTime must be positive ({deltaTiime}).";
+                errorMessage = $"Seconds must be non-negative ({seconds}) and deltaTime must be positive ({deltaTime}).";
                 actionFinished(false);
                 return;
             }

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1775,12 +1775,10 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 }
                 m_Camera.transform.localEulerAngles = new Vector3(action.horizon, 0.0f, 0.0f);
 
-                bool agentCollides = isAgentCapsuleColliding(collidersToIgnoreDuringMovement);
-
-                if (agentCollides) {
-                    errorMessage = "Cannot teleport due to agent collision.";
-                    Debug.Log(errorMessage);
-                } 
+                bool agentCollides = isAgentCapsuleColliding(
+                    collidersToIgnore: collidersToIgnoreDuringMovement,
+                    includeErrorMessage: true
+                );
 
                 if (agentCollides) {
                     transform.position = oldPosition;
@@ -2840,12 +2838,25 @@ namespace UnityStandardAssets.Characters.FirstPerson
             );
         }
 
-        protected bool isAgentCapsuleColliding(HashSet<Collider> collidersToIgnore = null) {
+        protected bool isAgentCapsuleColliding(
+            HashSet<Collider> collidersToIgnore = null,
+            bool includeErrorMessage = false
+        ) {
             int layerMask = 1 << 8;
             foreach (Collider c in PhysicsExtensions.OverlapCapsule(GetComponent<CapsuleCollider>(), layerMask, QueryTriggerInteraction.Ignore)) {
                 if ((!hasAncestor(c.transform.gameObject, gameObject)) && (
                     collidersToIgnore == null || !collidersToIgnoreDuringMovement.Contains(c))
                 ) {
+                    if (includeErrorMessage) {
+                        SimObjPhysics sop = ancestorSimObjPhysics(c.gameObject);
+                        String collidedWithName;
+                        if (sop != null) {
+                            collidedWithName = sop.ObjectID;
+                        } else {
+                            collidedWithName = sop.gameObject.name;
+                        }
+                        errorMessage = $"Collided with: {collidedWithName}.";
+                    }
 #if UNITY_EDITOR
                     Debug.Log("Collided with: ");
                     Debug.Log(c);

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -1006,7 +1006,14 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
                         break;
                     }  
-
+                case "spfs":
+                    {
+                        Dictionary<string, object> action = new Dictionary<string, object>();
+                        action["action"] = "SimulatePhysicsForSeconds";
+                        action["seconds"] = 2.0f;
+                        PhysicsController.ProcessControlCommand(action);
+                        break;
+                    }
 				case "spawn":
                     {
                         ServerAction action = new ServerAction();

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -128,6 +128,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
         #if UNITY_EDITOR
         public void Execute(string command)
         {
+
             if ((PhysicsController.enabled && PhysicsController.IsProcessing) ||
                 (StochasticController != null && StochasticController.enabled && StochasticController.IsProcessing)
             ) {

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -941,47 +941,53 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 //set forceAction to true to spawn with kinematic = true to more closely resemble pivot functionality
                 case "irs":
                     {
-                        ServerAction action = new ServerAction();
-                        action.action = "InitialRandomSpawn";
+                        Dictionary<string, object> action = new Dictionary<string, object>();
+                        action["action"] = "InitialRandomSpawn";
+
+                        // List<string> excludedObjectIds = new List<string>();
+                        // foreach (SimObjPhysics sop in AManager.agents[0].VisibleSimObjs(false)) {
+                        //     excludedObjectIds.Add(sop.ObjectID);
+                        // }
+                        // action["excludedObjectIds"] = excludedObjectIds.ToArray();
 
                         //give me a seed
                         if(splitcommand.Length == 2)
                         {
-                            action.randomSeed = int.Parse(splitcommand[1]);
-                            action.forceVisible = false;
-                            action.numPlacementAttempts = 5;
+                            action["randomSeed"] = int.Parse(splitcommand[1]);
+                            action["forceVisible"] = false;
+                            action["numPlacementAttempts"] = 5;
                         }
 
                         //should objects be spawned only in immediately visible areas?
                         else if(splitcommand.Length == 3)
                         {
-                            action.randomSeed = int.Parse(splitcommand[1]);
+                            action["randomSeed"] = int.Parse(splitcommand[1]);
 
                             if(splitcommand[2] == "t") 
-                            action.forceVisible = true;
+                            action["forceVisible"] = true;
 
                             if(splitcommand[2] == "f") 
-                            action.forceVisible = false;
+                            action["forceVisible"] = false;
                         }
 
                         else if(splitcommand.Length == 4)
                         {
-                            action.randomSeed = int.Parse(splitcommand[1]);
+                            action["randomSeed"] = int.Parse(splitcommand[1]);
 
                             if(splitcommand[2] == "t") 
-                            action.forceVisible = true;
+                            action["forceVisible"] = true;
 
                             if(splitcommand[2] == "f") 
-                            action.forceVisible = false;
+                            action["forceVisible"] = false;
 
-                            action.numPlacementAttempts = int.Parse(splitcommand[3]);
+                            action["numPlacementAttempts"] = int.Parse(splitcommand[3]);
                         }
 
                         else
                         {
-                            action.randomSeed = 0;
-                            action.forceVisible = false;//true;
-                            action.numPlacementAttempts = 20;
+                            action["randomSeed"] = 0;
+                            action["forceVisible"] = false;//true;
+                            action["numPlacementAttempts"] = 20;
                         }
 
                         // ObjectTypeCount otc = new ObjectTypeCount();
@@ -993,9 +999,9 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
                         String[] excludeThese = new String[1];
                         excludeThese[0] = "CounterTop";
-                        action.excludedReceptacles = excludeThese;
+                        action["excludedReceptacles"] = excludeThese;
 
-                        action.placeStationary = true;//set to false to spawn with kinematic = false, set to true to spawn everything kinematic true and they won't roll around
+                        action["placeStationary"] = true;//set to false to spawn with kinematic = false, set to true to spawn everything kinematic true and they won't roll around
                         PhysicsController.ProcessControlCommand(action);
 
                         break;

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -1002,15 +1002,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         PhysicsController.ProcessControlCommand(action);
 
                         break;
-                    }  
-                case "spfs":
-                    {
-                        Dictionary<string, object> action = new Dictionary<string, object>();
-                        action["action"] = "SimulatePhysicsForSeconds";
-                        action["seconds"] = 2.0f;
-                        PhysicsController.ProcessControlCommand(action);
-                        break;
-                    }
+                    } 
 				case "spawn":
                     {
                         ServerAction action = new ServerAction();

--- a/unity/Assets/Scripts/InstantiatePrefabTest.cs
+++ b/unity/Assets/Scripts/InstantiatePrefabTest.cs
@@ -540,38 +540,34 @@ public class InstantiatePrefabTest : MonoBehaviour
     //All adjustments to the Bounding Box must be done on the collider only using the
     //"Edit Collider" button if you need to change the size
     //this assumes that the BoundingBox transform is zeroed out according to the root transform of the prefab
-    public bool CheckSpawnArea(SimObjPhysics simObj, Vector3 position, Quaternion rotation, bool spawningInHand)
-    {
-		int layermask;
+    public Collider ColliderHitByObjectInSpawnArea(
+        SimObjPhysics simObj, Vector3 position, Quaternion rotation, bool spawningInHand
+    ) {
+        int layermask;
 
 		//first do a check to see if the area is clear
 
         //if spawning in the agent's hand, ignore collisions with the Agent
-		if(spawningInHand)
-		{
+		if (spawningInHand) {
 			layermask = 1 << 8;
-		}
-
-        //oh we are spawning it somehwere in the environment, we do need to make sure not to spawn inside the agent or the environment
-		else
-		{
+		} else {
+            //oh we are spawning it somehwere in the environment, we do need to make sure not to spawn inside the agent or the environment
 			layermask = (1 << 8) | (1 << 10);
 		}
 
         //get list of all active colliders of sim object, then toggle them off for now
         //disable all colliders of the object being placed
         List<Collider> colsToDisable = new List<Collider>();
-        foreach(Collider g in simObj.MyColliders)
-        {
+        foreach(Collider g in simObj.MyColliders) {
             //only track this collider if it's enabled by default
             //some objects, like houseplants, might have colliders in their simObj.MyColliders that are disabled
-            if(g.enabled)
-            colsToDisable.Add(g);
+            if(g.enabled) {
+                colsToDisable.Add(g);
+            }
         }
 
         //disable collision before moving to check the spawn area
-        foreach(Collider c in colsToDisable)
-        {
+        foreach (Collider c in colsToDisable) {
             c.enabled = false;
         }
 
@@ -588,24 +584,24 @@ public class InstantiatePrefabTest : MonoBehaviour
         BoxCollider bbcol = bb.GetComponent<BoxCollider>();
         Vector3 bbCenter = bbcol.center;
         Vector3 bbCenterTransformPoint = bb.transform.TransformPoint(bbCenter);
-        //keep track of all 8 corners of the OverlapBox
+        // keep track of all 8 corners of the OverlapBox
         List<Vector3> corners = new List<Vector3>();
-        //bottom forward right
+        // bottom forward right
         corners.Add(bb.transform.TransformPoint(bbCenter + new Vector3(bbcol.size.x, -bbcol.size.y, bbcol.size.z) * 0.5f));
-        //bottom forward left
+        // bottom forward left
         corners.Add(bb.transform.TransformPoint(bbCenter + new Vector3(-bbcol.size.x, -bbcol.size.y, bbcol.size.z) * 0.5f));
-        //bottom back left
+        // bottom back left
         corners.Add(bb.transform.TransformPoint(bbCenter + new Vector3(-bbcol.size.x, -bbcol.size.y, -bbcol.size.z) * 0.5f));
-        //bottom back right
+        // bottom back right
         corners.Add(bb.transform.TransformPoint(bbCenter + new Vector3(bbcol.size.x, -bbcol.size.y, -bbcol.size.z) * 0.5f));
 
-        //top forward right
+        // top forward right
         corners.Add(bb.transform.TransformPoint(bbCenter + new Vector3(bbcol.size.x, bbcol.size.y, bbcol.size.z) * 0.5f));
-        //top forward left
+        // top forward left
         corners.Add(bb.transform.TransformPoint(bbCenter + new Vector3(-bbcol.size.x, bbcol.size.y, bbcol.size.z) * 0.5f));
-        //top back left
+        // top back left
         corners.Add(bb.transform.TransformPoint(bbCenter + new Vector3(-bbcol.size.x, bbcol.size.y, -bbcol.size.z) * 0.5f));
-        //top back right
+        // top back right
         corners.Add(bb.transform.TransformPoint(bbCenter+ new Vector3(bbcol.size.x, bbcol.size.y, -bbcol.size.z) * 0.5f));
 
         SpawnCorners = corners;
@@ -624,36 +620,40 @@ public class InstantiatePrefabTest : MonoBehaviour
         simObj.transform.rotation = originalRot;
 
         //re-enable the collision after returning in place
-        foreach(Collider c in colsToDisable)
-        {
+        foreach(Collider c in colsToDisable) {
             c.enabled = true;
         }
 
         //spawn overlap box
-        Collider[] hitColliders = Physics.OverlapBox(bbCenterTransformPoint,
-                                                     bbcol.size / 2.0f, rotation, 
-                                                     layermask, QueryTriggerInteraction.Collide);
+        Collider[] hitColliders = Physics.OverlapBox(
+            bbCenterTransformPoint,
+            bbcol.size / 2.0f,
+            rotation, 
+            layermask,
+            QueryTriggerInteraction.Collide
+        );
 
-        int colliderCount = 0;
-        //if a collider was hit, then the space is not clear to spawn
+        // if a collider was hit, then the space is not clear to spawn
 		if (hitColliders.Length > 0)
 		{
             //filter out any AgentTriggerBoxes because those should be ignored now
             foreach(Collider c in hitColliders)
             {
-                if(c.isTrigger && c.GetComponentInParent<PhysicsRemoteFPSAgentController>())
-                continue;
-
-                else
-                colliderCount++;
+                if(c.isTrigger && c.GetComponentInParent<PhysicsRemoteFPSAgentController>()) {
+                    continue;
+                } else {
+                    return c;
+                }
             }
-
-            if(colliderCount > 0)
-            return false;
 		}
 
         //nothing was hit, we are good!
-		return true;
+		return null;
+    }
+    public bool CheckSpawnArea(
+        SimObjPhysics simObj, Vector3 position, Quaternion rotation, bool spawningInHand
+    ) {
+		return null == ColliderHitByObjectInSpawnArea(simObj, position, rotation, spawningInHand);
 	}
 
 #if UNITY_EDITOR

--- a/unity/Assets/Scripts/InstantiatePrefabTest.cs
+++ b/unity/Assets/Scripts/InstantiatePrefabTest.cs
@@ -163,7 +163,13 @@ public class InstantiatePrefabTest : MonoBehaviour
     //The ReceptacleSpawnPoint list should be sorted based on what we are doing. If placing from the agent's hand, the list
     //should be sorted by distance to agent so the closest points are checked first. If used for Random Initial Spawn, it should
     //be randomized so that the random spawn is... random
-    public bool PlaceObjectReceptacle(List<ReceptacleSpawnPoint> rsps, SimObjPhysics sop, bool PlaceStationary, int maxPlacementAttempts, int degreeIncrement, bool AlwaysPlaceUpright)
+    public bool PlaceObjectReceptacle(
+        List<ReceptacleSpawnPoint> rsps,
+        SimObjPhysics sop, 
+        bool PlaceStationary,
+        int maxPlacementAttempts,
+        int degreeIncrement,
+        bool AlwaysPlaceUpright)
     {
         
         if(rsps == null)
@@ -275,8 +281,13 @@ public class InstantiatePrefabTest : MonoBehaviour
         }
     }
 
-    public bool PlaceObject(SimObjPhysics sop, ReceptacleSpawnPoint rsp, bool PlaceStationary, int degreeIncrement, bool AlwaysPlaceUpright)
-	{
+    public bool PlaceObject(
+        SimObjPhysics sop,
+        ReceptacleSpawnPoint rsp,
+        bool PlaceStationary,
+        int degreeIncrement,
+        bool AlwaysPlaceUpright
+    ) {
         if(rsp.ParentSimObjPhys == sop)
         {
             #if UNITY_EDITOR

--- a/unity/Assets/Scripts/ListExtensions.cs
+++ b/unity/Assets/Scripts/ListExtensions.cs
@@ -45,8 +45,10 @@ public static class ListExtensions
 	}
 
 	public static IList<T> Shuffle_<T>(this IList<T> list, int seed) {
-		System.Random rng = new System.Random(seed);
+		return list.Shuffle_(new System.Random(seed));
+	}
 
+	public static IList<T> Shuffle_<T>(this IList<T> list, System.Random rng) {
 		int n = list.Count;
 		while (n > 1) {  
 			n--;  

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -693,7 +693,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             Vector3 rotation,
             bool forceAction = false,
             bool forceKinematic = false,
-            bool allowTeleportOutOfHand = false
+            bool allowTeleportOutOfHand = false,
+            bool makeUnbreakable = false
         ) {
             if (!physicsSceneManager.ObjectIdToSimObjPhysics.ContainsKey(objectId)) {
                 errorMessage = $"Cannot find object with id {objectId}";
@@ -709,6 +710,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 forceAction: forceAction,
                 forceKinematic: forceKinematic,
                 allowTeleportOutOfHand: allowTeleportOutOfHand,
+                makeUnbreakable: makeUnbreakable,
                 includeErrorMessage: true
             );
 
@@ -732,7 +734,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             Vector3 rotation,
             bool forceAction = false,
             bool forceKinematic = false,
-            bool allowTeleportOutOfHand = false
+            bool allowTeleportOutOfHand = false,
+            bool makeUnbreakable = false
         ) {
             if (!physicsSceneManager.ObjectIdToSimObjPhysics.ContainsKey(objectId)) {
                 errorMessage = $"Cannot find object with id {objectId}";
@@ -750,6 +753,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     forceAction: forceAction,
                     forceKinematic: forceKinematic,
                     allowTeleportOutOfHand: allowTeleportOutOfHand,
+                    makeUnbreakable: makeUnbreakable,
                     includeErrorMessage: true
                 );
                 if (teleportSuccess) {
@@ -779,6 +783,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             bool forceAction,
             bool forceKinematic,
             bool allowTeleportOutOfHand,
+            bool makeUnbreakable,
             bool includeErrorMessage = false
         ) {
             bool sopInHand = ItemInHand != null && sop == ItemInHand.GetComponent<SimObjPhysics>();
@@ -806,6 +811,12 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         errorMessage = $"{sop.ObjectID} is colliding with {(hitSop != null ? hitSop.ObjectID : colliderHitIfTeleported.name)} after teleport.";
                     }
                     return false;
+                }
+            }
+
+            if (makeUnbreakable) {
+                if (sop.GetComponent<Break>()) {
+                    sop.GetComponent<Break>().Unbreakable = true;
                 }
             }
 
@@ -843,7 +854,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             Vector3 rotation,
             bool forceAction = false,
             bool forceKinematic = false,
-            bool allowTeleportOutOfHand = false
+            bool allowTeleportOutOfHand = false,
+            bool makeUnbreakable = false
         ) {
             TeleportObject(
                 objectId: objectId,
@@ -851,7 +863,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 rotation: rotation,
                 forceAction: forceAction,
                 forceKinematic: forceKinematic,
-                allowTeleportOutOfHand: allowTeleportOutOfHand
+                allowTeleportOutOfHand: allowTeleportOutOfHand,
+                makeUnbreakable: makeUnbreakable
             );
         }
 
@@ -1716,15 +1729,14 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 }
                 m_Camera.transform.localEulerAngles = new Vector3(action.horizon, 0.0f, 0.0f);
 
-                bool agentCollides = isAgentCapsuleColliding(collidersToIgnoreDuringMovement);
+                bool agentCollides = isAgentCapsuleColliding(
+                    collidersToIgnore: collidersToIgnoreDuringMovement,
+                    includeErrorMessage: true
+                );
+                
                 bool handObjectCollides = isHandObjectColliding(true);
-
-                if (agentCollides) {
-                    errorMessage = "Cannot teleport due to agent collision.";
-                    Debug.Log(errorMessage);
-                } else if (handObjectCollides) {
+                if (handObjectCollides && !agentCollides) {
                     errorMessage = "Cannot teleport due to hand object collision.";
-                    Debug.Log(errorMessage);
                 }
 
                 if (agentCollides || handObjectCollides) {

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -3339,6 +3339,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             if (rotation.HasValue) {
                 target.transform.rotation = Quaternion.Euler(rotation.Value);
             }
+            Vector3 originalPos = target.transform.position;
+            target.transform.position = agentManager.SceneBounds.min - new Vector3(-100f, -100f, -100f);
 
             //ok let's get the distance from the simObj to the bottom most part of its colliders
             Vector3 targetNegY = target.transform.position + new Vector3(0, -1, 0);
@@ -3395,13 +3397,12 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     return;
                 }
             }
-
+            
+            target.transform.position = originalPos;
             target.transform.rotation = originalRotation;
             errorMessage = "spawn area not clear, can't place object at that point";
             actionFinished(false);
         }
-
-
 
         // Similar to PlaceObjectAtPoint(...) above but returns a bool if successful
         public bool placeObjectAtPoint(SimObjPhysics t, Vector3 position)
@@ -6809,7 +6810,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         public void ChangeOpenSpeed(ServerAction action) {
             foreach (CanOpen_Object coo in GameObject.FindObjectsOfType<CanOpen_Object>()) {
                 coo.animationTime = action.x;
-            }
+        }
             actionFinished(true);
         }
 

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -2188,7 +2188,10 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
         //used to check if an specified sim object has come to rest
         //set useTimeout bool to use a faster time out
-        private IEnumerator checkIfObjectHasStoppedMoving(SimObjPhysics sop, float length, bool useTimeout = false)
+        private IEnumerator checkIfObjectHasStoppedMoving(
+            SimObjPhysics sop,
+            float length,
+            bool useTimeout = false)
         {
             //yield for the physics update to make sure this yield is consistent regardless of framerate
             yield return new WaitForFixedUpdate();
@@ -5298,7 +5301,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             return;
         }
 
-        protected IEnumerator InteractAndWait(CanOpen_Object coo, bool freezeContained = false, float openPercent = 1.0f) {
+        protected IEnumerator InteractAndWait(
+            CanOpen_Object coo, bool freezeContained = false, float openPercent = 1.0f
+        ) {
             bool ignoreAgentInTransition = true;
 
             List<Collider> collidersDisabled = new List<Collider>();

--- a/unity/Assets/Scripts/UtilityFunctions.cs
+++ b/unity/Assets/Scripts/UtilityFunctions.cs
@@ -53,6 +53,20 @@ public static class UtilityFunctions {
         float expandBy = 0.0f,
         bool useBoundingBoxInChecks=false
      ) {
+        return null != firstColliderObjectCollidingWith(
+            go: go,
+            ignoreGameObjects: ignoreGameObjects,
+            expandBy: expandBy,
+            useBoundingBoxInChecks: useBoundingBoxInChecks
+        );
+    }
+
+    public static Collider firstColliderObjectCollidingWith(
+        GameObject go,
+        List<GameObject> ignoreGameObjects = null,
+        float expandBy = 0.0f,
+        bool useBoundingBoxInChecks=false
+     ) {
         if (ignoreGameObjects == null) {
             ignoreGameObjects = new List<GameObject>();
         }
@@ -68,7 +82,7 @@ public static class UtilityFunctions {
         foreach (CapsuleCollider cc in go.GetComponentsInChildren<CapsuleCollider>()) {
             foreach (Collider c in PhysicsExtensions.OverlapCapsule(cc, layerMask, QueryTriggerInteraction.Ignore, expandBy)) {
                 if (!ignoreColliders.Contains(c)) {
-                    return true;
+                    return c;
                 }
             }
         }
@@ -78,18 +92,18 @@ public static class UtilityFunctions {
             }
             foreach (Collider c in PhysicsExtensions.OverlapBox(bc, layerMask, QueryTriggerInteraction.Ignore, expandBy)) {
                 if (!ignoreColliders.Contains(c)) {
-                    return true;
+                    return c;
                 }
             }
         }
         foreach (SphereCollider sc in go.GetComponentsInChildren<SphereCollider>()) {
             foreach (Collider c in PhysicsExtensions.OverlapSphere(sc, layerMask, QueryTriggerInteraction.Ignore, expandBy)) {
                 if (!ignoreColliders.Contains(c)) {
-                    return true;
+                    return c;
                 }
             }
         }
-        return false;
+        return null;
     }
 
     public static Collider[] collidersObjectCollidingWith(


### PR DESCRIPTION
1. Made some general improvements to `PlaceObjectAtPoint` and `TeleportObject`, namely improving their robustness and using the new action dispatch API.
2. I made non-trivial updates to the `InitialRandomSpawn` code to improve it's speed and the diversity of places into which objects are placed (certain random seeds were being reused resulting in less randomness as, for example, receptacles would be considered in the same order).