### PR TITLE
Fix pushAngle in DirectionalPush

### DIFF
--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -2200,25 +2200,22 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
                 case "dirpush":
 					{
-						ServerAction action = new ServerAction();
-						action.action = "DirectionalPush";
+                        Dictionary<string, object> action = new Dictionary<string, object>();
+                        action["action"] = "DirectionalPush";
 
-                        if (splitcommand.Length > 1 && splitcommand.Length < 3)
-                        {
-                            action.objectId = splitcommand[1];
-                            action.moveMagnitude = 10f;//4000f;
+                        if (splitcommand.Length > 1 && splitcommand.Length < 3) {
+                            action["objectId"] = splitcommand[1];
+                            action["moveMagnitude"] = 10;
+                        } else if (splitcommand.Length > 2) {
+                            action["objectId"] = splitcommand[1];
+                            action["moveMagnitude"] = float.Parse(splitcommand[2]);
+                        } else {
+                            action["moveMagnitude"] = 159f;
                         }
 
-                        else if(splitcommand.Length > 2)
-                        {
-                            action.objectId = splitcommand[1];
-                            action.moveMagnitude = float.Parse(splitcommand[2]);
-                        }
-
-                        action.pushAngle = 279f;
-                        action.moveMagnitude = 159f;
-                        action.x = 0.5f;
-                        action.y = 0.5f;
+                        action["pushAngle"] = 279f;
+                        action["x"] = 0.5f;
+                        action["y"] = 0.5f;
 						PhysicsController.ProcessControlCommand(action);                  
 						break;
 					}
@@ -2227,20 +2224,13 @@ namespace UnityStandardAssets.Characters.FirstPerson
                     {
                         Dictionary<string, object> action = new Dictionary<string, object>();
                         action["action"] = "ToggleObjectOn";
-                        if (splitcommand.Length > 1)
-                        {
+                        if (splitcommand.Length > 1) {
                             action["objectId"] = splitcommand[1];
-                        }
-
-                        else
-                        {
-                            //action.objectId = Agent.GetComponent<PhysicsRemoteFPSAgentController>().ObjectIdOfClosestToggleObject();
+                        } else {
                             action["x"] = 0.5f;
                             action["y"] = 0.5f;
                         }
-
                         PhysicsController.ProcessControlCommand(action);
-
                         break;
                     }
 

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1886,54 +1886,65 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             ApplyForceObject(action);
         }
 
-        //pass in a magnitude and an angle offset to push an object relative to agent forward
-        public void DirectionalPush(ServerAction action)
-        {
-            if (ItemInHand != null && action.objectId == ItemInHand.GetComponent<SimObjPhysics>().objectID) {
+        public void DirectionalPush(
+            string objectId = null,
+            float? x = null,
+            float? y = null,
+            float? moveMagnitude = null,
+            float? pushAngle = null,
+            bool forceAction = false
+        ) {
+            if (ItemInHand != null && objectId == ItemInHand.GetComponent<SimObjPhysics>().objectID) {
                 errorMessage = "Please use Throw for an item in the Agent's Hand";
                 Debug.Log(errorMessage);
                 actionFinished(false);
                 return;
             }
 
-            //the direction vecctor to push the target object defined by action.PushAngle 
-            //degrees clockwise from the agent's forward, the PushAngle must be less than 360
-            if(action.pushAngle <= 0 || action.pushAngle >= 360)
-            {
-                errorMessage = "please give a PushAngle between 0 and 360.";
+            if (pushAngle == null) {
+                errorMessage = "pushAngle must be specified";
                 Debug.Log(errorMessage);
                 actionFinished(false);
                 return;
             }
 
-            SimObjPhysics target = null;
-
-            if (action.forceAction) {
-                action.forceVisible = true;
+            if (moveMagnitude == null) {
+                errorMessage = "moveMagnitude must be specified";
+                Debug.Log(errorMessage);
+                actionFinished(false);
+                return;
             }
 
-            if(action.objectId == null)
-            {
-                if(!ScreenToWorldTarget(action.x, action.y, ref target, !action.forceAction))
-                {
-                    //error message is set insice ScreenToWorldTarget
+            // the direction vector to push the target object defined by pushAngle 
+            // degrees clockwise from the agent's forward, the PushAngle must be less than 360
+            pushAngle = Mathf.Abs((float) pushAngle % 360);
+
+            SimObjPhysics target = null;
+
+            if(objectId == null) {
+                if (x == null || y == null) {
+                    errorMessage = "Must specify either (x and y) or objectId";
+                    Debug.Log(errorMessage);
+                    actionFinished(false);
+                    return;
+                }
+                if(!ScreenToWorldTarget((float) x, (float) y, ref target, !forceAction)) {
+                    // error message is set insice ScreenToWorldTarget
                     actionFinished(false);
                     return;
                 }
             }
 
-            //an objectId was given, so find that target in the scene if it exists
-            else
-            {
-                if (!physicsSceneManager.ObjectIdToSimObjPhysics.ContainsKey(action.objectId)) {
+            // an objectId was given, so find that target in the scene if it exists
+            else {
+                if (!physicsSceneManager.ObjectIdToSimObjPhysics.ContainsKey(objectId)) {
                     errorMessage = "Object ID appears to be invalid.";
                     actionFinished(false);
                     return;
                 }
                 
-                //if object is in the scene and visible, assign it to 'target'
-                foreach (SimObjPhysics sop in VisibleSimObjs(action)) 
-                {
+                // if object is in the scene and visible, assign it to 'target'
+                foreach (SimObjPhysics sop in VisibleSimObjs(objectId, forceVisible: forceAction)) {
                     target = sop;
                 }
             }
@@ -1953,8 +1964,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 return;
             }
 
-            //print(target.name);
-
             if (!target.GetComponent<SimObjPhysics>()) {
                 errorMessage = "Target must be SimObjPhysics!";
                 Debug.Log(errorMessage);
@@ -1962,37 +1971,31 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 return;
             }
 
-            bool canbepushed = false;
+            bool canBePushed = (
+                target.PrimaryProperty == SimObjPrimaryProperty.CanPickup ||
+                target.PrimaryProperty == SimObjPrimaryProperty.Moveable);
 
-            if (target.PrimaryProperty == SimObjPrimaryProperty.CanPickup ||
-                target.PrimaryProperty == SimObjPrimaryProperty.Moveable)
-                canbepushed = true;
-
-            if (!canbepushed) {
+            if (!canBePushed) {
                 errorMessage = "Target Primary Property type incompatible with push/pull";
                 actionFinished(false);
                 return;
             }
 
-            if (!action.forceAction && target.isInteractable == false) {
+            if (!forceAction && target.isInteractable == false) {
                 errorMessage = "Target is not interactable and is probably occluded by something!";
                 actionFinished(false);
                 return;
             }
 
-            //find the Direction to push the object basec on action.PushAngle
+            // find the Direction to push the object based on PushAngle
             Vector3 agentForward = transform.forward;
-            float pushAngleInRadians = action.pushAngle * Mathf.PI/-180; //using -180 so positive PushAngle values go clockwise
-
-            Vector3 direction = new Vector3((agentForward.x * Mathf.Cos(pushAngleInRadians) - agentForward.z * Mathf.Sin(pushAngleInRadians)), 0, 
-            agentForward.x * Mathf.Sin(pushAngleInRadians) + agentForward.z * Mathf.Cos(pushAngleInRadians));
+            float pushAngleInRadians = ((float) pushAngle) * Mathf.PI / -180; //using -180 so positive PushAngle values go clockwise
 
             ServerAction pushAction = new ServerAction();
-            pushAction.x = direction.x;
-            pushAction.y = direction.y;
-            pushAction.z = direction.z;
-
-            pushAction.moveMagnitude = action.moveMagnitude;
+            pushAction.x = agentForward.x * Mathf.Cos(pushAngleInRadians) - agentForward.z * Mathf.Sin(pushAngleInRadians);
+            pushAction.y = 0;
+            pushAction.z = agentForward.x * Mathf.Sin(pushAngleInRadians) + agentForward.z * Mathf.Cos(pushAngleInRadians);
+            pushAction.moveMagnitude = (float) moveMagnitude;
 
             target.GetComponent<Rigidbody>().isKinematic = false;
             sopApplyForce(pushAction, target);


### PR DESCRIPTION
Currently, when passing in `pushAngle=0`, an error message is thrown. However, the documentation states that the push angle is accepted between 0 corresponds to a push directly in-front of the agent.

This commit:
* Allows `pushAngle=0` to work.
* Updates `DirectionalPush` from the old ServerAction input.
* Allows any float to be passed in as a `pushAngle`, where the float is then modded by 360, with the absolute value being taken.