### PR TITLE
Updates to SetObjectPoses

### DIFF
--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4052,7 +4052,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         // a subsequent scene reset()
         protected IEnumerator setObjectPoses(ObjectPose[] objectPoses, bool placeStationary){
             yield return new WaitForEndOfFrame();
-            bool success = physicsSceneManager.SetObjectPoses(objectPoses, errorMessage, placeStationary);
+            bool success = physicsSceneManager.SetObjectPoses(objectPoses, out errorMessage, placeStationary);
             actionFinished(success, errorMessage);
         }
 

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4043,17 +4043,17 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 actionFinished(false);
                 return;
             }
-            StartCoroutine(setObjectPoses(action.objectPoses));
+            StartCoroutine(setObjectPoses(action.objectPoses, action.placeStationary));
         }
 
         // SetObjectPoses is performed in a coroutine otherwise if
         // a frame does not pass prior to this AND the imageSynthesis
         // is enabled for say depth or normals, Unity will crash on 
         // a subsequent scene reset()
-        protected IEnumerator setObjectPoses(ObjectPose[] objectPoses){
+        protected IEnumerator setObjectPoses(ObjectPose[] objectPoses, bool placeStationary){
             yield return new WaitForEndOfFrame();
-            bool success = physicsSceneManager.SetObjectPoses(objectPoses);
-            actionFinished(success);
+            bool success = physicsSceneManager.SetObjectPoses(objectPoses, errorMessage, placeStationary);
+            actionFinished(success, errorMessage);
         }
 
         //set all objects objects of a given type to a specific state, if that object has that state

--- a/unity/Assets/Scripts/PhysicsSceneManager.cs
+++ b/unity/Assets/Scripts/PhysicsSceneManager.cs
@@ -292,7 +292,7 @@ public class PhysicsSceneManager : MonoBehaviour {
         RequiredObjects.Remove(sop.gameObject);
     }
 
-    public bool SetObjectPoses(ObjectPose[] objectPoses, string errorMessage, bool placeStationary) {
+    public bool SetObjectPoses(ObjectPose[] objectPoses, out string errorMessage, bool placeStationary) {
         SetupScene();
         bool shouldFail = false;
         if (objectPoses != null && objectPoses.Length > 0) {

--- a/unity/Assets/Scripts/PhysicsSceneManager.cs
+++ b/unity/Assets/Scripts/PhysicsSceneManager.cs
@@ -323,19 +323,24 @@ public class PhysicsSceneManager : MonoBehaviour {
             for (int ii = 0; ii < objectPoses.Length; ii++) {
                 ObjectPose objectPose = objectPoses[ii];
 
-                //hey! one of the sim objects we are trying to set the pose of is neither Moveable nor Pickupable, or doesnt exist in this scene...
                 if (!nameToObject.ContainsKey(objectPose.objectName)) {
-                    errorMessage = "No object of name " + objectPose.objectName + " found in scene.";
+                    errorMessage = "No Pickupable or Moveable object of name " + objectPose.objectName + " found in scene.";
                     Debug.Log(errorMessage);
                     shouldFail = true;
                     continue;
                 }
                 if (isStaticNameToObject.ContainsKey(objectPose.objectName)){
-                    errorMessage = objectPose.objectName + "is not a Moveable or Pickupable object. SetObjectPoses only works with Moveable and Pickupable sim objects.";
+                    errorMessage = objectPose.objectName + " is not a Moveable or Pickupable object. SetObjectPoses only works with Moveable and Pickupable sim objects.";
                     Debug.Log(errorMessage);
                     shouldFail = true;
                     continue;
                 }
+                if (!nameToObject.ContainsKey(objectPose.objectName) && !isStaticNameToObject.ContainsKey(objectPose.objectName)) {
+                    errorMessage = objectPose.objectName + " does not exist in scene.";
+                    shouldFail = true;
+                    continue;
+                }
+
                 SimObjPhysics obj = nameToObject[objectPose.objectName];
                 SimObjPhysics existingSOP = obj.GetComponent<SimObjPhysics>();
                 SimObjPhysics copy;

--- a/unity/Assets/Scripts/PhysicsSceneManager.cs
+++ b/unity/Assets/Scripts/PhysicsSceneManager.cs
@@ -294,6 +294,7 @@ public class PhysicsSceneManager : MonoBehaviour {
 
     public bool SetObjectPoses(ObjectPose[] objectPoses, out string errorMessage, bool placeStationary) {
         SetupScene();
+        errorMessage = "";
         bool shouldFail = false;
         if (objectPoses != null && objectPoses.Length > 0) {
             // Perform object location sets

--- a/unity/Assets/Scripts/SimObjPhysics.cs
+++ b/unity/Assets/Scripts/SimObjPhysics.cs
@@ -101,6 +101,7 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj
     public bool IsReceptacle;
     public bool IsPickupable;
     public bool IsMoveable;
+	public bool isStatic;
     public bool IsToggleable;
     public bool IsOpenable;
     public bool IsBreakable;
@@ -834,6 +835,7 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj
         this.IsReceptacle = Array.IndexOf(SecondaryProperties, SimObjSecondaryProperty.Receptacle) > -1 && ReceptacleTriggerBoxes != null;
         this.IsPickupable = this.PrimaryProperty == SimObjPrimaryProperty.CanPickup;
         this.IsMoveable = this.PrimaryProperty == SimObjPrimaryProperty.Moveable;
+		this.isStatic = this.PrimaryProperty == SimObjPrimaryProperty.Static;
         this.IsToggleable = this.isToggleable;
         this.IsOpenable = this.GetComponent<CanOpen_Object>();
         this.IsBreakable = this.GetComponentInChildren<Break>();


### PR DESCRIPTION
-adding improved error messages returned on failed SetObjectPoses

-adding `placeStationary` flag to SetObjectPoses, allowing objects to be posed with kinematic = true, preventing additional physics resolution after repositioning