### PR TITLE
Better Event summarization in Event.__repr__ and Event.__str__

### DIFF
--- a/ai2thor/server.py
+++ b/ai2thor/server.py
@@ -119,7 +119,7 @@ class Event(object):
         return (
             '<ai2thor.server.Event at ' + hex(id(self)) + '\n' +
             '\t.metadata["lastActionSuccess"] = ' + self.metadata['lastActionSuccess'] + '\n' +
-            '\t.metadata["errorMessage"] = ' + self.metadata['errorMessage'] + '\n' +
+            '\t.metadata["errorMessage"] = "' + self.metadata['errorMessage'] + '"\n' +
             '\t.metadata["actionReturn"] = ' + self.metadata['actionReturn'] + '\n' +
             '>'
         )

--- a/ai2thor/server.py
+++ b/ai2thor/server.py
@@ -114,6 +114,19 @@ class Event(object):
 
         self.events = [self] # Ensure we have a similar API to MultiAgentEvent
 
+    def __repr__(self):
+        """Summarizes the results from an Event.""" 
+        return (
+            '<ai2thor.server.Event at ' + hex(id(self)) + '\n' +
+            '\t.metadata["lastActionSuccess"] = ' + self.metadata['lastActionSuccess'] + '\n' +
+            '\t.metadata["errorMessage"] = ' + self.metadata['errorMessage'] + '\n' +
+            '\t.metadata["actionReturn"] = ' + self.metadata['actionReturn'] + '\n' +
+            '>'
+        )
+
+    def __str__(self):
+        return self.__repr__()
+
     @property
     def image_data(self):
         warnings.warn("Event.image_data has been removed - RGB data can be retrieved from event.frame and encoded to an image format")


### PR DESCRIPTION
Currently, printing or viewing the result of an `ai2thor.server.Event` is not particularly helpful, since it only shows:
```python
<ai2thor.server.Event at {hex ID in memory}>
```
This is particularly annoying in notebooks, since one then must always immediately call:
```python
event.metadata['lastActionSuccess']
event.metadata['errorMessage']
event.metadata['actionReturn']
```
to see if anything happened.

This PR now adds this summary information to the Event, so when users print or evaluate the Event, they will see something like:
```python
<ai2thor.server.Event at 0x7f213063ed30
    .metadata['lastActionSuccess'] = True
    .metadata['errorMessage'] = ""
    .metadata['actionReturn'] = None
>
```

As an added benefit, it also shows new users that there is a `.metadata['lastActionSuccess']`, `.metadata['errorMessage']`, and `.metadata['actionReturn']`.