### PR TITLE
print -> logging

### DIFF
--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -454,7 +454,7 @@ class Controller(object):
                 init_return = event.metadata['actionReturn']
                 self.server.set_init_params(init_return)
 
-                print("Initialize return: {}".format(init_return))
+                logging.info("Initialize return: {}".format(init_return))
             else:
                 raise RuntimeError('Initialize action failure: {}'.format(
                     event.metadata['errorMessage'])


### PR DESCRIPTION
Changes from `print` to `logging.info` for consistency with other logging across the repo.

---

For reference, every time a Controller is currently initialized it runs:
```python
print("Initialize return: {}".format(init_return))
```
Within notebooks, particularly, this is non-trivial to suppress and forever displays the print statement after initializing a Controller.

---

For one to access this info here, they'd have to set
```python
import logging
logging.basicConfig(level=logging.INFO)
```
within the script that they initialize a Controller.