### PR TITLE
Enhance reset

### DIFF
--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -526,7 +526,9 @@ class Controller(object):
         init_params = init_params.copy()
 
         # width and height are updates in 'ChangeResolution', not 'Initialize'
-        if 'width' in init_params or 'height' in init_params:
+        if ('width' in init_params and  init_params['width'] != self.width) or (
+            'height' in init_params and init_params['height'] != self.height
+        ):
             if 'width' in init_params:
                 self.width = init_params['width']
                 del init_params['width']

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -58,6 +58,21 @@ def test_small_aspect():
     event = controller.step(dict(action='Initialize', gridSize=0.25))
     assert event.frame.shape == (64, 128, 3)
 
+def test_reset():
+    controller = build_controller()
+    width = 520
+    height = 310
+    event = controller.reset(scene='FloorPlan28', width=width, height=height, renderDepthImage=True)
+    assert event.frame.shape == (height, width, 3), "RGB frame dimensions are wrong!"
+    assert event.depth_frame is not None, 'depth frame should have rendered!'
+    assert event.depth_frame.shape == (height, width), "depth frame dimensions are wrong!"
+
+    width = 300
+    height = 300
+    event = controller.reset(scene='FloorPlan28', width=width, height=height, renderDepthImage=False)
+    assert event.depth_frame is None, "depth frame shouldn't have rendered!"
+    assert event.frame.shape == (height, width, 3), "RGB frame dimensions are wrong!"
+
 def test_fast_emit():
     fast_controller = build_controller(server_class=FifoServer, fastActionEmit=True)
     event = fast_controller.step(dict(action='RotateRight'))
@@ -81,7 +96,6 @@ def test_fast_emit_disabled(controller):
 
 @pytest.mark.parametrize("controller", [wsgi_controller, fifo_controller])
 def test_lookdown(controller):
-
     e = controller.step(dict(action='RotateLook', rotation=0, horizon=0))
     position = controller.last_event.metadata['agent']['position']
     horizon = controller.last_event.metadata['agent']['cameraHorizon']


### PR DESCRIPTION
Currently, the only documented way to make updates to initialization is to call:
```python
controller = Controller(init_params)
controller.stop()
controller = Controller(new_initialization_params)
```
However, this is highly undesirable when working with an interactive shell since: 
* It takes a non-trivial amount of time to create and destroy a controller. 
* If one doesn't first call `controller.stop()` and later initializes a controller with the same name `controller`, there is no way to ever stop it (without resetting the interactive session). For instance:
```python
controller = Controller(renderDepthImage=True)
controller = Controller()

# the first `controller` is no longer reachable, but it's Unity window still renders
```

This PR simply extends the abilities of `reset` to not only take in a `scene` but also take in any initialization parameter, such as:
```python
controller.reset(scene='FloorPlan1', renderDepthImage=True, agentMode='stochastic', width=4500)
```