### PR TITLE
Add obsolete attribute to ChangeColorOfMaterials

### DIFF
--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -710,7 +710,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             }
         }
 
-        // alias to RandomizeColors, supported for backwards compatibility
+        [ObsoleteAttribute(message: "This action is deprecated. Call RandomizeColors instead.", error: false)] 
         public void ChangeColorOfMaterials() {
             RandomizeColors();
         }


### PR DESCRIPTION
This provides better deprecation warnings if a user tries to call an outdated action (from unity), like `ChangeColorOfMaterials`.