### PR TITLE
Teleport bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ We have done our best to fix all bugs and issues. However, you might still encou
 
 AI2-THOR is an open-source project backed by [the Allen Institute for Artificial Intelligence (AI2)](http://www.allenai.org).
 AI2 is a non-profit institute with the mission to contribute to humanity through high-impact AI research and engineering.
+

--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -837,6 +837,13 @@ class Controller(object):
 
         self.last_action = action
 
+        # dangerously converts rotation(float) to rotation(dict(x=0, y=float, z=0))
+        # this should be removed when ServerActions have been removed from Unity
+        # for all relevant actions.
+        rotation = action.get("rotation")
+        if rotation is not None and not isinstance(rotation, dict):
+            action['rotation'] = dict(y=rotation)
+
         # Support for deprecated parameter names (old: new)
         # Note that these parameters used to be applicable to ANY action.
         changed_parameter_names = {

--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -862,10 +862,8 @@ class Controller(object):
         ]:
             raise ValueError(self.last_event.metadata["errorMessage"])
 
-        if raise_for_failure:
-            assert self.last_event.metadata[
-                "lastActionSuccess"
-            ], self.last_event.metadata.get("errorMessage", f"{action} failed")
+        if raise_for_failure and not self._last_event.metadata["lastActionSuccess"]:
+            raise RuntimeError(self.last_event.metadata.get("errorMessage", f"{action} failed"))
 
         return self.last_event
 

--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -852,18 +852,18 @@ class Controller(object):
         self.server.send(action)
         self.last_event = self.server.receive()
 
-        if not self.last_event.metadata[
-            "lastActionSuccess"
-        ] and self.last_event.metadata["errorCode"] in [
-            "InvalidAction",
-            "MissingArguments",
-            "AmbiguousAction",
-            "InvalidArgument",
-        ]:
-            raise ValueError(self.last_event.metadata["errorMessage"])
-
-        if raise_for_failure and not self._last_event.metadata["lastActionSuccess"]:
-            raise RuntimeError(self.last_event.metadata.get("errorMessage", f"{action} failed"))
+        if not self.last_event.metadata["lastActionSuccess"]:
+            if self.last_event.metadata["errorCode"] in [
+                "InvalidAction",
+                "MissingArguments",
+                "AmbiguousAction",
+                "InvalidArgument",
+            ]:
+                raise ValueError(self.last_event.metadata["errorMessage"])
+            elif raise_for_failure:
+                raise RuntimeError(
+                    self.last_event.metadata.get("errorMessage", f"{action} failed")
+                )
 
         return self.last_event
 

--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -863,7 +863,9 @@ class Controller(object):
             raise ValueError(self.last_event.metadata["errorMessage"])
 
         if raise_for_failure:
-            assert self.last_event.metadata["lastActionSuccess"]
+            assert self.last_event.metadata[
+                "lastActionSuccess"
+            ], self.last_event.metadata.get("errorMessage", f"{action} failed")
 
         return self.last_event
 

--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -837,11 +837,6 @@ class Controller(object):
 
         self.last_action = action
 
-        rotation = action.get("rotation")
-        if rotation is not None and type(rotation) != dict:
-            action["rotation"] = {}
-            action["rotation"]["y"] = rotation
-
         # Support for deprecated parameter names (old: new)
         # Note that these parameters used to be applicable to ANY action.
         changed_parameter_names = {
@@ -859,20 +854,16 @@ class Controller(object):
 
         if not self.last_event.metadata[
             "lastActionSuccess"
-        ]:
-            if self.last_event.metadata["errorCode"] in [
+        ] and self.last_event.metadata["errorCode"] in [
             "InvalidAction",
             "MissingArguments",
             "AmbiguousAction",
             "InvalidArgument",
-            ]:
-                raise ValueError(self.last_event.metadata["errorMessage"])
-            elif raise_for_failure:
-                raise RuntimeError(
-                    self.last_event.metadata.get("errorMessage", f"{action} failed.")
-                )
+        ]:
+            raise ValueError(self.last_event.metadata["errorMessage"])
 
-        assert (not raise_for_failure) or self.last_event.metadata["lastActionSuccess"]
+        if raise_for_failure:
+            assert self.last_event.metadata["lastActionSuccess"]
 
         return self.last_event
 

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -934,7 +934,7 @@ def test_teleport(controller):
         for action in ["Teleport", "TeleportFull"]:
             event = controller.step(
                 action=action,
-                position=dict(x=-1.5, y=0.9, z=1.5),
+                position=dict(x=-1.5, y=0.9, z=-1.5),
                 rotation=dict(x=0, y=90, z=0),
                 horizon=30
             )
@@ -942,7 +942,7 @@ def test_teleport(controller):
             try:
                 event = controller.step(
                     action=action,
-                    position=dict(x=-1.5, y=0.9, z=1.5),
+                    position=dict(x=-1.5, y=0.9, z=-1.5),
                     rotation=dict(x=0, y=90, z=0),
                     horizon=30,
                     standing=True

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -893,7 +893,7 @@ def test_teleport(controller):
     # make sure Teleport works with default args
     a1 = controller.last_event.metadata['agent']
     a2 = controller.step("Teleport", horizon=10).metadata['agent']
-    assert_near(a2['cameraHorizon'], 10)
+    assert abs(a2['cameraHorizon'] - 10) < 1e-2, "cameraHorizon should be ~10!"
 
     # all should be the same except for horizon
     for dim in 'x y z'.split():
@@ -963,7 +963,7 @@ def test_teleport(controller):
         # make sure Teleport works with default args
         a1 = controller.last_event.metadata['agent']
         a2 = controller.step("Teleport", horizon=10).metadata['agent']
-        assert_near(a2['cameraHorizon'], 10)
+        assert abs(a2['cameraHorizon'] - 10) < 1e-2, "cameraHorizon should be ~10!"
 
         # all should be the same except for horizon
         for dim in 'x y z'.split():
@@ -975,6 +975,8 @@ def test_teleport(controller):
         # if agent == "locobot":
             # agent = controller.step('TeleportFull', rotation=25).metadata['agent']
             # assert_near(agent['rotation']['y'], 25)
+
+    controller.reset(agentMode="default")
 
 
 ###################################################

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -903,8 +903,9 @@ def test_teleport(controller):
     assert a1['isStanding'] != None, "Agent isStanding should be set for physics agent!"
 
     # make sure float rotation works
-    agent = controller.step('TeleportFull', rotation=25).metadata['agent']
-    assert_near(agent['rotation']['y'], 25)
+    # TODO: readd this when it actually works
+    # agent = controller.step('TeleportFull', rotation=25).metadata['agent']
+    # assert_near(agent['rotation']['y'], 25)
 
     # test out of bounds with default agent
     for action in ['Teleport', 'TeleportFull']:
@@ -969,10 +970,11 @@ def test_teleport(controller):
             assert_near(a1['position'][dim], a2['position'][dim])
             assert_near(a1['rotation'][dim], a2['rotation'][dim])
 
+        # TODO: readd this when it actually works.
         # make sure float rotation works
-        if agent == "locobot":
-            agent = controller.step('TeleportFull', rotation=25).metadata['agent']
-            assert_near(agent['rotation']['y'], 25)
+        # if agent == "locobot":
+            # agent = controller.step('TeleportFull', rotation=25).metadata['agent']
+            # assert_near(agent['rotation']['y'], 25)
 
 
 ###################################################

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -839,6 +839,11 @@ def test_change_resolution(controller):
     )
 
 
+###################################################
+##### RESETTING WILL BE DONE AFTER THIS POINT #####
+###################################################
+
+
 @pytest.mark.parametrize("controller", [wsgi_controller, fifo_controller])
 def test_teleport(controller):
     # Checking y coordinate adjustment works
@@ -977,11 +982,6 @@ def test_teleport(controller):
             # assert_near(agent['rotation']['y'], 25)
 
     controller.reset(agentMode="default")
-
-
-###################################################
-##### RESETTING WILL BE DONE AFTER THIS POINT #####
-###################################################
 
 
 @pytest.mark.parametrize("controller", [wsgi_controller, fifo_controller])

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -901,9 +901,8 @@ def test_teleport(controller):
     assert abs(a2['cameraHorizon'] - 10) < 1e-2, "cameraHorizon should be ~10!"
 
     # all should be the same except for horizon
-    for dim in 'x y z'.split():
-        assert_near(a1['position'][dim], a2['position'][dim])
-        assert_near(a1['rotation'][dim], a2['rotation'][dim])
+    assert_near(a1['position'], a2['position'])
+    assert_near(a1['rotation'], a2['rotation'])
     assert a1['isStanding'] == a2['isStanding'], "Agent should remain in same standing when unspecified!"
     assert a1['isStanding'] != None, "Agent isStanding should be set for physics agent!"
 
@@ -971,9 +970,8 @@ def test_teleport(controller):
         assert abs(a2['cameraHorizon'] - 10) < 1e-2, "cameraHorizon should be ~10!"
 
         # all should be the same except for horizon
-        for dim in 'x y z'.split():
-            assert_near(a1['position'][dim], a2['position'][dim])
-            assert_near(a1['rotation'][dim], a2['rotation'][dim])
+        assert_near(a1['position'], a2['position'])
+        assert_near(a1['rotation'], a2['rotation'])
 
         # TODO: readd this when it actually works.
         # make sure float rotation works

--- a/unity/Assets/Scripts/ActionDispatcher.cs
+++ b/unity/Assets/Scripts/ActionDispatcher.cs
@@ -198,10 +198,11 @@ public static class ActionDispatcher {
                     for (int k = 0; k < minCommon; k++) {
                         if (sourceParams[k].ParameterType != targetParams[k].ParameterType) {
                             signatureMatch = false;
+                            break;
                         }
                     }
 
-                    if (sourceParams.Length != targetParams.Length) {
+                    if (signatureMatch && (sourceParams.Length != targetParams.Length)) {
                         // Some methods, like teleport full have
                         // add both required args and optional args to the end.
                         for (int i = minCommon - 1; i < sourceParams.Length; i++) {

--- a/unity/Assets/Scripts/ActionDispatcher.cs
+++ b/unity/Assets/Scripts/ActionDispatcher.cs
@@ -204,9 +204,6 @@ public static class ActionDispatcher {
                     if (sourceParams.Length != targetParams.Length) {
                         // Some methods, like teleport full have
                         // add both required args and optional args to the end.
-
-                        // TODO: Prioritize the child class one in the case of teleport,
-                        // when it's ambiguous.
                         for (int i = minCommon - 1; i < sourceParams.Length; i++) {
                             if (!sourceParams[i].HasDefaultValue) {
                                 signatureMatch = false;

--- a/unity/Assets/Scripts/ActionDispatcher.cs
+++ b/unity/Assets/Scripts/ActionDispatcher.cs
@@ -202,21 +202,10 @@ public static class ActionDispatcher {
                         }
                     }
 
-                    if (signatureMatch && (sourceParams.Length != targetParams.Length)) {
-                        // Some methods, like teleport full have
-                        // add both required args and optional args to the end.
-                        for (int i = minCommon - 1; i < sourceParams.Length; i++) {
-                            if (!sourceParams[i].HasDefaultValue) {
-                                signatureMatch = false;
-                                break;
-                            }
-                        }
-                        for (int i = minCommon - 1; i < targetParams.Length; i++) {
-                            if (!targetParams[i].HasDefaultValue) {
-                                signatureMatch = false;
-                                break;
-                            }
-                        }
+                    if (sourceParams.Length > targetParams.Length && !sourceParams[minCommon].HasDefaultValue) {
+                        signatureMatch = false;
+                    } else if (targetParams.Length > sourceParams.Length && !targetParams[minCommon].HasDefaultValue) {
+                        signatureMatch = false;
                     }
 
                     // if the method is more specific and the parameters match

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1216,30 +1216,32 @@ public class MetadataPatch
 //overlap between ObjectMetadata and AgentMetadata
 [Serializable]
 [MessagePackObject(keyAsPropertyName: true)]
-public class AgentMetadata
-{
+public class AgentMetadata {
     public string name;
     public Vector3 position;
     public Vector3 rotation;
     public float cameraHorizon;
-	public bool isStanding;
+
+    // TODO: this should be removed from base.
+    // some agents cannot stand (e.g., drone, locobot)
+	public bool? isStanding = null;
+
 	public bool inHighFrictionArea;
     public AgentMetadata() {}
 }
 
 [Serializable]
 [MessagePackObject(keyAsPropertyName: true)]
-public class DroneAgentMetadata : AgentMetadata
-{
-    public float droneCurrentTime;
+public class DroneAgentMetadata : AgentMetadata {
+    // why is the launcher position even attached to the agent's metadata
+    // and not the generic metdata?
     public Vector3 LauncherPosition;
 }
 
 //additional metadata for drone objects (only use with Drone controller)
 [Serializable]
 [MessagePackObject(keyAsPropertyName: true)]
-public class DroneObjectMetadata : ObjectMetadata
-{
+public class DroneObjectMetadata : ObjectMetadata {
     // Drone Related Metadata
     public int numSimObjHits;
     public int numFloorHits;

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1583,7 +1583,15 @@ public class DynamicServerAction
     }
 
     public DynamicServerAction(Dictionary<string, object> action) {
-        this.jObject = JObject.FromObject(action);
+        try {
+            this.jObject = JObject.FromObject(action);
+        } catch (InvalidOperationException e)  {
+            throw new InvalidOperationException(
+                "TL;DR: Use 'run' from the debug input field. If you're seeing this, you're in the Debug Input Field. " +
+                "There is a weird case where actions like Teleport having xyz parameters and rotation: Vector3() which also has xyz parameters results in a self-recursing loop. " +
+                $"{e.Message}"
+            );
+        }
     }
 
     public DynamicServerAction(JObject action) {

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -902,17 +902,17 @@ public class AgentManager : MonoBehaviour
     }
 
     private string serializeMetadataJson(MultiAgentMetadata multiMeta) {
-            var jsonResolver = new ShouldSerializeContractResolver();
-            return Newtonsoft.Json.JsonConvert.SerializeObject(multiMeta, Newtonsoft.Json.Formatting.None,
-                        new Newtonsoft.Json.JsonSerializerSettings()
-                            {
-                                ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore,
-                                ContractResolver = jsonResolver
-                            }
-
-            );
+        var jsonResolver = new ShouldSerializeContractResolver();
+        return Newtonsoft.Json.JsonConvert.SerializeObject(
+            multiMeta,
+            Newtonsoft.Json.Formatting.None,
+            new Newtonsoft.Json.JsonSerializerSettings()
+            {
+                ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore,
+                ContractResolver = jsonResolver
+            }
+        );
     }
-
 
     private bool canEmit() {
         bool emit = true;
@@ -1851,28 +1851,27 @@ public class TypedVariable {
 
 
 
-public class ShouldSerializeContractResolver : DefaultContractResolver
-{
-   public static readonly ShouldSerializeContractResolver Instance = new ShouldSerializeContractResolver();
+public class ShouldSerializeContractResolver : DefaultContractResolver {
+    public static readonly ShouldSerializeContractResolver Instance = new ShouldSerializeContractResolver();
 
-   protected override JsonProperty CreateProperty( MemberInfo member,
-                                    MemberSerialization memberSerialization )
-   {
-      JsonProperty property = base.CreateProperty( member, memberSerialization );
+    protected override JsonProperty CreateProperty(
+        MemberInfo member,
+        MemberSerialization memberSerialization
+    ) {
+       JsonProperty property = base.CreateProperty(member, memberSerialization);
 
-      // exclude these properties to make serialization match JsonUtility
-      if( property.DeclaringType == typeof(Vector3) &&
-            (property.PropertyName == "sqrMagnitude" || 
-            property.PropertyName == "magnitude"  ||
-            property.PropertyName == "normalized" 
-            ))
-      {
+       // exclude these properties to make serialization match JsonUtility
+      if (property.DeclaringType == typeof(Vector3) &&
+          (property.PropertyName == "sqrMagnitude" ||
+          property.PropertyName == "magnitude"  ||
+          property.PropertyName == "normalized")
+      ) {
          property.ShouldSerialize = instance => { return false; };
          return property;
       } else {
           return base.CreateProperty(member, memberSerialization);
       }
-
+      return base.CreateProperty(member, memberSerialization);
    }
 }
 

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1879,7 +1879,6 @@ public class ShouldSerializeContractResolver : DefaultContractResolver {
       } else {
           return base.CreateProperty(member, memberSerialization);
       }
-      return base.CreateProperty(member, memberSerialization);
    }
 }
 

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -59,6 +59,10 @@ namespace UnityStandardAssets.Characters.FirstPerson
         protected float TimeToWaitForObjectsToComeToRest = 0.0f;
         //determins default move distance for move actions
 		protected float moveMagnitude;
+
+        // this should eventually be removed if StochasticRemoteFPSAgentController overrides the 4 TeleportFull methods
+        private string agentMode;
+
         //determines rotation increment of rotate functions
         protected float rotateStepDegrees = 90.0f;
         protected bool snapToGrid;
@@ -546,14 +550,13 @@ namespace UnityStandardAssets.Characters.FirstPerson
             this.visibilityScheme = action.GetVisibilityScheme();
         }
 
-        public void SetAgentMode(string mode)
-        {
-            string whichMode;
-            whichMode = mode.ToLower();
+        public void SetAgentMode(string mode) {
+            string whichMode = mode.ToLower();
+
+            this.agentMode = whichMode;
 
             //null check for camera, used to ensure no missing references on initialization
-            if(m_Camera == null)
-            {
+            if(m_Camera == null) {
                 m_Camera = this.gameObject.GetComponentInChildren<Camera>();
             }
 
@@ -1937,12 +1940,15 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
             if (!forceAction) {
                 // Adjust y position so that the agent is more on the floor
-                m_CharacterController.Move(new Vector3(0f, Physics.gravity.y * this.m_GravityMultiplier, 0f));
-                bool tooMuchYMovement = Mathf.Abs(transform.position.y - position.y) > 0.05f;
-                if (tooMuchYMovement) {
-                    errorMessage = "After teleporting and adjusting agent position to floor, there was too large a change" +
-                    $"({Mathf.Abs(transform.position.y - rotation.y)} > 0.05) in the y component." +
-                    " Consider using `forceAction=true` if you'd like to teleport anyway.";
+                bool tooMuchYMovement  = false;
+                if (this.agentMode != "drone") {
+                    m_CharacterController.Move(new Vector3(0f, Physics.gravity.y * this.m_GravityMultiplier, 0f));
+                    tooMuchYMovement = Mathf.Abs(transform.position.y - position.y) > 0.05f;
+                    if (tooMuchYMovement) {
+                        errorMessage = "After teleporting and adjusting agent position to floor, there was too large a change" +
+                        $"({Mathf.Abs(transform.position.y - rotation.y)} > 0.05) in the y component." +
+                        " Consider using `forceAction=true` if you'd like to teleport anyway.";
+                    }
                 }
 
                 bool agentCollides = isAgentCapsuleColliding(

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1373,8 +1373,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             return b;
         }
 
-		public virtual  MetadataPatch generateMetadataPatch()
-		{
+		public virtual  MetadataPatch generateMetadataPatch() {
             MetadataPatch patch = new MetadataPatch();
             patch.lastAction = this.lastAction;
             patch.lastActionSuccess = this.lastActionSuccess;
@@ -1386,8 +1385,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             return patch;
         }
 
-		public virtual MetadataWrapper generateMetadataWrapper()
-		{
+		public virtual MetadataWrapper generateMetadataWrapper() {
             // AGENT METADATA
             AgentMetadata agentMeta = new AgentMetadata();
             agentMeta.name = "agent";
@@ -1434,6 +1432,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
             metaMessage.inventoryObjects = ios.ToArray();
 
+            // TODO: remove from base.
             // HAND
             metaMessage.hand = new HandMetadata();
             metaMessage.hand.position = AgentHand.transform.position;
@@ -1441,6 +1440,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             metaMessage.hand.rotation = AgentHand.transform.eulerAngles;
             metaMessage.hand.localRotation = AgentHand.transform.localEulerAngles;
 
+            // TODO: remove from base.
              // ARM
             if (Arm != null) {
                 metaMessage.arm = Arm.GenerateMetadata();

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1918,12 +1918,12 @@ namespace UnityStandardAssets.Characters.FirstPerson
             // cache old values in case there's a failure
             Vector3 oldPosition = transform.position;
             Quaternion oldRotation = transform.rotation;
-            float oldHorizon = m_Camera.transform.localPosition.x;
+            float oldHorizon = m_Camera.transform.localEulerAngles.x;
 
             // here we actually teleport 
             transform.position = position;
             transform.localEulerAngles = new Vector3(0, rotation.y, 0);
-            m_Camera.transform.eulerAngles = new Vector3(horizon, 0, 0);
+            m_Camera.transform.localEulerAngles = new Vector3(horizon, 0, 0);
 
             if (!forceAction &&
                 isAgentCapsuleColliding(
@@ -1932,7 +1932,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             ) {
                 transform.position = oldPosition;
                 transform.rotation = oldRotation;
-                m_Camera.transform.eulerAngles = new Vector3(oldHorizon, 0, 0);
+                m_Camera.transform.localEulerAngles = new Vector3(oldHorizon, 0, 0);
                 throw new InvalidOperationException(errorMessage);
             }
         }

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1391,7 +1391,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             agentMeta.rotation = transform.eulerAngles;
 
             float cameraX = m_Camera.transform.rotation.eulerAngles.x;
-            agentMeta.cameraHorizon = cameraX < 0 ? 360 + (cameraX % 360) : cameraX % 360;
+            agentMeta.cameraHorizon = cameraX > 180 ? cameraX - 360 : cameraX;
             agentMeta.inHighFrictionArea = inHighFrictionArea;
 
             // OTHER METADATA

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1865,14 +1865,20 @@ namespace UnityStandardAssets.Characters.FirstPerson
         ///////////////////////////////////////////
 
         // this is not used with non-grounded agents (e.g., drones)
-        protected void assertTeleportedNearGround() {
+        protected void assertTeleportedNearGround(Vector3? targetPosition) {
+            // position should not change if it's null.
+            if (targetPosition == null) {
+                return;
+            }
+
+            Vector3 pos = (Vector3) targetPosition;
             m_CharacterController.Move(new Vector3(0f, Physics.gravity.y * this.m_GravityMultiplier, 0f));
 
             // perhaps like y=2 was specified, with an agent's standing height of 0.9
-            if (Mathf.Abs(transform.position.y - position.y) > 0.05f) {
+            if (Mathf.Abs(transform.position.y - pos.y) > 0.05f) {
                 throw new InvalidOperationException(
                     "After teleporting and adjusting agent position to floor, there was too large a change" +
-                    $"({Mathf.Abs(transform.position.y - rotation.y)} > 0.05) in the y component." +
+                    $"({Mathf.Abs(transform.position.y - pos.y)} > 0.05) in the y component." +
                     " Consider using `forceAction=true` if you'd like to teleport anyway."
                 );
             }

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -3330,7 +3330,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         action["x"] = -1.5f;
                         action["y"] = 0.9009995460510254f;
                         action["z"] = -1.5f;
-                        float rotation = 135.0f;
+                        Vector3 rotation = new Vector3(0, 135.0f, 0);
                         int horizon = 0;
                         bool standing = true;
 
@@ -3338,7 +3338,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                             action["x"] = float.Parse(splitcommand[1]);
                             action["y"] = float.Parse(splitcommand[2]);
                             action["z"] = float.Parse(splitcommand[3]);
-                            rotation = float.Parse(splitcommand[4]);
+                            // rotation = float.Parse(splitcommand[4]);
                         }
 
                         else if(splitcommand.Length > 5)
@@ -3346,7 +3346,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                             action["x"] = float.Parse(splitcommand[1]);
                             action["y"] = float.Parse(splitcommand[2]);
                             action["z"] = float.Parse(splitcommand[3]);
-                            rotation = float.Parse(splitcommand[4]);
+                            // rotation = float.Parse(splitcommand[4]);
                             horizon = int.Parse(splitcommand[5]);
                         }
 

--- a/unity/Assets/Scripts/DiscreteHidenSeekAgentController.cs
+++ b/unity/Assets/Scripts/DiscreteHidenSeekAgentController.cs
@@ -118,19 +118,18 @@ public int objectVariation;
         }
 
         public void SetObjectVisible(bool visible) {
-            
-                                 visibleObject = visible;
-                                 // Debug.Log("Calling disply with "+ visibleObject);
-                                 var go = PhysicsController.WhatAmIHolding();
-                                PhysicsController.UpdateDisplayGameObject( go, visibleObject);
-                                var layer = go.layer;
-                                if (!visibleObject) {
-                                    // go.layer = LayerMask.NameToLayer("SimObjInvisible");
-                                    SetLayerRecursively(go, LayerMask.NameToLayer("SimObjInvisible"));
-                                }
-                                else {
-                                    SetLayerRecursively(go, LayerMask.NameToLayer("SimObjVisible"));
-                                }
+            visibleObject = visible;
+            // Debug.Log("Calling disply with "+ visibleObject);
+            var go = PhysicsController.WhatAmIHolding();
+            PhysicsController.UpdateDisplayGameObject( go, visibleObject);
+            var layer = go.layer;
+            if (!visibleObject) {
+                // go.layer = LayerMask.NameToLayer("SimObjInvisible");
+                SetLayerRecursively(go, LayerMask.NameToLayer("SimObjInvisible"));
+            }
+            else {
+                SetLayerRecursively(go, LayerMask.NameToLayer("SimObjVisible"));
+            }
         }
 
         public void Step(string serverAction)

--- a/unity/Assets/Scripts/DroneFPSAgentController.cs
+++ b/unity/Assets/Scripts/DroneFPSAgentController.cs
@@ -323,11 +323,24 @@ namespace UnityStandardAssets.Characters.FirstPerson
             return output;
         }
 
-        //change what timeScale is automatically reset to on emitFrame when in FlightMode
-        public void ChangeAutoResetTimeScale(float timeScale)
-        {
+        // change what timeScale is automatically reset to on emitFrame when in FlightMode
+        public void ChangeAutoResetTimeScale(float timeScale) {
             autoResetTimeScale = timeScale;
             actionFinished(true);
+        }
+
+        public void Teleport(
+            Vector3? position = null, Vector3? rotation = null, float? horizon = null, bool forceAction = false
+        ) {
+            base.teleport(position: position, rotation: rotation, horizon: horizon, forceAction: forceAction);
+            actionFinished(success: true);
+        }
+
+        public void TeleportFull(
+            Vector3 position, Vector3 rotation, float horizon, bool forceAction = false
+        ) {
+            base.teleportFull(position: position, rotation: rotation, horizon: horizon, forceAction: forceAction);
+            actionFinished(success: true);
         }
 
         public void FlyRandomStart(float y)

--- a/unity/Assets/Scripts/DroneFPSAgentController.cs
+++ b/unity/Assets/Scripts/DroneFPSAgentController.cs
@@ -130,9 +130,8 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
         }
 
-        //generates object metatada based on sim object's properties
-        public override ObjectMetadata ObjectMetadataFromSimObjPhysics(SimObjPhysics simObj, bool isVisible) 
-        {            
+        //generates object metadata based on sim object's properties
+        public override ObjectMetadata ObjectMetadataFromSimObjPhysics(SimObjPhysics simObj, bool isVisible) {            
             DroneObjectMetadata objMeta = new DroneObjectMetadata();
             objMeta.isCaught = this.GetComponent<DroneFPSAgentController>().isObjectCaught(simObj);
             objMeta.numSimObjHits = simObj.numSimObjHit;
@@ -241,111 +240,37 @@ namespace UnityStandardAssets.Characters.FirstPerson
             return objMeta;
         }
 
-        public override MetadataWrapper generateMetadataWrapper()
-        {
-            // AGENT METADATA
-            DroneAgentMetadata agentMeta = new DroneAgentMetadata();
-            agentMeta.name = "agent";
-            agentMeta.position = transform.position;
-            agentMeta.rotation = transform.eulerAngles;
-            agentMeta.cameraHorizon = m_Camera.transform.rotation.eulerAngles.x;
-            if (agentMeta.cameraHorizon > 180) 
-            {
-                agentMeta.cameraHorizon -= 360;
-            }
+        public override MetadataWrapper generateMetadataWrapper() {
+            MetadataWrapper metadata = base.generateMetadataWrapper();
 
-            //New Drone Stuff for agentMeta
-            agentMeta.LauncherPosition = GetLauncherPosition();
+            // For Drone controller, currentTime should be based on
+            // fixed update passes so use DroneTimeSinceStart instead of TimeSinceStart
+            metadata.currentTime = DroneTimeSinceStart();
 
-            // OTHER METADATA
-            MetadataWrapper metaMessage = new MetadataWrapper();
-    
-            //For Drone controller, currentTime should be based on
-            //fixed update passes so use DroneTimeSinceStart instead of TimeSinceStart
-            metaMessage.currentTime = DroneTimeSinceStart();
+            // TODO: clean this up with reflection.
+            // it works, but will not update when something changes to AgentMetadata
+            // metadata.agent = new 
+            AgentMetadata baseAgent = metadata.agent;
 
-            //agentMeta.FlightMode = FlightMode;
-            metaMessage.agent = agentMeta;
-            metaMessage.sceneName = UnityEngine.SceneManagement.SceneManager.GetActiveScene().name;
-            metaMessage.objects = this.generateObjectMetadata();
-            //check scene manager to see if the scene's objects are at rest
-            metaMessage.isSceneAtRest = physicsSceneManager.isSceneAtRest;
-            metaMessage.collided = collidedObjects.Length > 0;
-            metaMessage.collidedObjects = collidedObjects;
-            metaMessage.screenWidth = Screen.width;
-            metaMessage.screenHeight = Screen.height;
-            metaMessage.cameraPosition = m_Camera.transform.position;
-            metaMessage.cameraOrthSize = cameraOrthSize;
-            cameraOrthSize = -1f;
-            metaMessage.fov = m_Camera.fieldOfView;
-            metaMessage.lastAction = lastAction;
-            metaMessage.lastActionSuccess = lastActionSuccess;
-            metaMessage.errorMessage = errorMessage;
-            metaMessage.actionReturn = this.actionReturn;
+            DroneAgentMetadata droneMeta = new DroneAgentMetadata();
+            droneMeta.name = "drone";
+            droneMeta.position = baseAgent.position;
+            droneMeta.rotation = baseAgent.rotation;
+            droneMeta.cameraHorizon = baseAgent.cameraHorizon;
+            droneMeta.inHighFrictionArea = baseAgent.inHighFrictionArea;
 
-            if (errorCode != ServerActionErrorCode.Undefined) {
-                metaMessage.errorCode = Enum.GetName(typeof(ServerActionErrorCode), errorCode);
-            }
+            // New drone stuff for agent metadata
+            droneMeta.LauncherPosition = GetLauncherPosition();
 
-            List<InventoryObject> ios = new List<InventoryObject>();
-
-            if (ItemInHand != null) {
-                SimObjPhysics so = ItemInHand.GetComponent<SimObjPhysics>();
-                InventoryObject io = new InventoryObject();
-                io.objectId = so.ObjectID;
-                io.objectType = Enum.GetName(typeof(SimObjType), so.Type);
-                ios.Add(io);
-            }
-
-            metaMessage.inventoryObjects = ios.ToArray();
-
-            // HAND
-            metaMessage.hand = new HandMetadata();
-            metaMessage.hand.position = AgentHand.transform.position;
-            metaMessage.hand.localPosition = AgentHand.transform.localPosition;
-            metaMessage.hand.rotation = AgentHand.transform.eulerAngles;
-            metaMessage.hand.localRotation = AgentHand.transform.localEulerAngles;
-
-            // EXTRAS
-            metaMessage.reachablePositions = reachablePositions;
-            metaMessage.flatSurfacesOnGrid = flatten3DimArray(flatSurfacesOnGrid);
-            metaMessage.distances = flatten2DimArray(distances);
-            metaMessage.normals = flatten3DimArray(normals);
-            metaMessage.isOpenableGrid = flatten2DimArray(isOpenableGrid);
-            metaMessage.segmentedObjectIds = segmentedObjectIds;
-            metaMessage.objectIdsInBox = objectIdsInBox;
-            metaMessage.actionIntReturn = actionIntReturn;
-            metaMessage.actionFloatReturn = actionFloatReturn;
-            metaMessage.actionFloatsReturn = actionFloatsReturn;
-            metaMessage.actionStringsReturn = actionStringsReturn;
-            metaMessage.actionVector3sReturn = actionVector3sReturn;
-
-            if (alwaysReturnVisibleRange) {
-                metaMessage.visibleRange = visibleRange();
-            }
-
-            // Resetting things
-            reachablePositions = new Vector3[0];
-            flatSurfacesOnGrid = new float[0, 0, 0];
-            distances = new float[0, 0];
-            normals = new float[0, 0, 0];
-            isOpenableGrid = new bool[0, 0];
-            segmentedObjectIds = new string[0];
-            objectIdsInBox = new string[0];
-            actionIntReturn = 0;
-            actionFloatReturn = 0.0f;
-            actionFloatsReturn = new float[0];
-            actionStringsReturn = new string[0];
-            actionVector3sReturn = new Vector3[0];
-
-            return metaMessage;
+            metadata.agent = droneMeta;
+            return metadata;
 		}
 
         public float DroneTimeSinceStart() {
             return fixupdateCnt * Time.fixedDeltaTime;
         }
 
-        //Flying Drone Agent Controls
+        // Flying drone agent controls
         public Vector3 GetFlyingOrientation(float moveMagnitude, int targetOrientation) {
             Vector3 m;
             int currentRotation = (int) Math.Round(transform.rotation.eulerAngles.y, 0);
@@ -373,8 +298,8 @@ namespace UnityStandardAssets.Characters.FirstPerson
             return m;
         }
 
-        //Flying Drone Agent Controls
-        //use get reachable positions, get two positions, one in front of the other
+        // Flying drone agent controls
+        // use get reachable positions, get two positions, one in front of the other
         public Vector3[] SeekTwoPos(Vector3[] shuffledCurrentlyReachable){
             Vector3[] output = new Vector3[2];
             System.Random rnd = new System.Random();

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1692,23 +1692,22 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 // default high level hand when teleporting
                 DefaultAgentHand();
                 ToggleArmColliders(arm: Arm, value: forceAction);
-                base.TeleportFull(position: position, rotation: rotation, horizon: horizon, forceAction: forceAction);
+                base.teleportFull(position: position, rotation: rotation, horizon: horizon, forceAction: forceAction);
 
                 // add arm value cases
                 if (!forceAction) {
-                    bool handObjectCollides = isHandObjectColliding(ignoreAgent: true);
-                    if (handObjectCollides) {
-                        errorMessage = "Cannot teleport due to hand object collision.";
+                    if (isHandObjectColliding(ignoreAgent: true)) {
+                        throw new InvalidOperationException("Cannot teleport due to hand object collision.");
                     }
 
-                    bool armCollides = Arm != null && Arm.IsArmColliding();
-                    if (armCollides) {
-                        errorMessage = "Mid Level Arm is actively clipping with some geometry in the environment. TeleportFull fails in this position.";
+                    if (Arm != null && Arm.IsArmColliding()) {
+                        throw new InvalidOperationException(
+                            "Mid Level Arm is actively clipping with some geometry in the environment. TeleportFull fails in this position."
+                        );
                     }
 
-                    if (handObjectCollides || armCollides) {
-                        throw new InvalidOperationException(errorMessage);
-                    }
+                    base.assertTeleportedNearGround();
+
                     ToggleArmColliders(arm: Arm, value: false);
                 }
             } catch (InvalidOperationException e) {

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1616,22 +1616,22 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         ////////////// TELEPORT FULL //////////////
         ///////////////////////////////////////////
 
-        [ObsoleteAttribute(message: "This action is deprecated. Call TeleportFull(position, ...) instead.", error: false)] 
-        public void TeleportFull(
-            float x, float y, float z,
-            float rotation,
-            float horizon,
-            bool standing,
-            bool forceAction = false
-        ) {
-            TeleportFull(
-                position: new Vector3(x, y, z),
-                rotation: new Vector3(0, rotation, 0),
-                horizon: horizon,
-                standing: standing,
-                forceAction: forceAction
-            );
-        }
+        // [ObsoleteAttribute(message: "This action is deprecated. Call TeleportFull(position, ...) instead.", error: false)] 
+        // public void TeleportFull(
+        //     float x, float y, float z,
+        //     float rotation,
+        //     float horizon,
+        //     bool standing,
+        //     bool forceAction = false
+        // ) {
+        //     TeleportFull(
+        //         position: new Vector3(x, y, z),
+        //         rotation: new Vector3(0, rotation, 0),
+        //         horizon: horizon,
+        //         standing: standing,
+        //         forceAction: forceAction
+        //     );
+        // }
 
         [ObsoleteAttribute(message: "This action is deprecated. Call TeleportFull(position, ...) instead.", error: false)] 
         public void TeleportFull(
@@ -1651,21 +1651,21 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
         // keep undocumented until float: rotation is added to Stochastic
-        public void TeleportFull(
-            Vector3 position,
-            float rotation,
-            float horizon,
-            bool standing,
-            bool forceAction = false
-        ) {
-            TeleportFull(
-                position: position,
-                rotation: new Vector3(0, rotation, 0),
-                horizon: horizon,
-                standing: standing,
-                forceAction: forceAction
-            );
-        }
+        // public void TeleportFull(
+        //     Vector3 position,
+        //     float rotation,
+        //     float horizon,
+        //     bool standing,
+        //     bool forceAction = false
+        // ) {
+        //     TeleportFull(
+        //         position: position,
+        //         rotation: new Vector3(0, rotation, 0),
+        //         horizon: horizon,
+        //         standing: standing,
+        //         forceAction: forceAction
+        //     );
+        // }
 
         // has to consider both the arm and standing
         public void TeleportFull(
@@ -1736,22 +1736,22 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         //////////////// TELEPORT /////////////////
         ///////////////////////////////////////////
 
-        [ObsoleteAttribute(message: "This action is deprecated. Call Teleport(position, ...) instead.", error: false)] 
-        public void Teleport(
-            float x, float y, float z,
-            float? rotation = null,
-            float? horizon = null,
-            bool? standing = null,
-            bool forceAction = false
-        ) {
-            Teleport(
-                position: new Vector3(x, y, z),
-                rotation: rotation,
-                horizon: horizon,
-                standing: standing,
-                forceAction: forceAction
-            );
-        }
+        // [ObsoleteAttribute(message: "This action is deprecated. Call Teleport(position, ...) instead.", error: false)] 
+        // public void Teleport(
+        //     float x, float y, float z,
+        //     float? rotation = null,
+        //     float? horizon = null,
+        //     bool? standing = null,
+        //     bool forceAction = false
+        // ) {
+        //     Teleport(
+        //         position: new Vector3(x, y, z),
+        //         rotation: rotation,
+        //         horizon: horizon,
+        //         standing: standing,
+        //         forceAction: forceAction
+        //     );
+        // }
 
         [ObsoleteAttribute(message: "This action is deprecated. Call Teleport(position, ...) instead.", error: false)] 
         public void Teleport(
@@ -1772,21 +1772,21 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
         // keep undocumented until float: rotation is added to Stochastic
         // DO NOT add float: rotation to base.
-        public void Teleport(
-            Vector3? position = null,
-            float? rotation = null,
-            float? horizon = null,
-            bool? standing = null,
-            bool forceAction = false
-        ) {
-            Teleport(
-                position: position,
-                rotation: rotation == null ? m_Camera.transform.localEulerAngles : new Vector3(0, (float) rotation, 0),
-                horizon: horizon,
-                standing: standing,
-                forceAction: forceAction
-            );
-        }
+        // public void Teleport(
+        //     Vector3? position = null,
+        //     float? rotation = null,
+        //     float? horizon = null,
+        //     bool? standing = null,
+        //     bool forceAction = false
+        // ) {
+        //     Teleport(
+        //         position: position,
+        //         rotation: rotation == null ? m_Camera.transform.localEulerAngles : new Vector3(0, (float) rotation, 0),
+        //         horizon: horizon,
+        //         standing: standing,
+        //         forceAction: forceAction
+        //     );
+        // }
 
         public void Teleport(
             Vector3? position = null,

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1699,14 +1699,12 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     if (isHandObjectColliding(ignoreAgent: true)) {
                         throw new InvalidOperationException("Cannot teleport due to hand object collision.");
                     }
-
                     if (Arm != null && Arm.IsArmColliding()) {
                         throw new InvalidOperationException(
                             "Mid Level Arm is actively clipping with some geometry in the environment. TeleportFull fails in this position."
                         );
                     }
-
-                    base.assertTeleportedNearGround();
+                    base.assertTeleportedNearGround(targetPosition: position);
 
                     ToggleArmColliders(arm: Arm, value: false);
                 }

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1693,6 +1693,11 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 DefaultAgentHand();
                 ToggleArmColliders(arm: Arm, value: forceAction);
                 base.teleportFull(position: position, rotation: rotation, horizon: horizon, forceAction: forceAction);
+                if (standing) {
+                    stand();
+                } else {
+                    crouch();
+                }
 
                 // add arm value cases
                 if (!forceAction) {

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1679,7 +1679,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             bool wasStanding = isStanding();
             Vector3 oldPosition = transform.position;
             Quaternion oldRotation = transform.rotation;
-            Vector3 oldCameraEulerAngle = m_Camera.transform.eulerAngles;
+            Vector3 oldCameraLocalEulerAngle = m_Camera.transform.localEulerAngles;
 
             Vector3 oldLocalHandPosition = new Vector3();
             Quaternion oldLocalHandRotation = new Quaternion();
@@ -1722,7 +1722,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                 transform.position = oldPosition;
                 transform.rotation = oldRotation;
-                m_Camera.transform.eulerAngles = oldCameraEulerAngle;
+                m_Camera.transform.localEulerAngles = oldCameraLocalEulerAngle;
 
                 throw new InvalidOperationException(e.Message);
             }
@@ -1794,7 +1794,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         ) {
             TeleportFull(
                 position: position == null ? transform.position : (Vector3) position,
-                rotation: rotation == null ? transform.localEulerAngles : (Vector3) rotation,
+                rotation: rotation == null ? transform.eulerAngles : (Vector3) rotation,
                 horizon: horizon == null ? m_Camera.transform.localEulerAngles.x : (float) horizon,
                 standing: standing == null ? isStanding() : (bool) standing,
                 forceAction: forceAction

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -6852,7 +6852,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 // Consider the case where one does not want to move on a perfect grid, and is currently moving
                 // with an offsetted set of rotations like {10, 100, 190, 280} instead of the default {0, 90, 180, 270}.
                 // This may happen if the agent starts by teleports with the rotation of 10 degrees.
-                int offset = (int) Math.Round(transform.localEulerAngles.y % rotateStepDegrees);
+                int offset = (int) Math.Round(transform.eulerAngles.y % rotateStepDegrees);
 
                 // Examples:
                 // if rotateStepDegrees=10 and offset=70, then the paths would be [70, 80, ..., 400, 410, 420].

--- a/unity/Assets/Scripts/StochasticRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/StochasticRemoteFPSAgentController.cs
@@ -213,19 +213,44 @@ namespace UnityStandardAssets.Characters.FirstPerson
             Rotate(new ServerAction() { rotation = new Vector3(0, -1.0f * rotationAmount, 0) });
         }
 
+        ///////////////////////////////////////////
+        //////////////// TELEPORT /////////////////
+        ///////////////////////////////////////////
+
+        [ObsoleteAttribute(message: "This action is deprecated. Call Teleport(position, ...) instead.", error: false)] 
+        public void Teleport(
+            float x, float y, float z,
+            Vector3? rotation = null, float? horizon = null, bool forceAction = false
+        ) {
+            Teleport(
+                position: new Vector3(x, y, z), rotation: rotation, horizon: horizon, forceAction: forceAction
+            );
+        }
+
         public void Teleport(
             Vector3? position = null, Vector3? rotation = null, float? horizon = null, bool forceAction = false
         ) {
             base.teleport(position: position, rotation: rotation, horizon: horizon, forceAction: forceAction);
-            base.assertTeleportedNearGround();
+            base.assertTeleportedNearGround(targetPosition: position);
             actionFinished(success: true);
+        }
+
+        ///////////////////////////////////////////
+        ////////////// TELEPORT FULL //////////////
+        ///////////////////////////////////////////
+
+        [ObsoleteAttribute(message: "This action is deprecated. Call TeleportFull(position, ...) instead.", error: false)] 
+        public void TeleportFull(float x, float y, float z, Vector3 rotation, float horizon, bool forceAction = false) {
+            TeleportFull(
+                position: new Vector3(x, y, z), rotation: rotation, horizon: horizon, forceAction: forceAction
+            );
         }
 
         public void TeleportFull(
             Vector3 position, Vector3 rotation, float horizon, bool forceAction = false
         ) {
             base.teleportFull(position: position, rotation: rotation, horizon: horizon, forceAction: forceAction);
-            base.assertTeleportedNearGround();
+            base.assertTeleportedNearGround(targetPosition: position);
             actionFinished(success: true);
         }
 

--- a/unity/Assets/Scripts/StochasticRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/StochasticRemoteFPSAgentController.cs
@@ -213,6 +213,22 @@ namespace UnityStandardAssets.Characters.FirstPerson
             Rotate(new ServerAction() { rotation = new Vector3(0, -1.0f * rotationAmount, 0) });
         }
 
+        public void Teleport(
+            Vector3? position = null, Vector3? rotation = null, float? horizon = null, bool forceAction = false
+        ) {
+            base.teleport(position: position, rotation: rotation, horizon: horizon, forceAction: forceAction);
+            base.assertTeleportedNearGround();
+            actionFinished(success: true);
+        }
+
+        public void TeleportFull(
+            Vector3 position, Vector3 rotation, float horizon, bool forceAction = false
+        ) {
+            base.teleportFull(position: position, rotation: rotation, horizon: horizon, forceAction: forceAction);
+            base.assertTeleportedNearGround();
+            actionFinished(success: true);
+        }
+
         public override void MoveAhead(ServerAction action)
         {
             action.x = 0.0f;


### PR DESCRIPTION
The new changes were incompatible with the locobot and drone's ability to teleport, since they do not have the ability to stand.

I've also reproduced the bug in the action dispatcher, where adding in `rotation: float` alongside `rotation: Vector3` tries to get the float to convert to a Vector3. This has not been fixed in this PR. I have simply commented out the new Teleport actions that would have allowed `rotation: float`.