### PR TITLE
Removing strange restrictions on arguments to methods checking if movement is possible.

### DIFF
--- a/scripts/update_private.py
+++ b/scripts/update_private.py
@@ -4,40 +4,41 @@
 Script that maintains the Private directory checkout - intended to be run 
 immediately after switching branches in the parent ai2thor project
 """
-import subprocess
 import os
+import subprocess
+
 private_repo_url = "https://github.com/allenai/ai2thor-private"
 base_dir = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath(__file__)) , ".."))
 private_dir = os.path.join(base_dir, "unity", "Assets", "Private")
 
 def current_branch():
     git_dir = os.path.join(base_dir, '.git')
-    return subprocess.check_output("git --git-dir=%s rev-parse --abbrev-ref HEAD" % git_dir, shell=True).decode('ascii').strip()
+    return subprocess.check_output(f"git --git-dir={git_dir} rev-parse --abbrev-ref HEAD", shell=True).decode('ascii').strip()
 
 
-def checkout_branch():
+def checkout_branch(remote="origin"):
     if not os.path.isdir(private_dir):
-        subprocess.check_call("git clone %s %s" % (private_repo_url, private_dir), shell=True)
+        subprocess.check_call(f"git clone {private_repo_url} {private_dir}", shell=True)
 
     cwd = os.getcwd()
     os.chdir(private_dir)
     branch = current_branch()
     try:
-        print("Trying to checkout checkout %s -> %s" % (private_dir, branch))
-        subprocess.check_call("git fetch origin %s" % branch, shell=True)
-        subprocess.check_call("git checkout %s" % branch, shell=True)
-        subprocess.check_call("git pull origin %s" % branch, shell=True)
+        print(f"Trying to checkout {private_dir} -> {branch}")
+        subprocess.check_call(f"git fetch {remote} {branch}", shell=True)
+        subprocess.check_call(f"git checkout {branch}", shell=True)
+        subprocess.check_call(f"git pull {remote} {branch}", shell=True)
     except subprocess.CalledProcessError as e:
-        print("No branch exists for private: %s - remaining on master" % branch )
-        subprocess.check_call("git fetch origin master", shell=True)
-        subprocess.check_call("git checkout master", shell=True)
-        subprocess.check_call("git pull origin master", shell=True)
+        print(f"No branch exists for private: {branch} - remaining on master" )
+        subprocess.check_call(f"git fetch {remote} master", shell=True)
+        subprocess.check_call(f"git checkout master", shell=True)
+        subprocess.check_call(f"git pull {remote} master", shell=True)
 
     os.chdir(cwd)
 
 
 if __name__ == "__main__":
     if not os.path.isdir(private_dir) and os.path.exists(private_dir):
-        raise Exception("Private directory %s is not a directory - please remove" % private_dir)
+        raise Exception(f"Private directory {private_dir} is not a directory - please remove")
     else:
         checkout_branch()


### PR DESCRIPTION
For some reason the `CheckIfAgentCanMove` and `CheckIfItemBlocksAgentMovement` don't you to give them arbitrary offsets as input, I've removed this restriction.