### PR TITLE
Bug fixes to and enhancements to ProcessControlCommand inside of AgentManager

### DIFF
--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -684,7 +684,7 @@ class Controller(object):
         self.server.send(action)
         self.last_event = self.server.receive()
 
-        if not self.last_event.metadata['lastActionSuccess'] and self.last_event.metadata['errorCode'] in ['InvalidAction', 'MissingArguments', 'AmbiguousAction']:
+        if not self.last_event.metadata['lastActionSuccess'] and self.last_event.metadata['errorCode'] in ['InvalidAction', 'MissingArguments', 'AmbiguousAction', 'InvalidArgument']:
             raise ValueError(self.last_event.metadata['errorMessage'])
 
         if raise_for_failure:

--- a/ai2thor/fifo_server.py
+++ b/ai2thor/fifo_server.py
@@ -83,7 +83,7 @@ class FifoServer(ai2thor.server.Server):
             FieldType.THIRD_PARTY_IMAGE_IDS,
             FieldType.THIRD_PARTY_CLASSES,
             FieldType.THIRD_PARTY_FLOW
-            }
+        }
 
         self.eom_header = self._create_header(FieldType.END_OF_MESSAGE, b'')
         super().__init__(width, height, depth_format, add_depth_noise)
@@ -175,7 +175,7 @@ class FifoServer(ai2thor.server.Server):
 
         # need to switch this to msgpack
         self._send_message(FieldType.ACTION, json.dumps(action, cls=ai2thor.server.NumpyAwareEncoder).encode('utf8'))
-    
+
     def start(self):
         os.mkfifo(self.server_pipe_path)
         os.mkfifo(self.client_pipe_path)

--- a/ai2thor/server.py
+++ b/ai2thor/server.py
@@ -78,7 +78,7 @@ def unique_rows(arr, return_index=False, return_inverse=False):
 
 class Event(object):
     """
-    Object that is returned from a call to  controller.step().
+    Object that is returned from a call to controller.step().
     This class wraps the screenshot that Unity captures as well
     as the metadata sent about each object
     """

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -220,6 +220,24 @@ def test_add_third_party_camera(controller):
     assert_near(camera[ThirdPartyCameraMetadata.rotation], expectedRotation, 'initial rotation should have been set')
     assert camera[ThirdPartyCameraMetadata.fieldOfView] == expectedFieldOfView, 'initial fieldOfView should have been set'
 
+    # expects position to be a Vector3, should fail!
+    event = controller.step(
+        action="AddThirdPartyCamera",
+        position=5,
+        rotation=dict(x=0, y=0, z=0)
+    )
+    assert not event.metadata['lastActionSuccess'], 'position should not allow float input!'
+
+    # orthographicSize expects float, not Vector3!
+    event = controller.step(
+        action="AddThirdPartyCamera",
+        position=dict(x=0, y=0, z=0),
+        rotation=dict(x=0, y=0, z=0),
+        orthographic=True,
+        orthographicSize=dict(x=0, y=0, z=0)
+    )
+    assert not event.metadata['lastActionSuccess'], 'orthographicSize should not allow Vector3 input!'
+
 
 def test_update_third_party_camera():
     controller = build_controller(server_class=FifoServer)

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -229,14 +229,18 @@ def test_add_third_party_camera(controller):
     assert not event.metadata['lastActionSuccess'], 'position should not allow float input!'
 
     # orthographicSize expects float, not Vector3!
-    event = controller.step(
-        action="AddThirdPartyCamera",
-        position=dict(x=0, y=0, z=0),
-        rotation=dict(x=0, y=0, z=0),
-        orthographic=True,
-        orthographicSize=dict(x=0, y=0, z=0)
-    )
-    assert not event.metadata['lastActionSuccess'], 'orthographicSize should not allow Vector3 input!'
+    error_message = None
+    try:
+        event = controller.step(
+            action="AddThirdPartyCamera",
+            position=dict(x=0, y=0, z=0),
+            rotation=dict(x=0, y=0, z=0),
+            orthographic=True,
+            orthographicSize=dict(x=0, y=0, z=0)
+        )
+    except ValueError as e:
+        error_message = str(e)
+    assert error_message == "action: AddThirdPartyCamera has invalid an argument: orthographicSize. Cannot cast to: Nullable`1"
 
 
 def test_update_third_party_camera():

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -240,7 +240,7 @@ def test_add_third_party_camera(controller):
         )
     except ValueError as e:
         error_message = str(e)
-    assert error_message == "action: AddThirdPartyCamera has invalid an argument: orthographicSize. Cannot cast to: Nullable`1"
+    assert error_message == "action: AddThirdPartyCamera has an invalid argument: orthographicSize. Cannot convert to: float"
 
 
 def test_update_third_party_camera():

--- a/unity/Assets/Scripts/ActionDispatcher.cs
+++ b/unity/Assets/Scripts/ActionDispatcher.cs
@@ -116,9 +116,9 @@ public static class ActionDispatcher {
         return methodCache[targetType];
     }
 
-    // Find public/void methods that have matching Method names and idenitical parameter names,
+    // Find public/void methods that have matching Method names and identical parameter names,
     // but either different parameter order or parameter types which make dispatching
-    // ambiguous.  This method is used during testing to find conflicts.
+    // ambiguous. This method is used during testing to find conflicts.
     public static Dictionary<string, List<string>> FindMethodVariableNameConflicts(Type targetType) {
         MethodInfo[] allMethods = getMethods(targetType);
         Dictionary<string, List<string>> methodConflicts = new Dictionary<string, List<string>>();

--- a/unity/Assets/Scripts/ActionDispatcher.cs
+++ b/unity/Assets/Scripts/ActionDispatcher.cs
@@ -320,7 +320,11 @@ public static class ActionDispatcher {
             for(int i = 0; i < methodParams.Length; i++) {
                 System.Reflection.ParameterInfo pi = methodParams[i];
                 if (dynamicServerAction.ContainsKey(pi.Name)) {
-                    arguments[i] = dynamicServerAction.GetValue(pi.Name).ToObject(pi.ParameterType);
+                    try {
+                        arguments[i] = dynamicServerAction.GetValue(pi.Name).ToObject(pi.ParameterType);
+                    } catch (ArgumentException ex) {
+                        throw new ToObjectArgumentActionException(pi.Name, pi.ParameterType, ex);
+                    }
                 } else {
                     if (!pi.HasDefaultValue)  {
                         if (missingArguments == null) {
@@ -375,6 +379,18 @@ public class InvalidActionException : Exception { }
 [Serializable]
 public class AmbiguousActionException : Exception { 
     public AmbiguousActionException(string message) : base(message) {}
+}
+
+[Serializable]
+public class ToObjectArgumentActionException : Exception {
+    public string parameterName;
+    public ArgumentException innerException;
+    public Type parameterType;
+    public ToObjectArgumentActionException (string parameterName, Type parameterType, ArgumentException ex) {
+        this.parameterName = parameterName;
+        this.parameterType = parameterType;
+        this.innerException = ex;
+    }
 }
 
 [Serializable]

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -753,7 +753,8 @@ public class AgentManager : MonoBehaviour
 			yield return new WaitForEndOfFrame();
 		}
 
-		string msg = "{\"action\": \"RotateRight\", \"timeScale\": 90.0}";
+        // NOTE: sequenceId is required in DynamicServerAction.
+		string msg = "{\"action\": \"RotateRight\", \"timeScale\": 90.0, \"sequenceId\": 0}";
 		ProcessControlCommand(msg);
 	}
 

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1075,13 +1075,9 @@ public class AgentManager : MonoBehaviour
 
 		if (agentManagerActions.Contains(controlCommand.action)) {
             this.agentManagerState = AgentState.Processing;
-            try {
-                ActionDispatcher.Dispatch(this, controlCommand);
-            } catch (MissingArgumentsActionException e) {
-                string errorMessage = "action: " + controlCommand.action + " is missing the following arguments: " + string.Join(",", e.ArgumentNames.ToArray());
-                Debug.LogError(errorMessage);
-                actionError(errorMessage, controlCommand.action.ToString(), ServerActionErrorCode.MissingArguments);
-            }
+
+            // let's look in this file for the action
+            this.activeAgent().ProcessControlCommand(controlCommand: controlCommand, target: this);
 		} else {
             //we only allow renderObjectImage to be flipped on
             //on a per step() basis, since by default the param is null
@@ -1096,7 +1092,9 @@ public class AgentManager : MonoBehaviour
                 updateImageSynthesis(true);
                 updateThirdPartyCameraImageSynthesis(true);
             }
-			this.activeAgent().ProcessControlCommand (controlCommand);
+
+            // let's look in the agent's set of actions for the action
+			this.activeAgent().ProcessControlCommand(controlCommand: controlCommand);
 		}
 	}
 

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -357,9 +357,18 @@ public class AgentManager : MonoBehaviour
         float? orthographicSize,
         string actionName
     ) {
+        if (orthographic != true && orthographicSize != null) {
+            throw new InvalidOperationException(
+                $"orthographicSize(: {orthographicSize}) can only be set when orthographic=True.\n" +
+                "Otherwise, we use assume perspective camera setting." +
+                "Hint: call .step(..., orthographic=True)."
+            );
+        }
+
         // update the position and rotation
         camera.gameObject.transform.position = position;
         camera.gameObject.transform.eulerAngles = rotation;
+
 
         // updates the camera's perspective
         camera.fieldOfView = fieldOfView;

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1662,7 +1662,8 @@ public enum ServerActionErrorCode  {
 	LookDownCantExceedMin,
 	InvalidAction,
     MissingArguments,
-	AmbiguousAction
+	AmbiguousAction,
+    InvalidArgument
 }
 
 public enum VisibilityScheme {

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1061,11 +1061,10 @@ public class AgentManager : MonoBehaviour
 		return this.agents[activeAgentId];
 	}
 
-	private void ProcessControlCommand(string msg)
-	{
-
+    // making it public makes it accessible from debug input field
+	private void ProcessControlCommand(string msg) {
         this.renderObjectImage = this.defaultRenderObjectImage;
-        
+
         DynamicServerAction controlCommand = new DynamicServerAction(msg); //jObject);
 
 		this.currentSequenceId = controlCommand.sequenceId;
@@ -1074,9 +1073,7 @@ public class AgentManager : MonoBehaviour
         this.activeAgentId = controlCommand.agentId;
 
 		if (agentManagerActions.Contains(controlCommand.action)) {
-            this.agentManagerState = AgentState.Processing;
-
-            // let's look in this file for the action
+            // let's look in this class for the action
             this.activeAgent().ProcessControlCommand(controlCommand: controlCommand, target: this);
 		} else {
             //we only allow renderObjectImage to be flipped on

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -753,8 +753,7 @@ public class AgentManager : MonoBehaviour
 			yield return new WaitForEndOfFrame();
 		}
 
-        // NOTE: sequenceId is required in DynamicServerAction.
-		string msg = "{\"action\": \"RotateRight\", \"timeScale\": 90.0, \"sequenceId\": 0}";
+		string msg = "{\"action\": \"RotateRight\", \"timeScale\": 90.0}";
 		ProcessControlCommand(msg);
 	}
 

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1528,31 +1528,31 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 // TargetInvocationException is called whenever an action
                 // throws an exception. It is used to short circuit errors,
                 // which terminates the action immediately.
-                string errorMsg = e.InnerException.Message;
-
-                // Newtonian.JSON doesn't provide particularly nice error messages.
-                // Let's give a better hint.
-                if (errorMsg.Contains("Newtonsoft.Json")) {
-                    actionFinished(
-                        success: false,
-                        errorMessage: (
-                            $"{e.InnerException.GetType().Name}: " + "An argument has an unparsable type." +
-                            $"(For instance, maybe you're passing in a dict, when we expect a float). {errorMsg}"
-                        )
-                    );
-                } else {
-                    actionFinished(
-                        success: false,
-                        errorMessage: $"{e.InnerException.GetType().Name}: {errorMsg}"
-                    );
-                }
+                actionFinished(
+                    success: false,
+                    errorMessage: $"{e.InnerException.GetType().Name}: {e.InnerException.Message}"
+                );
             }
             catch (Exception e)
             {
                 Debug.LogError("Caught error with invoke for action: " + controlCommand.action);
                 Debug.LogError("Action error message: " + errorMessage);
                 errorMessage += e.ToString();
-                actionFinished(false);
+
+                // Newtonian.JSON doesn't provide particularly nice error messages.
+                // Let's give a better hint.
+                if (errorMessage.Contains("Newtonsoft.Json")) {
+                    // sadly, the error message does not say which argument is invalid :(
+                    actionFinished(
+                        success: false,
+                        errorMessage: (
+                            "An argument has an invalid type. " +
+                            $"For instance, maybe you're passing in a dict/object, when we expect a float. {errorMessage}"
+                        )
+                    );
+                } else {
+                    actionFinished(success: false, errorMessage: errorMessage);
+                }
             }
 
             #if UNITY_EDITOR

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1449,33 +1449,33 @@ namespace UnityStandardAssets.Characters.FirstPerson
         // This should only be used by DebugInputField and HideNSeekController
         // Once all those invocations have been converted to Dictionary<string, object>
         // this can be removed
-        public void ProcessControlCommand(ServerAction controlCommand)
+        public void ProcessControlCommand(ServerAction serverAction)
         {
 
             errorMessage = "";
             errorCode = ServerActionErrorCode.Undefined;
             collisionsInAction = new List<string>();
 
-            lastAction = controlCommand.action;
+            lastAction = serverAction.action;
             lastActionSuccess = false;
             lastPosition = new Vector3(transform.position.x, transform.position.y, transform.position.z);
-			System.Reflection.MethodInfo method = this.GetType().GetMethod(controlCommand.action);
+			System.Reflection.MethodInfo method = this.GetType().GetMethod(serverAction.action);
 			
             this.agentState = AgentState.Processing;
 			try
 			{
 				if (method == null) {
-					errorMessage = "Invalid action: " + controlCommand.action;
+					errorMessage = "Invalid action: " + serverAction.action;
 					errorCode = ServerActionErrorCode.InvalidAction;
 					Debug.LogError(errorMessage);
 					actionFinished(false);
 				} else {
-					method.Invoke(this, new object[] { controlCommand });
+					method.Invoke(this, new object[] { serverAction });
 				}
 			}
 			catch (Exception e)
 			{
-				Debug.LogError("Caught error with invoke for action: " + controlCommand.action);
+				Debug.LogError("Caught error with invoke for action: " + serverAction.action);
                 Debug.LogError("Action error message: " + errorMessage);
 				Debug.LogError(e);
 

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1560,21 +1560,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 Debug.LogError("Caught error with invoke for action: " + controlCommand.action);
                 Debug.LogError("Action error message: " + errorMessage);
                 errorMessage += e.ToString();
-
-                // Newtonian.JSON doesn't provide particularly nice error messages.
-                // Let's give a better hint.
-                if (errorMessage.Contains("Newtonsoft.Json")) {
-                    // sadly, the error message does not say which argument is invalid :(
-                    actionFinished(
-                        success: false,
-                        errorMessage: (
-                            "An argument has an invalid type. " +
-                            $"For instance, maybe you're passing in a dict/object, when we expect a float. {errorMessage}"
-                        )
-                    );
-                } else {
-                    actionFinished(success: false, errorMessage: errorMessage);
-                }
+                actionFinished(success: false, errorMessage: errorMessage);
             }
 
             #if UNITY_EDITOR

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1510,6 +1510,12 @@ namespace UnityStandardAssets.Characters.FirstPerson
             {
                 ActionDispatcher.Dispatch(target: target, dynamicServerAction: controlCommand);
             }
+            catch (ToObjectArgumentActionException e)
+            {
+                errorMessage = "action: " + controlCommand.action + " has an invalid argument: " + e.parameterName + ". Cannot cast to: " + e.parameterType.Name;
+                errorCode = ServerActionErrorCode.InvalidArgument;
+                actionFinished(false);
+            }
             catch (MissingArgumentsActionException e)
             {
                 errorMessage = "action: " + controlCommand.action + " is missing the following arguments: " + string.Join(",", e.ArgumentNames.ToArray());

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1492,7 +1492,11 @@ namespace UnityStandardAssets.Characters.FirstPerson
             ProcessControlCommand(new DynamicServerAction(actionDict));
         }
 
-        public void ProcessControlCommand(DynamicServerAction controlCommand, object target = null) {
+        public void ProcessControlCommand(DynamicServerAction controlCommand) {
+            ProcessControlCommand(controlCommand: controlCommand, target: this);
+        }
+
+        public void ProcessControlCommand(DynamicServerAction controlCommand, object target) {
             errorMessage = "";
             errorCode = ServerActionErrorCode.Undefined;
             collisionsInAction = new List<string>();
@@ -1504,7 +1508,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
             try
             {
-                ActionDispatcher.Dispatch(target: target == null ? this : target, dynamicServerAction: controlCommand);
+                ActionDispatcher.Dispatch(target: target, dynamicServerAction: controlCommand);
             }
             catch (MissingArgumentsActionException e)
             {

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1493,7 +1493,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             ProcessControlCommand(new DynamicServerAction(actionDict));
         }
 
-        public void ProcessControlCommand(DynamicServerAction controlCommand, object target = this) {
+        public void ProcessControlCommand(DynamicServerAction controlCommand, object target = null) {
             errorMessage = "";
             errorCode = ServerActionErrorCode.Undefined;
             collisionsInAction = new List<string>();
@@ -1505,7 +1505,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
             try
             {
-                ActionDispatcher.Dispatch(target: target, dynamicServerAction: controlCommand);
+                ActionDispatcher.Dispatch(target: target == null ? this : target, dynamicServerAction: controlCommand);
             }
             catch (MissingArgumentsActionException e)
             {

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -129,11 +129,10 @@ namespace UnityStandardAssets.Characters.FirstPerson
 		protected CollisionFlags m_CollisionFlags;
 		protected Vector3 lastPosition;
 
-        // These are public for actions outside of the agent context (e.g., AddThirdPartyCamera)
-        public string lastAction;
-        public bool lastActionSuccess;
-        public string errorMessage;
-        public ServerActionErrorCode errorCode;
+        protected string lastAction;
+        protected bool lastActionSuccess;
+        protected string errorMessage;
+        protected ServerActionErrorCode errorCode;
 
 		public System.Object actionReturn;
         [SerializeField] protected Vector3 standingLocalCameraPosition;

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1512,7 +1512,19 @@ namespace UnityStandardAssets.Characters.FirstPerson
             }
             catch (ToObjectArgumentActionException e)
             {
-                errorMessage = "action: " + controlCommand.action + " has an invalid argument: " + e.parameterName + ". Cannot cast to: " + e.parameterType.Name;
+                Dictionary<string, string> typeMap = new Dictionary<string, string>{
+                    {"Single", "float"},
+                    {"Double", "float"},
+                    {"Int16", "int"},
+                    {"Int32", "int"},
+                    {"Int64", "int"}
+                };
+                Type underlingType = Nullable.GetUnderlyingType(e.parameterType);
+                string typeName = underlingType == null ? e.parameterType.Name : underlingType.Name;
+                if (typeMap.ContainsKey(typeName)) {
+                    typeName = typeMap[typeName];
+                }
+                errorMessage = "action: " + controlCommand.action + " has an invalid argument: " + e.parameterName + ". Cannot convert to: " + typeName;
                 errorCode = ServerActionErrorCode.InvalidArgument;
                 actionFinished(false);
             }

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -791,7 +791,9 @@ namespace UnityStandardAssets.Characters.FirstPerson
                     {
                         AManager.AddThirdPartyCamera(
                             position: Vector3.zero,
-                            rotation: Vector3.zero
+                            rotation: Vector3.zero,
+                            orthographic: true,
+                            orthographicSize: 5
                         );
                         break;
                     }


### PR DESCRIPTION
Reuses the equivalent `ProcessControlCommand` from `BaseFPSAgentController`, but parameterizes the `target` object reference. 

Using the same idea, we can now call `actionFinished` and throw exceptions (#578) from `AddThirdPartyCamera` and `UpdateThirdPartyCamera` instead of the whole `actionError` and `actionSuccess` shenanigans that has been removed.

This also then fixes (and tests) many hanging bugs, such as:
```python
controller.step('AddThirdPartyCamera', ..., orthographicSize=dict(x=5, y=5))
```
where we expect `orthographicSize` to be a float.

Finally, we provide a better error message in the case that the types mismatch than what is currently provided by Json.Net.