### PR TITLE
ThirdPartyCameras bug fixes and enhancements

### DIFF
--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -152,8 +152,6 @@ def test_simobj_filter(controller):
 
 @pytest.mark.parametrize("controller", [wsgi_controller, fifo_controller])
 def test_add_third_party_camera(controller):
-
-
     expectedPosition = dict(x=1.2, y=2.3, z=3.4)
     expectedRotation = dict(x=30, y=40, z=50)
     expectedFieldOfView = 45.0
@@ -167,8 +165,13 @@ def test_add_third_party_camera(controller):
     assert camera[ThirdPartyCameraMetadata.fieldOfView] == expectedFieldOfView, 'initial fieldOfView should have been set'
 
 
-@pytest.mark.parametrize("controller", [wsgi_controller, fifo_controller])
-def test_update_third_party_camera(controller):
+def test_update_third_party_camera():
+    controller = build_controller(server_class=FifoServer)
+    expectedPosition = dict(x=1.2, y=2.3, z=3.4)
+    expectedRotation = dict(x=30, y=40, z=50)
+    expectedFieldOfView = 45.0
+
+    e = controller.step(dict(action=Actions.AddThirdPartyCamera, position=expectedPosition, rotation=expectedRotation, fieldOfView=expectedFieldOfView))
     assert len(controller.last_event.metadata[MultiAgentMetadata.thirdPartyCameras]) == 1, 'there should be 1 camera'
 
     # update camera pose

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -167,14 +167,15 @@ def test_add_third_party_camera(controller):
 
 def test_update_third_party_camera():
     controller = build_controller(server_class=FifoServer)
+
+    # add a new camera
     expectedPosition = dict(x=1.2, y=2.3, z=3.4)
     expectedRotation = dict(x=30, y=40, z=50)
     expectedFieldOfView = 45.0
-
     e = controller.step(dict(action=Actions.AddThirdPartyCamera, position=expectedPosition, rotation=expectedRotation, fieldOfView=expectedFieldOfView))
     assert len(controller.last_event.metadata[MultiAgentMetadata.thirdPartyCameras]) == 1, 'there should be 1 camera'
 
-    # update camera pose
+    # update camera pose fully
     expectedPosition = dict(x=2.2, y=3.3, z=4.4)
     expectedRotation = dict(x=10, y=20, z=30)
     expectedInitialFieldOfView = 45.0
@@ -184,19 +185,30 @@ def test_update_third_party_camera():
     assert_near(camera[ThirdPartyCameraMetadata.rotation], expectedRotation, 'rotation should have been updated')
     assert camera[ThirdPartyCameraMetadata.fieldOfView] == expectedInitialFieldOfView, 'fieldOfView should not have changed'
 
-    e = controller.step(dict(action=Actions.UpdateThirdPartyCamera, thirdPartyCameraId=0, fieldOfView=0))
-    assert not e.metadata['lastActionSuccess'], 'fieldOfView should fail when <= 0'
-
+    # partially update the camera pose
     changeFOV = 55.0
-    e = controller.step(dict(action=Actions.UpdateThirdPartyCamera, thirdPartyCameraId=0, fieldOfView=changeFOV))
+    expectedPosition2 = dict(x=3.2, z=5)
+    expectedRotation2 = dict(y=90)
+    e = controller.step(
+        action=Actions.UpdateThirdPartyCamera,
+        thirdPartyCameraId=0,
+        fieldOfView=changeFOV,
+        position=expectedPosition2,
+        rotation=expectedRotation2
+    )
     camera = e.metadata[MultiAgentMetadata.thirdPartyCameras][0]
     assert camera[ThirdPartyCameraMetadata.fieldOfView] == changeFOV, 'fieldOfView should have been updated'
 
-    e = controller.step(dict(action=Actions.UpdateThirdPartyCamera, thirdPartyCameraId=0, fieldOfView=-1))
-    assert not e.metadata['lastActionSuccess'], 'fieldOfView should fail when <= 0'
+    expectedPosition.update(expectedPosition2)
+    expectedRotation.update(expectedPosition2)
+    assert_near(camera[ThirdPartyCameraMetadata.position], expectedPosition, 'position should been slightly updated')
+    assert_near(camera[ThirdPartyCameraMetadata.rotation], expectedRotation, 'rotation should been slightly updated')
 
-    e = controller.step(dict(action=Actions.UpdateThirdPartyCamera, thirdPartyCameraId=0, fieldOfView=181))
-    assert not e.metadata['lastActionSuccess'], 'fieldOfView should fail when >= 180'
+    for fov in [-1, 181, 0]:
+        e = controller.step(dict(action=Actions.UpdateThirdPartyCamera, thirdPartyCameraId=0, fieldOfView=fov))
+        assert not e.metadata['lastActionSuccess'], 'fieldOfView should fail outside of (0, 180)'
+        assert_near(camera[ThirdPartyCameraMetadata.position], expectedPosition, 'position should not have updated')
+        assert_near(camera[ThirdPartyCameraMetadata.rotation], expectedRotation, 'rotation should not have updated')
 
 
 @pytest.mark.parametrize("controller", [wsgi_controller, fifo_controller])

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -200,7 +200,7 @@ def test_update_third_party_camera():
     assert camera[ThirdPartyCameraMetadata.fieldOfView] == changeFOV, 'fieldOfView should have been updated'
 
     expectedPosition.update(expectedPosition2)
-    expectedRotation.update(expectedPosition2)
+    expectedRotation.update(expectedRotation2)
     assert_near(camera[ThirdPartyCameraMetadata.position], expectedPosition, 'position should been slightly updated')
     assert_near(camera[ThirdPartyCameraMetadata.rotation], expectedRotation, 'rotation should been slightly updated')
 

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -48,7 +48,7 @@ public class AgentManager : MonoBehaviour
     private bool fastActionEmit;
     private HashSet<string> agentManagerActions = new HashSet<string>{"Reset", "Initialize", "AddThirdPartyCamera", "UpdateThirdPartyCamera"};
 
-	public const float DEFAULT_FOV = 90;
+    public const float DEFAULT_FOV = 90;
     public const float MAX_FOV = 180;
     public const float MIN_FOV = 0;
 

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1066,10 +1066,9 @@ public class AgentManager : MonoBehaviour
 
 		if (agentManagerActions.Contains(controlCommand.action.ToString())) {
             this.agentManagerState = AgentState.Processing;
-            try{
+            try {
                 ActionDispatcher.Dispatch(this, controlCommand);
-            } catch (MissingArgumentsActionException e)
-            {
+            } catch (MissingArgumentsActionException e) {
                 string errorMessage = "action: " + controlCommand.action + " is missing the following arguments: " + string.Join(",", e.ArgumentNames.ToArray());
                 Debug.LogError(errorMessage);
                 actionError(errorMessage, controlCommand.action.ToString(), ServerActionErrorCode.MissingArguments);

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -421,6 +421,19 @@ public class AgentManager : MonoBehaviour
         agentManagerState = AgentState.ActionComplete;
     }
 
+    // returns true if the FOV is in the correct range, otherwise returns false
+    // and provides an action error.
+    private bool checkFOV(float fov, string actionName) {
+        if (fov <= MIN_FOV) {
+            actionError($"fieldOfView must be > {MIN_FOV}.", actionName);
+            return false;
+        } else if (fov >= MAX_FOV) {
+            actionError($"fieldOfView must be < {MAX_FOV}.", actionName);
+            return false;
+        }
+        return true;
+    }
+
     public void AddThirdPartyCamera(
         Dictionary<string, float> position = null,
         Dictionary<string, float> rotation = null,
@@ -432,6 +445,11 @@ public class AgentManager : MonoBehaviour
         // dynamic way of getting the method name, in case it ever changes
         string actionName = System.Reflection.MethodBase.GetCurrentMethod().Name;
 
+        // adds error if fieldOfView is out of bounds
+        if (fieldOfView != null && !checkFOV((float) fieldOfView, actionName)) {
+            return;
+        }
+
         // require position and rotation to be specified in Vector3 style
         if (position == null || rotation == null) {
             actionError("Must pass in both rotation (xyz dictionary) and position (xyz dictionary).", actionName);
@@ -442,21 +460,6 @@ public class AgentManager : MonoBehaviour
         ) {
             actionError("Must specify xyz keys for both position and rotation.", actionName);
             return;
-        }
-
-        // For backwards compatibility, when fieldOfView=0, that used to mean use DEFAULT_FOV.
-        // However, fieldOfView is now nullable, so fieldOfView=null would be cleaner.
-        if (fieldOfView == 0) {
-            fieldOfView = DEFAULT_FOV;
-        } else {
-            // bound the FOV
-            if (fieldOfView < MIN_FOV) {
-                actionError($"fieldOfView must be > {MIN_FOV}.", actionName);
-                return;
-            } else if (fieldOfView >= MAX_FOV) {
-                actionError($"fieldOfView must be < {MAX_FOV}.", actionName);
-                return;
-            }
         }
 
         GameObject gameObject = new GameObject("ThirdPartyCamera" + thirdPartyCameras.Count);
@@ -493,6 +496,11 @@ public class AgentManager : MonoBehaviour
     ) {
         // dynamic way of getting the method name, in case it ever changes
         string actionName = System.Reflection.MethodBase.GetCurrentMethod().Name;
+
+        // adds error if fieldOfView is out of bounds
+        if (fieldOfView != null && !checkFOV((float) fieldOfView, actionName)) {
+            return;
+        }
 
         // count is out of bounds
         if (thirdPartyCameraId >= thirdPartyCameras.Count || thirdPartyCameraId < 0) {

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -444,13 +444,19 @@ public class AgentManager : MonoBehaviour
             return;
         }
 
-        // bound the FOV
-        if (fieldOfView <= MIN_FOV) {
-            actionError($"fieldOfView must be > {MIN_FOV}.", actionName);
-            return;
-        } else if (fieldOfView >= MAX_FOV) {
-            actionError($"fieldOfView must be < {MAX_FOV}.", actionName);
-            return;
+        // For backwards compatibility, when fieldOfView=0, that used to mean use DEFAULT_FOV.
+        // However, fieldOfView is now nullable, so fieldOfView=null would be cleaner.
+        if (fieldOfView == 0) {
+            fieldOfView = DEFAULT_FOV;
+        } else {
+            // bound the FOV
+            if (fieldOfView < MIN_FOV) {
+                actionError($"fieldOfView must be > {MIN_FOV}.", actionName);
+                return;
+            } else if (fieldOfView >= MAX_FOV) {
+                actionError($"fieldOfView must be < {MAX_FOV}.", actionName);
+                return;
+            }
         }
 
         GameObject gameObject = new GameObject("ThirdPartyCamera" + thirdPartyCameras.Count);

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -493,7 +493,7 @@ public class AgentManager : MonoBehaviour
         float? orthographicSize = null
     ) {
         // adds error if fieldOfView is out of bounds
-        if (!fovInBounds(fov: (float) fieldOfView, actionName: "UpdateThirdPartyCamera")) {
+        if (fieldOfView !=null && !fovInBounds(fov: (float) fieldOfView, actionName: "UpdateThirdPartyCamera")) {
             return;
         }
 

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -128,10 +128,13 @@ namespace UnityStandardAssets.Characters.FirstPerson
 		public CharacterController m_CharacterController;
 		protected CollisionFlags m_CollisionFlags;
 		protected Vector3 lastPosition;
-		protected string lastAction;
-		protected bool lastActionSuccess;
-		protected string errorMessage;
-		protected ServerActionErrorCode errorCode;
+
+        // These are public for actions outside of the agent context (e.g., AddThirdPartyCamera)
+		public string lastAction;
+		public bool lastActionSuccess;
+		public string errorMessage;
+		public ServerActionErrorCode errorCode;
+
 		public System.Object actionReturn;
         [SerializeField] protected Vector3 standingLocalCameraPosition;
         [SerializeField] protected Vector3 crouchingLocalCameraPosition;

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -130,10 +130,10 @@ namespace UnityStandardAssets.Characters.FirstPerson
 		protected Vector3 lastPosition;
 
         // These are public for actions outside of the agent context (e.g., AddThirdPartyCamera)
-		public string lastAction;
-		public bool lastActionSuccess;
-		public string errorMessage;
-		public ServerActionErrorCode errorCode;
+        public string lastAction;
+        public bool lastActionSuccess;
+        public string errorMessage;
+        public ServerActionErrorCode errorCode;
 
 		public System.Object actionReturn;
         [SerializeField] protected Vector3 standingLocalCameraPosition;

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -737,9 +737,10 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
                 case "atpc":
                     {
-                        ServerAction action = new ServerAction();
-                        action.action = "AddThirdPartyCamera";
-                        AManager.AddThirdPartyCamera(action);
+                        AManager.AddThirdPartyCamera(
+                            position: new Dictionary<string, float>() {{"x", 0}, {"y", 0}, {"z", 0}},
+                            rotation: new Dictionary<string, float>() {{"x", 0}, {"y", 0}, {"z", 0}}
+                        );
                         break;
                     }
 

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -738,8 +738,8 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 case "atpc":
                     {
                         AManager.AddThirdPartyCamera(
-                            position: new Dictionary<string, float>() {{"x", 0}, {"y", 0}, {"z", 0}},
-                            rotation: new Dictionary<string, float>() {{"x", 0}, {"y", 0}, {"z", 0}}
+                            position: Vector3.zero,
+                            rotation: Vector3.zero
                         );
                         break;
                     }


### PR DESCRIPTION
**HTML colors for skyboxes.** People can now pass in the skybox color as an HTML color. For instance, one can pass in:
```python
controller.step('AddThirdPartyCamera', skyboxColor='rgb(0, 0, 255)')
controller.step('UpdateThirdPartyCamera', skyboxColor='hsl(180, 50, 50)')
controller.step('UpdateThirdPartyCamera', skyboxColor='white')
controller.step('UpdateThirdPartyCamera', skyboxColor='green')
```
This is particularly nice for top-down videos and images.

---

**Metadata Bug fixes**. Currently when calling either `AddThirdPartyCamera` or `UpdateThirdPartyCamera`, the metadata does not update its:
* `lastAction`
* `lastActionSuccess`
* `errorMessage`
* `errorCode`

since the actions are in the `AgentManager`. These changes add metadata for these 2 actions.

---

**Orthographic extensions.** Ability to set `orthographic: bool = false` and `orthographicSize: float? = null` are supported in both `UpdateThirdPartyCamera` and `AddThirdPartyCamera`.