### PR TITLE
Using Exceptions to short circuit action failures

### DIFF
--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -136,6 +136,14 @@ def test_no_leak_params(controller):
     assert 'sequenceId' not in action
 
 @pytest.mark.parametrize("controller", [wsgi_controller, fifo_controller])
+def test_target_invocation_exception(controller):
+    # TargetInvocationException is raised when short circuiting failures occur
+    # on the Unity side. It often occurs when invalid arguments are used.
+    event = controller.step('OpenObject', x=1.5, y=0.5)
+    assert not event.metadata['lastActionSuccess'], 'OpenObject(x > 1) should fail.'
+    assert event.metadata['errorMessage'], 'errorMessage should not be empty when OpenObject(x > 1).'
+
+@pytest.mark.parametrize("controller", [wsgi_controller, fifo_controller])
 def test_lookup(controller):
 
     e = controller.step(dict(action='RotateLook', rotation=0, horizon=0))

--- a/unity/Assets/Scripts/ActionDispatcher.cs
+++ b/unity/Assets/Scripts/ActionDispatcher.cs
@@ -379,9 +379,6 @@ public class MethodParamComparer: IComparer<MethodInfo> {
 public class InvalidActionException : Exception { }
 
 [Serializable]
-public class StopActionNow : Exception { }
-
-[Serializable]
 public class AmbiguousActionException : Exception { 
     public AmbiguousActionException(string message) : base(message) {}
 }

--- a/unity/Assets/Scripts/ActionDispatcher.cs
+++ b/unity/Assets/Scripts/ActionDispatcher.cs
@@ -379,6 +379,9 @@ public class MethodParamComparer: IComparer<MethodInfo> {
 public class InvalidActionException : Exception { }
 
 [Serializable]
+public class StopActionNow : Exception { }
+
+[Serializable]
 public class AmbiguousActionException : Exception { 
     public AmbiguousActionException(string message) : base(message) {}
 }

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -290,7 +290,10 @@ namespace UnityStandardAssets.Characters.FirstPerson
             }
         }
 
-		public virtual void actionFinished(bool success, System.Object actionReturn = null, bool stopActionNow = false) {
+		public virtual void actionFinished(bool success, System.Object actionReturn = null, string errorMessage = null, bool stopActionNow = false) {
+            if (errorMessage != null) {
+                this.errorMessage = errorMessage;
+            }
             actionFinished(
                 success: success,
                 newState: AgentState.ActionComplete,
@@ -298,15 +301,6 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 stopActionNow: stopActionNow
             );
             this.resumePhysics();
-		}
-
-		public virtual void actionFinished(bool success, string errorMessage, System.Object actionReturn = null, bool stopActionNow = false) {
-            this.errorMessage = errorMessage;
-            actionFinished(
-                success: success,
-                actionReturn: actionReturn,
-                stopActionNow: stopActionNow
-            );
 		}
 
         protected virtual void resumePhysics() {}

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -265,18 +265,12 @@ namespace UnityStandardAssets.Characters.FirstPerson
             }
         }
 
-		public void actionFinishedEmit(bool success, System.Object actionReturn=null, bool stopActionNow = false) {
-            actionFinished(
-                success: success,
-                newState: AgentState.Emit,
-                actionReturn: actionReturn,
-                stopActionNow: stopActionNow
-            );
+		public void actionFinishedEmit(bool success, object actionReturn = null) {
+            actionFinished(success: success, newState: AgentState.Emit, actionReturn: actionReturn);
 		}
 
-		protected virtual void actionFinished(bool success, AgentState newState, System.Object actionReturn = null, bool stopActionNow = false) {
-			if (!this.IsProcessing)
-			{
+		protected virtual void actionFinished(bool success, AgentState newState, object actionReturn = null) {
+			if (!this.IsProcessing) {
 				Debug.LogError ("ActionFinished called with agentState not in processing ");
 			}
 
@@ -285,23 +279,21 @@ namespace UnityStandardAssets.Characters.FirstPerson
 			this.actionReturn = actionReturn;
 			actionCounter = 0;
 			targetTeleport = Vector3.zero;
-            if (stopActionNow) {
-                throw new StopActionNow();
-            }
         }
 
-		public virtual void actionFinished(bool success, System.Object actionReturn = null, string errorMessage = null, bool stopActionNow = false) {
+		public virtual void actionFinished(bool success, object actionReturn = null, string errorMessage = null) {
             if (errorMessage != null) {
                 this.errorMessage = errorMessage;
             }
-            actionFinished(
-                success: success,
-                newState: AgentState.ActionComplete,
-                actionReturn: actionReturn,
-                stopActionNow: stopActionNow
-            );
+            actionFinished(success: success, newState: AgentState.ActionComplete, actionReturn: actionReturn);
             this.resumePhysics();
 		}
+
+        // immediately stops the execution of an action.
+        public void haltAction(bool success, object actionReturn = null, string errorMessage = null) {
+            actionFinished(success: success, actionReturn: actionReturn, errorMessage: errorMessage);
+            throw new StopActionNow();
+        }
 
         protected virtual void resumePhysics() {}
 

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -2031,8 +2031,8 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         break;
                     }
 
-                    // StopActionNow test!
-                case "san":
+                    // Short circuiting exception test
+                case "sc":
                     {
                         Dictionary<string, object> action = new Dictionary<string, object>();
                         action["action"] = "OpenObject";

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -2020,6 +2020,28 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         break;
                     }  
 
+                    // do nothing action
+                case "pass":
+                case "done":
+                case "noop":
+                    {
+                        Dictionary<string, object> action = new Dictionary<string, object>();
+                        action["action"] = "NoOp";
+                        PhysicsController.ProcessControlCommand(action);
+                        break;
+                    }
+
+                    // StopActionNow test!
+                case "san":
+                    {
+                        Dictionary<string, object> action = new Dictionary<string, object>();
+                        action["action"] = "OpenObject";
+                        action["x"] = 1.5;
+                        action["y"] = 0.5;
+                        PhysicsController.ProcessControlCommand(action);
+                        break;
+                    }
+
 					//move hand up, relative to agent's facing
 					//pass in move magnitude or default is 0.25 units
                 case "mhu":

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4630,50 +4630,50 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             // #endif
         }
 
-        //used for all actions that need a sim object target
-        //instead of objectId, use screen coordinates to raycast toward potential targets
-        //will set the target object by reference if raycast is succesful
-        public bool ScreenToWorldTarget(float x, float y, ref SimObjPhysics target, bool requireWithinViewportRange)
-        {
-            //float x = action.x;
-            y = 1.0f - y; //reverse the y so that the origin (0, 0) can be passed in as the top left of the screen
-            //cast ray from screen coordinate into world space. If it hits an object
+        // used for all actions that need a sim object target
+        // instead of objectId, use screen coordinates to raycast toward potential targets
+        // will set the target object by reference if raycast is succesful
+        public bool ScreenToWorldTarget(float x, float y, ref SimObjPhysics target, bool requireWithinViewportRange) {
+            // reverse the y so that the origin (0, 0) can be passed in as the top left of the screen
+            y = 1.0f - y;
+
+            // cast ray from screen coordinate into world space. If it hits an object
             Ray ray = m_Camera.ViewportPointToRay(new Vector3(x, y, 0.0f));
             RaycastHit hit;
-            //if something was touched, actionFinished(true) always
-            if(Physics.Raycast(ray, out hit, Mathf.Infinity, 1 << 0 | 1 << 8 | 1 << 10, QueryTriggerInteraction.Ignore))
-            {
-                if(hit.transform.GetComponent<SimObjPhysics>())
-                {
-                    //wait! First check if the point hit is withing visibility bounds (camera viewport, max distance etc)
-                    //this should basically only happen if the handDistance value is too big
-                    if(requireWithinViewportRange && !CheckIfTargetPositionIsInViewportRange(hit.point))
-                    {
-                        errorMessage = "target sim object at screen coordinate: (" + x + ", " + y + ") is not within the viewport";
-                        return false;
+
+            // if something was touched, actionFinished(true) always
+            if (Physics.Raycast(ray, out hit, Mathf.Infinity, 1 << 0 | 1 << 8 | 1 << 10, QueryTriggerInteraction.Ignore)) {
+                if (hit.transform.GetComponent<SimObjPhysics>()) {
+                    // wait! First check if the point hit is withing visibility bounds (camera viewport, max distance etc)
+                    // this should basically only happen if the handDistance value is too big
+                    if (requireWithinViewportRange && !CheckIfTargetPositionIsInViewportRange(hit.point)) {
+                        actionFinished(
+                            success: false,
+                            errorMessage: "target sim object at screen coordinate: (" + x + ", " + y + ") is not within the viewport",
+                            stopActionNow: true
+                        );
                     }
 
-                    //it is within viewport, so we are good, assign as target
+                    // it is within viewport, so we are good, assign as target
                     target = hit.transform.GetComponent<SimObjPhysics>();
                 }
             }
 
-            //try again, this time cast for placeable surface for things like countertops or interior of cabinets
-            //if no target was found in the layers above, try the SimObjInvisible layer. 
-            //additionally, if a target was found above, but that target was one of the SimObjPhysics Types that can have
-            //PlaceableSurfaces on it, also make sure to check again
-            if(target == null || hasPlaceableSurface.Contains(target.Type))
-            {
-                if(Physics.Raycast(ray, out hit, Mathf.Infinity, 1 << 11, QueryTriggerInteraction.Ignore))
-                {
-                    if(hit.transform.GetComponentInParent<SimObjPhysics>())
-                    {
-                        //wait! First check if the point hit is withing visibility bounds (camera viewport, max distance etc)
-                        //this should basically only happen if the handDistance value is too big
-                        if(requireWithinViewportRange && !CheckIfTargetPositionIsInViewportRange(hit.point))
-                        {
-                            errorMessage = "target sim object at screen coordinate: (" + x + ", " + y + ") is not within the viewport";
-                            return false;
+            // try again, this time cast for placeable surface for things like countertops or interior of cabinets
+            // if no target was found in the layers above, try the SimObjInvisible layer. 
+            // additionally, if a target was found above, but that target was one of the SimObjPhysics Types that can have
+            // PlaceableSurfaces on it, also make sure to check again
+            if (target == null || hasPlaceableSurface.Contains(target.Type)) {
+                if (Physics.Raycast(ray, out hit, Mathf.Infinity, 1 << 11, QueryTriggerInteraction.Ignore)) {
+                    if (hit.transform.GetComponentInParent<SimObjPhysics>()) {
+                        // wait! First check if the point hit is withing visibility bounds (camera viewport, max distance etc)
+                        // this should basically only happen if the handDistance value is too big
+                        if (requireWithinViewportRange && !CheckIfTargetPositionIsInViewportRange(hit.point)) {
+                            actionFinished(
+                                success: false,
+                                errorMessage: "target sim object at screen coordinate: (" + x + ", " + y + ") is not within the viewport",
+                                stopActionNow: true
+                            );
                         }
                         //it is within viewport, so we are good, assign as target
                         target = hit.transform.GetComponentInParent<SimObjPhysics>();
@@ -5119,16 +5119,12 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             actionFinished(true);
         }
 
-        // Helper method that parses objectId and (x and y) parameters to return the
-        // sim object that they target.
-        private SimObjPhysics getTargetObject(
-                string objectId,
-                bool forceAction = false
-        ) {
+        // Helper method that parses objectId parameter to return the sim object that it target.
+        // A stopActionNow exception is raised if the objectId does not appear in the scene.
+        private SimObjPhysics getTargetObject( string objectId, bool forceAction = false) {
             // an objectId was given, so find that target in the scene if it exists
             if (!physicsSceneManager.ObjectIdToSimObjPhysics.ContainsKey(objectId)) {
-                errorMessage = "Object ID appears to be invalid.";
-                return null;
+                actionFinished(success: false, errorMessage: "Object ID appears to be invalid.", stopActionNow: true);
             }
 
             // if object is in the scene and visible, assign it to 'target'
@@ -5136,6 +5132,12 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             foreach (SimObjPhysics sop in VisibleSimObjs(objectId: objectId, forceVisible: forceAction)) {
                 target = sop;
             }
+
+            // target not found!
+            if (target == null) {
+                actionFinished(success: false, errorMessage: "Target object not found within visibility.", stopActionNow: true);
+            }
+
             return target;
         }
 
@@ -5146,12 +5148,11 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             float y,
             bool forceAction
         ) {
-            // no target object specified, so instead try and use x/y screen coordinates
-            SimObjPhysics target = null;
-            if(!ScreenToWorldTarget((float) x, (float) y, ref target, !forceAction)) {
-                // error message is set inside ScreenToWorldTarget
-                return null;
+            if (x < 0 || x > 1 || y < 0 || y > 1) {
+                actionFinished(success: false, errorMessage: "x/y must be in [0:1].", stopActionNow: true);
             }
+            SimObjPhysics target = null;
+            ScreenToWorldTarget((float) x, (float) y, ref target, !forceAction);
             return target;
         }
 

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4647,7 +4647,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     // wait! First check if the point hit is withing visibility bounds (camera viewport, max distance etc)
                     // this should basically only happen if the handDistance value is too big
                     if (requireWithinViewportRange && !CheckIfTargetPositionIsInViewportRange(hit.point)) {
-                        haltAction(success: false, errorMessage: "target sim object at screen coordinate: (" + x + ", " + y + ") is not within the viewport");
+                        throw new InvalidOperationException($"Target sim object at screen coordinate: ({x}, {y}) is not within the viewport");
                     }
 
                     // it is within viewport, so we are good, assign as target
@@ -4665,15 +4665,15 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         // wait! First check if the point hit is withing visibility bounds (camera viewport, max distance etc)
                         // this should basically only happen if the handDistance value is too big
                         if (requireWithinViewportRange && !CheckIfTargetPositionIsInViewportRange(hit.point)) {
-                            haltAction(success: false, errorMessage: "target sim object at screen coordinate: (" + x + ", " + y + ") is not within the viewport");
+                            throw new InvalidOperationException($"Target sim object at screen coordinate: ({x}, {y}) is not within the viewport");
                         }
-                        //it is within viewport, so we are good, assign as target
+                        // it is within viewport, so we are good, assign as target
                         target = hit.transform.GetComponentInParent<SimObjPhysics>();
                     }
                 }
             }
 
-            //force update objects to be visible/interactable correctly
+            // force update objects to be visible/interactable correctly
             VisibleSimObjs(false);
             return true;
         }
@@ -5113,10 +5113,10 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
         // Helper method that parses objectId parameter to return the sim object that it target.
         // The action is halted if the objectId does not appear in the scene.
-        private SimObjPhysics getTargetObject( string objectId, bool forceAction = false) {
+        private SimObjPhysics getTargetObject(string objectId, bool forceAction = false) {
             // an objectId was given, so find that target in the scene if it exists
             if (!physicsSceneManager.ObjectIdToSimObjPhysics.ContainsKey(objectId)) {
-                haltAction(success: false, errorMessage: "Object ID appears to be invalid.");
+                throw new ArgumentException($"objectId: {objectId} is not the objectId on any object in the scene!");
             }
 
             // if object is in the scene and visible, assign it to 'target'
@@ -5127,7 +5127,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             // target not found!
             if (target == null) {
-                haltAction(success: false, errorMessage: "Target object not found within visibility.");
+                throw new NullReferenceException("Target object not found within the specified visibility.");
             }
 
             return target;
@@ -5135,13 +5135,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
         // Helper method that parses (x and y) parameters to return the
         // sim object that they target.
-        private SimObjPhysics getTargetObject(
-            float x,
-            float y,
-            bool forceAction
-        ) {
+        private SimObjPhysics getTargetObject(float x, float y, bool forceAction) {
             if (x < 0 || x > 1 || y < 0 || y > 1) {
-                haltAction(success: false, errorMessage: "x/y must be in [0:1].");
+                throw new ArgumentOutOfRangeException("x/y must be in [0:1]");
             }
             SimObjPhysics target = null;
             ScreenToWorldTarget((float) x, (float) y, ref target, !forceAction);
@@ -5149,10 +5145,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
         // syntactic sugar for open object with openness = 0.
-        public void CloseObject(
-            string objectId,
-            bool forceAction = false
-        ) {
+        public void CloseObject(string objectId, bool forceAction = false) {
             OpenObject(objectId: objectId, forceAction: forceAction, openness: 0);
         }
 

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4647,11 +4647,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     // wait! First check if the point hit is withing visibility bounds (camera viewport, max distance etc)
                     // this should basically only happen if the handDistance value is too big
                     if (requireWithinViewportRange && !CheckIfTargetPositionIsInViewportRange(hit.point)) {
-                        actionFinished(
-                            success: false,
-                            errorMessage: "target sim object at screen coordinate: (" + x + ", " + y + ") is not within the viewport",
-                            stopActionNow: true
-                        );
+                        haltAction(success: false, errorMessage: "target sim object at screen coordinate: (" + x + ", " + y + ") is not within the viewport");
                     }
 
                     // it is within viewport, so we are good, assign as target
@@ -4669,11 +4665,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         // wait! First check if the point hit is withing visibility bounds (camera viewport, max distance etc)
                         // this should basically only happen if the handDistance value is too big
                         if (requireWithinViewportRange && !CheckIfTargetPositionIsInViewportRange(hit.point)) {
-                            actionFinished(
-                                success: false,
-                                errorMessage: "target sim object at screen coordinate: (" + x + ", " + y + ") is not within the viewport",
-                                stopActionNow: true
-                            );
+                            haltAction(success: false, errorMessage: "target sim object at screen coordinate: (" + x + ", " + y + ") is not within the viewport");
                         }
                         //it is within viewport, so we are good, assign as target
                         target = hit.transform.GetComponentInParent<SimObjPhysics>();
@@ -5120,11 +5112,11 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
         // Helper method that parses objectId parameter to return the sim object that it target.
-        // A stopActionNow exception is raised if the objectId does not appear in the scene.
+        // The action is halted if the objectId does not appear in the scene.
         private SimObjPhysics getTargetObject( string objectId, bool forceAction = false) {
             // an objectId was given, so find that target in the scene if it exists
             if (!physicsSceneManager.ObjectIdToSimObjPhysics.ContainsKey(objectId)) {
-                actionFinished(success: false, errorMessage: "Object ID appears to be invalid.", stopActionNow: true);
+                haltAction(success: false, errorMessage: "Object ID appears to be invalid.");
             }
 
             // if object is in the scene and visible, assign it to 'target'
@@ -5135,7 +5127,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             // target not found!
             if (target == null) {
-                actionFinished(success: false, errorMessage: "Target object not found within visibility.", stopActionNow: true);
+                haltAction(success: false, errorMessage: "Target object not found within visibility.");
             }
 
             return target;
@@ -5149,7 +5141,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             bool forceAction
         ) {
             if (x < 0 || x > 1 || y < 0 || y > 1) {
-                actionFinished(success: false, errorMessage: "x/y must be in [0:1].", stopActionNow: true);
+                haltAction(success: false, errorMessage: "x/y must be in [0:1].");
             }
             SimObjPhysics target = null;
             ScreenToWorldTarget((float) x, (float) y, ref target, !forceAction);


### PR DESCRIPTION
## Overview

This PR allows short circuiting action failures, which may terminate the action immediately (from any function call).

We also encourage error messages to be set within the invoked exception, so

```c#
if (failure) {
    actionFinished(success: false);
    errorMessage = "Failure because of XXX.";
    return;
}
```
becomes:
```c#
if (failure) {
    throw new <...Exception>("Failure because of XXX.");
}
```
In the former case, too, notice that errorMessage would never execute if `actionFinished` was refactored to throw an exception.


## Motivation

A ton of actions are functionalized. For instance, 
* `OpenObject(x, y, forceAction)` calls `getTargetObject(x, y, forceAction)` which calls `ScreenToWorldTarget(x, y, ...)`.

Previously, if `ScreenToWorldTarget` had an error, all it would do was set the `errorMessage`, but it could not end the action right there. Instead, it would have to shakily rely on `getTargetObject` and `OpenObject` to catch that there was an error by returning null.

Often, inside the null catches, less specific error messages are overwritten, because the outer functions don't know if the inner functions wrote a better error message:
```c#
PushObject(...) {
    returnedValue = getTargetObject(...);
    if (returnedValue == null) {
        errorMessage = "maybe this happened inside of getTargetObject";
        actionFinished(success: false);
        return;
    }
    // ...
}

getTargetObject(...) {
    returnedValue = ScreenToWorldTarget(...);
    if (returnedValue == null) {
        errorMessage = "maybe this happened inside of ScreenToWorldTarget";
        return;
    }
    // ...
}

ScreenToWorldTarget(...) {
    if (failure) {
        errorMessage = "specific error message";
        return null;
    }
}
```

Now, instead of all these checks, we can short-circuit the action failure and terminate immediately, which refactors to:
```c#
PushObject(...) {
    returnedValue = getTargetObject(...);
}

getTargetObject(...) {
    returnedValue = ScreenToWorldTarget(...);
}

ScreenToWorldTarget(...) {
    if (failure) {
        throw new <...Exception>("specific error message");
    }
}
```
where the action terminates immediately when the exception is thrown.

## Avoiding Early Termination

In rare cases, actions may not actually want to terminate upon failure. Here, these actions can use try/catch statements to avoid such early stoppage. For instance:
```c#
OpenAllObjects(...) {
    for each openable object
        try {
            openObject(...)
        } catch (InvalidOperationException e) { }
}
```
which will do nothing if the `InvalidOperationException` is encountered upon calling `openObject`.

## Backwards compatibility

Everything should be fully backward compatible.

## Refactoring Note

This PR doesn't clean up every possible case where short-circuiting can be applied. Rather, just a few for now, since the functionality is just being proposed.