### PR TITLE
defaulting fastActionEmit to true in ServerAction; updating Reset/Set…

### DIFF
--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -100,19 +100,18 @@ def test_reset():
     assert event.frame.shape == (height, width, 3), "RGB frame dimensions are wrong!"
     controller.stop()
 
-def test_fast_emit():
-    fast_controller = build_controller(server_class=FifoServer, fastActionEmit=True)
-    event = fast_controller.step(dict(action='RotateRight'))
-    event_fast_emit = fast_controller.step(dict(action='TestFastEmit', rvalue='foo'))
-    event_no_fast_emit = fast_controller.step(dict(action='LookUp'))
-    event_no_fast_emit_2 = fast_controller.step(dict(action='RotateRight'))
+@pytest.mark.parametrize("controller", [fifo_controller])
+def test_fast_emit(controller):
+    event = controller.step(dict(action='RotateRight'))
+    event_fast_emit = controller.step(dict(action='TestFastEmit', rvalue='foo'))
+    event_no_fast_emit = controller.step(dict(action='LookUp'))
+    event_no_fast_emit_2 = controller.step(dict(action='RotateRight'))
 
     assert event.metadata['actionReturn'] is None
     assert event_fast_emit.metadata['actionReturn'] == 'foo' 
     assert id(event.metadata['objects']) ==  id(event_fast_emit.metadata['objects'])
     assert id(event.metadata['objects']) !=  id(event_no_fast_emit.metadata['objects'])
     assert id(event_no_fast_emit_2.metadata['objects']) !=  id(event_no_fast_emit.metadata['objects'])
-    fast_controller.stop()
 
 @pytest.mark.parametrize("controller", [fifo_controller])
 def test_fifo_large_input(controller):
@@ -120,12 +119,13 @@ def test_fifo_large_input(controller):
     event = controller.step(dict(action='TestActionReflectParam', rvalue=random_string))
     assert event.metadata['actionReturn'] == random_string
 
-@pytest.mark.parametrize("controller", [fifo_controller])
-def test_fast_emit_disabled(controller):
-    event = controller.step(dict(action='RotateRight'))
-    event_fast_emit = controller.step(dict(action='TestFastEmit', rvalue='foo'))
+def test_fast_emit_disabled():
+    slow_controller = build_controller(server_class=FifoServer, fastActionEmit=False)
+    event = slow_controller.step(dict(action='RotateRight'))
+    event_fast_emit = slow_controller.step(dict(action='TestFastEmit', rvalue='foo'))
     # assert that when actionFastEmit is off that the objects are different
     assert id(event.metadata['objects']) !=  id(event_fast_emit.metadata['objects'])
+    slow_controller.stop()
 
 
 @pytest.mark.parametrize("controller", [wsgi_controller, fifo_controller])

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1591,7 +1591,7 @@ public class ServerAction
 	public float TimeToWaitForObjectsToComeToRest = 10.0f;
 	public float scale;
     public string visibilityScheme = VisibilityScheme.Collider.ToString();
-    public bool fastActionEmit;
+    public bool fastActionEmit = true;
     // this allows us to chain the dispatch between two separate
     // legacy action (e.g. AgentManager.Initialize and BaseFPSAgentController.Initialize)
     public DynamicServerAction dynamicServerAction;

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1119,7 +1119,11 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
         public void ResetObjectFilter() {
             this.simObjFilter = null;
-            actionFinishedEmit(true);
+            // this could technically be a FastEmit action
+            // but could cause confusion since the result of this 
+            // action should return all the objects. Resetting the filter
+            // should cause all the objects to get returned, which FastEmit would not do.
+            actionFinished(true);
         }
         public void SetObjectFilter(string[] objectIds) {
             SimObjPhysics[] simObjects = GameObject.FindObjectsOfType<SimObjPhysics>();
@@ -1131,7 +1135,12 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 }
             }
             simObjFilter = filter.ToArray();
-            actionFinishedEmit(true);
+            // this could technically be a FastEmit action
+            // but could cause confusion since the result of this 
+            // action should return a limited set of objects. Setting the filter
+            // should cause only the objects in the filter to get returned, 
+            // which FastEmit would not do.
+            actionFinished(true);
         }
 
         public virtual ObjectMetadata[] generateObjectMetadata()


### PR DESCRIPTION
…ObjecFilter to not use fastActionEmit since calling these should result in a change to the metadata[objects]