### PR TITLE
enable ResetColors, alias with RandomColors

### DIFF
--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -710,6 +710,23 @@ namespace UnityStandardAssets.Characters.FirstPerson
             }
         }
 
+        // alias to RandomColors, supported for backwards compatibility
+        public void ChangeColorOfMaterials() {
+            RandomColors();
+        }
+
+        public void RandomColors() {
+            ColorChanger colorChangeComponent = physicsSceneManager.GetComponent<ColorChanger>();
+            colorChangeComponent.RandomizeColor();
+            actionFinished(true);
+        }
+
+        public void ResetColors() {
+            ColorChanger colorChangeComponent = physicsSceneManager.GetComponent<ColorChanger>();
+            colorChangeComponent.ResetColors();
+            actionFinished(true);
+        }
+
         //for all translational movement, check if the item the player is holding will hit anything, or if the agent will hit anything
         //NOTE: (XXX) All four movements below no longer use base character controller Move() due to doing initial collision blocking
         //checks before actually moving. Previously we would moveCharacter() first and if we hit anything reset, but now to match
@@ -1973,8 +1990,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             return visible;
         }
 
-        public SimObjPhysics[] VisibleSimObjs(string objectId, bool forceVisible = false)
-        {
+        public SimObjPhysics[] VisibleSimObjs(string objectId, bool forceVisible = false) {
             ServerAction action = new ServerAction();
             action.objectId = objectId;
             action.forceVisible = forceVisible;
@@ -1982,8 +1998,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
         }
 
 
-        public SimObjPhysics[] VisibleSimObjs(ServerAction action)
-        {
+        public SimObjPhysics[] VisibleSimObjs(ServerAction action) {
             List<SimObjPhysics> simObjs = new List<SimObjPhysics>();
 
             //go through array of sim objects visible to the camera

--- a/unity/Assets/Scripts/ColorChanger.cs
+++ b/unity/Assets/Scripts/ColorChanger.cs
@@ -1,9 +1,8 @@
 ﻿using System.Linq;
 using UnityEngine;
  
-public class ColorChanger : MonoBehaviour
-{
-    //Define all material types
+public class ColorChanger : MonoBehaviour {
+    // Define all material types
     public Material[] alarmClockMaterials;
     public Material[] appleMaterials;
     public Material[] basketballMaterials;
@@ -50,35 +49,31 @@ public class ColorChanger : MonoBehaviour
     Material[] quickMaterials;
 
     Material[] allMaterials;
+    Color[] origColors;
 
-    public void Start()
-    {
+    public void Start() {
         targetMaterials = alarmClockMaterials.Concat(appleMaterials).Concat(basketballMaterials).Concat(bowlMaterials).Concat(garbageBinMaterials).Concat(houseplantMaterials).Concat(pillowMaterials).Concat(sprayBottleMaterials).ToArray();
         backgroundMaterials = bedMaterials.Concat(boxMaterials).Concat(cellphoneMaterials).Concat(cupMaterials).Concat(floorLampMaterials).Concat(penPencilMaterials).Concat(plateMaterials).Concat(potMaterials).Concat(statueMaterials).Concat(watchMaterials).ToArray();
         furnitureMaterials = armchairMaterials.Concat(bedMaterials).Concat(chairMaterials).Concat(coffeeTableMaterials).Concat(deskMaterials).Concat(diningTableMaterials).Concat(dresserMaterials).Concat(officeChairMaterials).Concat(shelvingUnitMaterials).Concat(sideTableMaterials).Concat(sofaMaterials).ToArray();
         quickMaterials = ceramicMaterials.Concat(fabricMaterials).Concat(glassMaterials).Concat(lightMaterials).Concat(metalMaterials).Concat(miscMaterials).Concat(plasticMaterials).Concat(woodMaterials).ToArray();
 
         allMaterials = targetMaterials.Concat(backgroundMaterials).Concat(furnitureMaterials).Concat(quickMaterials).ToArray();
-        //print(allMaterials[allMaterials.Length - 1]);
+
+        origColors = new Color[allMaterials.Length];
+        for (int i = 0; i < allMaterials.Length; i++) {
+            origColors[i] = allMaterials[i].color;
+        }
     }
 
-    public void Update()
-    {
-        // MeshRenderer meshRenderer = GetComponent<MeshRenderer>();
-
-        //for (int i = 0; i < quickMaterials.Length; i++)
-        //{
-        //    quickMaterials[i].color = Random.ColorHSV(0f, 1f, 0.5f, 1f, 0.5f, 1f);
-        //}
-    }
-
-    public void RandomizeColor()
-    {
-        //MeshRenderer meshRenderer = GetComponent<MeshRenderer>();
-
-        for (int i = 0; i < allMaterials.Length; i++)
-        {
+    public void RandomizeColor() {
+        for (int i = 0; i < allMaterials.Length; i++) {
             allMaterials[i].color = Random.ColorHSV(0f, 1f, 0.5f, 1f, 0.5f, 1f);
+        }
+    }
+
+    public void ResetColors() {
+        for (int i = 0; i < allMaterials.Length; i++) {
+            allMaterials[i].color = origColors[i];
         }
     }
 }

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -515,10 +515,18 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 case "color":
                     {
                         Dictionary<string, object> action = new Dictionary<string, object>();
-                        action["action"] = "ChangeColorOfMaterials";
+                        action["action"] = "RandomColors";
                         PhysicsController.ProcessControlCommand(action);
                         break;
                     }
+                case "resetcolor":
+                    {
+                        Dictionary<string, object> action = new Dictionary<string, object>();
+                        action["action"] = "ResetColors";
+                        PhysicsController.ProcessControlCommand(action);
+                        break;
+                    }
+
                 case "spawnabove":
                     {
                         ServerAction action = new ServerAction();

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -188,13 +188,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             actionFinished(true);
         }
 
-        public void ChangeColorOfMaterials()
-        {
-            ColorChanger ColorChangeComponent = physicsSceneManager.GetComponent<ColorChanger>();
-            ColorChangeComponent.RandomizeColor();
-            actionFinished(true);
-        }
-
         //EDITOR DEBUG SCRIPTS:
         //////////////////////////////////////////////////////////////////////
         #if UNITY_EDITOR


### PR DESCRIPTION
Now, instead of destroying a controller to reset from crazy colors, that is:
```python
from ai2thor.controller import Controller
controller = Controller(scene='FloorPlan28')
controller.step('RandomColors')

controller.stop()
controller = Controller(scene='FloorPlan28')
```

one simply can call `ResetColors`:
```python
from ai2thor.controller import Controller
controller = Controller(scene='FloorPlan28')

controller.step('RandomColors')  # crazy random colors
controller.step('ResetColors')  # reset colors
```

I've also created an alias from the undocumented `ChangeColorOfMaterials` to a new name: `RandomColors`. The name `ChangeColorOfMaterials` was too hard to remember and the plurals on colors vs. materials seemed arbitrary.

This should be enough to officially support both `RandomColors` and `ResetColors` officially.

---

Note that these actions have also moved to `BaseFPSAgentController`, instead of `PhysicsRemoteFPSAgentController` because they do not require the use of any particular agent.