### PR TITLE
GetInteractablePoses, dynamic rotateStepDegrees, rotation instead of eulerAngles bug fixes

### DIFF
--- a/ai2thor/server.py
+++ b/ai2thor/server.py
@@ -117,10 +117,10 @@ class Event(object):
     def __repr__(self):
         """Summarizes the results from an Event.""" 
         return (
-            '<ai2thor.server.Event at ' + hex(id(self)) + '\n' +
-            '\t.metadata["lastActionSuccess"] = ' + self.metadata['lastActionSuccess'] + '\n' +
-            '\t.metadata["errorMessage"] = "' + self.metadata['errorMessage'] + '"\n' +
-            '\t.metadata["actionReturn"] = ' + self.metadata['actionReturn'] + '\n' +
+            '<ai2thor.server.Event at ' + str(hex(id(self))) + '\n' +
+            '\t.metadata["lastActionSuccess"] = ' + str(self.metadata['lastActionSuccess']) + '\n' +
+            '\t.metadata["errorMessage"] = "' + str(self.metadata['errorMessage']) + '"\n' +
+            '\t.metadata["actionReturn"] = ' + str(self.metadata['actionReturn']) + '\n' +
             '>'
         )
 

--- a/ai2thor/server.py
+++ b/ai2thor/server.py
@@ -115,12 +115,16 @@ class Event(object):
         self.events = [self] # Ensure we have a similar API to MultiAgentEvent
 
     def __repr__(self):
-        """Summarizes the results from an Event.""" 
+        """Summarizes the results from an Event."""
+        action_return = str(self.metadata['actionReturn'])
+        if len(action_return) > 100:
+            action_return = action_return[:100] + '...'
         return (
             '<ai2thor.server.Event at ' + str(hex(id(self))) + '\n' +
+            '\t.metadata["lastAction"] = ' + str(self.metadata['lastAction']) + '\n' +
             '\t.metadata["lastActionSuccess"] = ' + str(self.metadata['lastActionSuccess']) + '\n' +
-            '\t.metadata["errorMessage"] = "' + str(self.metadata['errorMessage']) + '"\n' +
-            '\t.metadata["actionReturn"] = ' + str(self.metadata['actionReturn']) + '\n' +
+            '\t.metadata["errorMessage"] = "' + str(self.metadata['errorMessage']).replace('\n', ' ') + '"\n' +
+            '\t.metadata["actionReturn"] = ' + action_return + '\n' +
             '>'
         )
 

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -621,21 +621,10 @@ def test_get_interactable_poses(controller):
             raise Exception("Not expecting rotation: " + pose['rotation'])
 
     # assert only checking certain horizons and rotations is working correctly
-    horizons = [0, 30]
-    rotations = [0, 45]
-    event = controller.step('GetInteractablePoses', objectId=fridgeId, horizons=horizons, rotations=rotations)
-    for pose in event.metadata['actionReturn']:
-        for horizon in horizons:
-            if abs(pose['horizon'] - horizon) < 1e-3:
-                break
-        else:
-            raise Exception("Not expecting horizon: " + pose['horizon'])
+    event = controller.step('GetInteractablePoses', objectId=fridgeId, rotations=[270])
+    assert len(event.metadata['actionReturn']) == 0, "Fridge shouldn't be viewable from this rotation!"
+    assert event.metadata['lastActionSuccess'], "GetInteractablePoses with Fridge shouldn't have failed!"
 
-        for rotation in rotations:
-            if abs(pose['rotation'] - rotation) < 1e-3:
-                break
-        else:
-            raise Exception("Not expecting rotation: " + pose['rotation'])
-    
+    # test maxDistance
     event = controller.step('GetInteractablePoses', objectId=fridgeId, maxDistance=5)
     assert 1300 > len(event.metadata['actionReturn']) > 1200, 'GetInteractablePoses with large maxDistance is off!'

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -638,4 +638,4 @@ def test_get_interactable_poses(controller):
             raise Exception("Not expecting rotation: " + pose['rotation'])
     
     event = controller.step('GetInteractablePoses', objectId=fridgeId, maxDistance=5)
-    assert len(event.metadata['actionReturn']) == 1241, 'GetInteractablePoses with large maxDistance is off!'
+    assert 1300 > len(event.metadata['actionReturn']) > 1200, 'GetInteractablePoses with large maxDistance is off!'

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -608,17 +608,19 @@ def test_get_interactable_poses(controller):
     rotations = [0, 45]
     event = controller.step('GetInteractablePoses', objectId=fridgeId, horizons=horizons, rotations=rotations)
     for pose in event.metadata['actionReturn']:
+        horizon_works = False
         for horizon in horizons:
             if abs(pose['horizon'] - horizon) < 1e-3:
+                horizon_works = True
                 break
-        else:
-            raise Exception("Not expecting horizon: " + pose['horizon'])
+        assert horizon_works, "Not expecting horizon: " + pose['horizon']
 
+        rotation_works = False
         for rotation in rotations:
             if abs(pose['rotation'] - rotation) < 1e-3:
+                rotation_works = True
                 break
-        else:
-            raise Exception("Not expecting rotation: " + pose['rotation'])
+        assert rotation_works, "Not expecting rotation: " + pose['rotation']
 
     # assert only checking certain horizons and rotations is working correctly
     event = controller.step('GetInteractablePoses', objectId=fridgeId, rotations=[270])

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -591,3 +591,51 @@ def test_get_interactable_poses(controller):
     assert abs(pose['rotation'] - event.metadata['agent']['rotation']['y']) < 1e-3, "Agent rotation off!"
     assert abs(pose['horizon'] - event.metadata['agent']['cameraHorizon']) < 1e-3, "Agent horizon off!"
     assert pose['standing'] == event.metadata['agent']['isStanding'], "Agent's isStanding is off!"
+
+    # potato should be inside of the fridge (and, thus, non interactable)
+    potatoId = next(obj['objectId'] for obj in controller.last_event.metadata['objects']
+                    if obj['objectType'] == 'Potato')
+    event = controller.step('GetInteractablePoses', objectId=potatoId)
+    assert len(event.metadata['actionReturn']) == 0, "Potato is inside of fridge, and thus, shouldn't be interactable"
+    assert event.metadata['lastActionFinished'], "GetInteractablePoses with Potato shouldn't have failed!"
+
+    # assertion for maxPoses
+    event = controller.step('GetInteractablePoses', objectId=fridgeId, maxPoses=50)
+    assert len(event.metadata['actionReturn']) == 50, "maxPoses should be capped at 50!"
+
+    # assert only checking certain horizons and rotations is working correctly
+    horizons = [0, 30]
+    rotations = [0, 45]
+    event = controller.step('GetInteractablePoses', objectId=fridgeId, horizons=horizons, rotations=rotations)
+    for pose in event.metadata['actionReturn']:
+        for horizon in horizons:
+            if abs(pose['horizon'] - horizon) < 1e-3:
+                break
+        else:
+            raise Exception("Not expecting horizon: " + pose['horizon'])
+
+        for rotation in rotations:
+            if abs(pose['rotation'] - rotation) < 1e-3:
+                break
+        else:
+            raise Exception("Not expecting rotation: " + pose['rotation'])
+
+    # assert only checking certain horizons and rotations is working correctly
+    horizons = [0, 30]
+    rotations = [0, 45]
+    event = controller.step('GetInteractablePoses', objectId=fridgeId, horizons=horizons, rotations=rotations)
+    for pose in event.metadata['actionReturn']:
+        for horizon in horizons:
+            if abs(pose['horizon'] - horizon) < 1e-3:
+                break
+        else:
+            raise Exception("Not expecting horizon: " + pose['horizon'])
+
+        for rotation in rotations:
+            if abs(pose['rotation'] - rotation) < 1e-3:
+                break
+        else:
+            raise Exception("Not expecting rotation: " + pose['rotation'])
+    
+    event = controller.step('GetInteractablePoses', objectId=fridgeId, maxDistance=5)
+    assert len(event.metadata['actionReturn']) == 1241, 'GetInteractablePoses with large maxDistance is off!'

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -597,7 +597,7 @@ def test_get_interactable_poses(controller):
                     if obj['objectType'] == 'Potato')
     event = controller.step('GetInteractablePoses', objectId=potatoId)
     assert len(event.metadata['actionReturn']) == 0, "Potato is inside of fridge, and thus, shouldn't be interactable"
-    assert event.metadata['lastActionFinished'], "GetInteractablePoses with Potato shouldn't have failed!"
+    assert event.metadata['lastActionSuccess'], "GetInteractablePoses with Potato shouldn't have failed!"
 
     # assertion for maxPoses
     event = controller.step('GetInteractablePoses', objectId=fridgeId, maxPoses=50)

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -2804,7 +2804,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             SimObjPhysics soInHand = ItemInHand.GetComponent<SimObjPhysics>();
 
             Vector3 handObjPosRelAgent =
-                Quaternion.Euler(0, rotation - transform.rotation.y, 0) *
+                Quaternion.Euler(0, rotation - transform.eulerAngles.y, 0) *
                 (transform.position - ItemInHand.transform.position);
 
             Vector3 newHandPosition = handObjPosRelAgent + newAgentPosition;

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -884,6 +884,15 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         break;
                     }
 
+                case "gip":
+                    {
+                        Dictionary<string, object> action = new Dictionary<string, object>();
+                        action["action"] = "GetInteractablePoses";
+                        action["objectId"] = "Fridge|-02.10|+00.00|+01.09";
+                        PhysicsController.ProcessControlCommand(action);
+                        break;
+                    }
+
                 //tests the Reset function on AgentManager.cs, adding a path to it from the PhysicsController
                 case "reset":
                     {

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1513,7 +1513,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     return;
                 }
                 Quaternion oldRotation = sop.transform.rotation;
-                sop.transform.rotation = Quaternion.Euler(new Vector3(0.0f, (float) Math.Round(sop.transform.eulerAngles.y + 90f % 360), 0.0f));;
+                sop.transform.rotation = Quaternion.Euler(new Vector3(0.0f, (float) Math.Round((sop.transform.eulerAngles.y + 90f) % 360), 0.0f));;
                 if (!action.forceAction) {
                     if (action.maxAgentsDistance > 0.0f) {
                         for (int i = 0; i < agentManager.agents.Count; i++) {

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1513,7 +1513,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     return;
                 }
                 Quaternion oldRotation = sop.transform.rotation;
-                sop.transform.rotation = Quaternion.Euler(new Vector3(0.0f, (float) Math.Round(sop.transform.rotation.y + 90f % 360), 0.0f));;
+                sop.transform.rotation = Quaternion.Euler(new Vector3(0.0f, (float) Math.Round(sop.transform.eulerAngles.y + 90f % 360), 0.0f));;
                 if (!action.forceAction) {
                     if (action.maxAgentsDistance > 0.0f) {
                         for (int i = 0; i < agentManager.agents.Count; i++) {
@@ -7006,14 +7006,14 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             // populate the rotations based on rotateStepDegrees
             if (rotations == null) {
                 // Consider the case where one does not want to move on a perfect grid, and is currently moving
-                //  with an offsetted set of rotations like {10, 100, 190, 280} instead of the default {0, 90, 180, 270}.
+                // with an offsetted set of rotations like {10, 100, 190, 280} instead of the default {0, 90, 180, 270}.
                 // This may happen if the agent starts by teleports with the rotation of 10 degrees.
-                float offset = transform.rotation.y % rotateStepDegrees;
+                int offset = (int) Math.Round(transform.eulerAngles.y % rotateStepDegrees);
 
                 // Examples:
                 // if rotateStepDegrees=10 and offset=70, then the paths would be [70, 80, ..., 400, 410, 420].
                 // if rotateStepDegrees=90 and offset=10, then the paths would be [10, 100, 190, 280]
-                rotations = new float[(int) (360 / rotateStepDegrees)];
+                rotations = new float[(int) Math.Round(360 / rotateStepDegrees)];
                 int i = 0;
                 for (float rotation = offset; rotation < 360 + offset; rotation += rotateStepDegrees) {
                     rotations[i++] = rotation;

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -6975,13 +6975,15 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             float[] rotations = null,
             float[] horizons = null,
             bool[] standings = null,
-            float? maxDistance = null
+            float? maxDistance = null,
+            int maxPoses = int.MaxValue  // works like infinity
         ) {
             getInteractablePoses(
                 objectId: objectId,
                 markActionFinished: true,
                 positions: positions, rotations: rotations, horizons: horizons, standings: standings,
-                maxDistance: maxDistance
+                maxDistance: maxDistance,
+                maxPoses: maxPoses
             );
         }
 

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -6999,11 +6999,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 horizons: horizons.ToArray()
             );
 
-            if (interactablePoses == null) {
-                actionFinished(false);
-                return;
-            }
-
             // for backwards compatibility, PositionsFromWhichItemIsInteractable returns
             // Dictionary<string, float> instead of List<Dictionary<string, object>>,
             // where the latter is cleaner in python.
@@ -7031,7 +7026,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             List<Dictionary<string, object>> interactablePoses = getInteractablePoses(
                 objectId: objectId,
                 positions: positions,
-                maxDistance: 1e5f,                                                // super large number for maximum distance!
+                maxDistance: 1e5f,  // super large number for maximum distance!
                 horizons: new float[] { m_Camera.transform.localEulerAngles.x },  // don't care about every horizon here, just horizon={current horizon}
                 markActionFinished: false,
                 maxPoses: maxPoses

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -6928,7 +6928,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             return allVisible;
         }
 
-        // returns null on failure.
         // @positions/@rotations/@horizons/@standings are used to override all possible values the agent
         // may encounter with basic agent navigation commands (excluding teleport).
         private List<Dictionary<string, object>> getInteractablePoses(
@@ -6941,20 +6940,12 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             float? maxDistance = null,
             int maxPoses = int.MaxValue  // works like infinity
         ) {
-            if (360 % rotateStepDegrees != 0) {
-                errorMessage = "360 % rotateStepDegrees must be 0, unless 'rotations: float[]' is overwritten.";
-                if (markActionFinished) {
-                    actionFinished(success: false);
-                }
-                return null;
+            if (360 % rotateStepDegrees != 0 && rotations != null) {
+                throw new InvalidOperationException("360 % rotateStepDegrees must be 0, unless 'rotations: float[]' is overwritten.");
             }
 
             if (maxPoses <= 0) {
-                errorMessage = "maxPoses must be > 0.";
-                if (markActionFinished) {
-                    actionFinished(success: false);
-                }
-                return null;
+                throw new ArgumentOutOfRangeException("maxPoses must be > 0.");
             }
 
             // default "visibility" distance
@@ -6962,11 +6953,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             if (maxDistance == null) {
                 maxDistanceFloat = maxVisibleDistance;
             } else if ((float) maxDistance <= 0) {
-                errorMessage = "maxDistance must be >= 0 meters from the object.";
-                if (markActionFinished) {
-                    actionFinished(success: false);
-                }
-                return null;
+                throw new ArgumentOutOfRangeException("maxDistance must be >= 0 meters from the object.");
             } else {
                 maxDistanceFloat = (float) maxDistance;
             }

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -7146,7 +7146,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             );
         }
 
-        [ObsoleteAttribute(message: "This action is deprecated. Call GetInteractablePositions instead.", error: false)]
+        [ObsoleteAttribute(message: "This action is deprecated. Call GetInteractablePoses instead.", error: false)]
         public void PositionsFromWhichItemIsInteractable(string objectId, float horizon = 30, Vector3[] positions = null) {
             // set horizons using the horizon as an increment
             List<float> horizons = new List<float>();

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -6795,7 +6795,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             int maxPoses = int.MaxValue  // works like infinity
         ) {
             if (360 % rotateStepDegrees != 0 && rotations != null) {
-                throw new InvalidOperationException("360 % rotateStepDegrees must be 0, unless 'rotations: float[]' is overwritten.");
+                throw new InvalidOperationException($"360 % rotateStepDegrees (360 % {rotateStepDegrees} != 0) must be 0, unless 'rotations: float[]' is overwritten.");
             }
 
             if (maxPoses <= 0) {

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -7166,16 +7166,22 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
 
             // for backwards compatibility, PositionsFromWhichItemIsInteractable returns
-            // Dictionary<string, List<object>> instead of List<Dictionary<string, object>>,
+            // Dictionary<string, float> instead of List<Dictionary<string, object>>,
             // where the latter is cleaner in python.
-            Dictionary<string, List<object>> d = new Dictionary<string, List<object>>();
+            Dictionary<string, List<float>> d = new Dictionary<string, List<float>>();
             string[] keys = {"x", "y", "z", "rotation", "standing", "horizon"};
             foreach (string key in keys) {
-                d[key] = new List<object>();
+                d[key] = new List<float>();
             }
             foreach(Dictionary<string, object> pose in interactablePoses) {
                 foreach (string key in keys) {
-                    d[key].Add(pose[key]);
+                    if (key == "standing") {
+                        // standing is converted from true => 1 to false => 0, for backwards compatibility
+                        d[key].Add((bool) pose[key] ? 1 : 0);
+                    } else {
+                        // all other keys have float outputs
+                        d[key].Add((float) pose[key]);
+                    }
                 }
             }
             actionFinished(true, d);

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -8615,7 +8615,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 sop.gameObject.SetActive(true);
                 objectIdToPositionsVisibleFrom.Add(
                     sop.ObjectID,
-                    numVisiblePositions(objectId: sop, markActionFinished: false, positions: positions)
+                    numVisiblePositions(objectId: sop.ObjectID, markActionFinished: false, positions: positions)
                 );
 
                 #if UNITY_EDITOR

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -7193,7 +7193,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 objectId: objectId,
                 positions: positions,
                 maxDistance: 1e5f,                                                // super large number for maximum distance!
-                horizons: new float[] { m_Camera.transform.localEulerAngles.x },  // don't care about every horizon here, just horizon=0
+                horizons: new float[] { m_Camera.transform.localEulerAngles.x },  // don't care about every horizon here, just horizon={current horizon}
                 markActionFinished: false,
                 maxPoses: maxPoses
             );

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -7192,8 +7192,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             List<Dictionary<string, object>> interactablePoses = getInteractablePoses(
                 objectId: objectId,
                 positions: positions,
-                maxDistance: 1e5f,          // super large number for maximum distance!
-                horizons: new float[] {0},  // don't care about every horizon here, just horizon=0
+                maxDistance: 1e5f,                                                // super large number for maximum distance!
+                horizons: new float[] { m_Camera.transform.localEulerAngles.x },  // don't care about every horizon here, just horizon=0
                 markActionFinished: false,
                 maxPoses: maxPoses
             );


### PR DESCRIPTION
Aliases `PositionsFromWhichItemIsInteractable` to its new name `GetInteractablePositions`, since the former is **super** long. `GetInteractablePositions` is also more consistent with `GetReachablePositions`.

Also updates rotations to use `rotateStepDegrees`, instead of assuming that the agent is rotating in 90-degree increments.