### PR TITLE
Add GetObjectInFrame(x: float, y: float, forceAction: bool)

### DIFF
--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -23,9 +23,7 @@ import re
 import os
 import platform
 import uuid
-import tty
 import sys
-import termios
 from functools import lru_cache
 
 
@@ -342,16 +340,6 @@ RECEPTACLE_OBJECTS = {
     "TowelHolder": {"Cloth"},
 }
 
-
-def get_term_character():
-    fd = sys.stdin.fileno()
-    old_settings = termios.tcgetattr(fd)
-    try:
-        tty.setraw(sys.stdin.fileno())
-        ch = sys.stdin.read(1)
-    finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
-    return ch
 
 
 def process_alive(pid):
@@ -753,6 +741,8 @@ class Controller(object):
             self._prune_release(release)
 
     def next_interact_command(self):
+        # NOTE: Leave this here because it is incompatible with Windows.
+        from ai2thor.interact import get_term_character
         current_buffer = ""
         while True:
             commands = self._interact_commands

--- a/ai2thor/interact.py
+++ b/ai2thor/interact.py
@@ -1,6 +1,4 @@
-import tty
 import sys
-import termios
 from PIL import Image
 import numpy as np
 import os
@@ -37,6 +35,9 @@ class DefaultActions(Enum):
 
 
 def get_term_character():
+    # NOTE: Leave these imports here! They are incompatible with Windows.
+    import tty
+    import termios
     fd = sys.stdin.fileno()
     old_settings = termios.tcgetattr(fd)
     try:
@@ -215,6 +216,7 @@ class InteractiveControllerPrompt(object):
                 print(" ".join(command_info))
 
     def next_interact_command(self):
+        
         current_buffer = ""
         while True:
             commands = self._interact_commands

--- a/ai2thor/server.py
+++ b/ai2thor/server.py
@@ -122,6 +122,9 @@ class Event(object):
 
         self.events = [self]  # Ensure we have a similar API to MultiAgentEvent
 
+    def __bool__(self):
+        return self.metadata["lastActionSuccess"]
+
     def __repr__(self):
         """Summarizes the results from an Event."""
         action_return = str(self.metadata["actionReturn"])

--- a/ai2thor/server.py
+++ b/ai2thor/server.py
@@ -33,6 +33,9 @@ class MultiAgentEvent(object):
         self.third_party_camera_frames = []
         # XXX add methods for depth,sem_seg
 
+    def __bool__(self):
+        return bool(self._active_event)
+
     @property
     def cv2img(self):
         return self._active_event.cv2img

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -1019,11 +1019,11 @@ def test_get_object_in_frame(controller):
     assert not query, "x=0.6, y=0.6 should fail!"
 
     query = controller.step("GetObjectInFrame", x=0.6, y=0.4)
-    assert query["actionReturn"].startswith(
+    assert query.metadata["actionReturn"].startswith(
         "Cabinet"
     ), "x=0.6, y=0.4 should have a cabinet!"
 
     query = controller.step("GetObjectInFrame", x=0.3, y=0.5)
-    assert query["actionReturn"].startswith(
+    assert query.metadata["actionReturn"].startswith(
         "Fridge"
     ), "x=0.3, y=0.5 should have a fridge!"

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -37,7 +37,7 @@ def build_controller(**args):
 
 wsgi_controller = build_controller(server_class=WsgiServer)
 fifo_controller = build_controller(server_class=FifoServer)
-stochastic_controller = build_controller(agentControllerType='stochastic')
+stochastic_controller = build_controller(agentControllerType="stochastic")
 
 BASE_FP28_POSITION = dict(
     x=-1.5,
@@ -53,10 +53,14 @@ BASE_FP28_LOCATION = dict(
 
 
 def teleport_to_base_location(controller: Controller):
-    assert controller.last_event.metadata["sceneName"].replace("_physics", "") == "FloorPlan28"
+    assert (
+        controller.last_event.metadata["sceneName"].replace("_physics", "")
+        == "FloorPlan28"
+    )
 
     controller.step("TeleportFull", **BASE_FP28_LOCATION)
     assert controller.last_event.metadata["lastActionSuccess"]
+
 
 def teardown_module(module):
     wsgi_controller.stop()
@@ -66,7 +70,9 @@ def teardown_module(module):
 def assert_near(point1, point2, error_message=""):
     assert point1.keys() == point2.keys(), error_message + "Keys mismatch."
     for k in point1.keys():
-        assert abs(point1[k] - point2[k]) < 1e-3, error_message + f"for {k} key, {point1[k]} != {point2[k]}"
+        assert abs(point1[k] - point2[k]) < 1e-3, (
+            error_message + f"for {k} key, {point1[k]} != {point2[k]}"
+        )
 
 
 def test_stochastic_controller():
@@ -137,7 +143,9 @@ def test_small_aspect():
 @pytest.mark.skip(reason="temporarily skipping deprecation test")
 def test_bot_deprecation():
     controller = build_controller(agentMode="bot", width=128, height=64)
-    assert controller.initialization_parameters["agentMode"].lower() == "locobot", "bot should alias to locobot!"
+    assert (
+        controller.initialization_parameters["agentMode"].lower() == "locobot"
+    ), "bot should alias to locobot!"
     controller.stop()
 
 
@@ -193,6 +201,7 @@ def test_reset():
     assert event.depth_frame is None, "depth frame shouldn't have rendered!"
     assert event.frame.shape == (height, width, 3), "RGB frame dimensions are wrong!"
     controller.stop()
+
 
 @pytest.mark.parametrize("controller", [fifo_controller])
 def test_fast_emit(controller):
@@ -263,8 +272,9 @@ def test_target_invocation_exception(controller):
     ], "errorMessage should not be empty when OpenObject(x > 1)."
 
 
-
-@pytest.mark.parametrize("controller", [wsgi_controller, fifo_controller, stochastic_controller])
+@pytest.mark.parametrize(
+    "controller", [wsgi_controller, fifo_controller, stochastic_controller]
+)
 def test_lookup(controller):
 
     e = controller.step(dict(action="RotateLook", rotation=0, horizon=0))
@@ -370,7 +380,9 @@ def test_add_third_party_camera(controller):
     except ValueError as e:
         error_message = str(e)
 
-    assert error_message.startswith("action: AddThirdPartyCamera has an invalid argument: orthographicSize")
+    assert error_message.startswith(
+        "action: AddThirdPartyCamera has an invalid argument: orthographicSize"
+    )
 
 
 def test_update_third_party_camera():
@@ -507,9 +519,7 @@ def test_rotate_right(controller):
 def test_teleport(controller):
     # Checking y coordinate adjustment works
     controller.step(
-        "TeleportFull",
-        **{**BASE_FP28_LOCATION, "y": 0.95},
-        raise_for_failure=True
+        "TeleportFull", **{**BASE_FP28_LOCATION, "y": 0.95}, raise_for_failure=True
     )
     position = controller.last_event.metadata["agent"]["position"]
     assert_near(position, BASE_FP28_POSITION)
@@ -517,7 +527,7 @@ def test_teleport(controller):
     controller.step(
         "TeleportFull",
         **{**BASE_FP28_LOCATION, "x": -2.0, "z": -2.5, "y": 0.95},
-        raise_for_failure=True
+        raise_for_failure=True,
     )
     position = controller.last_event.metadata["agent"]["position"]
     assert_near(position, dict(x=-2.0, z=-2.5, y=0.901))
@@ -528,30 +538,31 @@ def test_teleport(controller):
         "Teleport",
         **{**BASE_FP28_LOCATION, "y": 1.0},
     )
-    assert not controller.last_event.metadata["lastActionSuccess"], (
-        "Teleport should not allow changes for more than 0.05 in the y coordinate."
-    )
-    assert controller.last_event.metadata["agent"]["position"] == before_position, (
-        "After failed teleport, the agent's position should not change."
-    )
+    assert not controller.last_event.metadata[
+        "lastActionSuccess"
+    ], "Teleport should not allow changes for more than 0.05 in the y coordinate."
+    assert (
+        controller.last_event.metadata["agent"]["position"] == before_position
+    ), "After failed teleport, the agent's position should not change."
 
     # Teleporting into an object
     controller.step(
         "Teleport",
-        **{**BASE_FP28_LOCATION, "z":-3.5},
+        **{**BASE_FP28_LOCATION, "z": -3.5},
     )
-    assert not controller.last_event.metadata["lastActionSuccess"], (
-        "Should not be able to teleport into an object."
-    )
+    assert not controller.last_event.metadata[
+        "lastActionSuccess"
+    ], "Should not be able to teleport into an object."
 
     # Teleporting into a wall
     controller.step(
         "Teleport",
         **{**BASE_FP28_LOCATION, "z": 0},
     )
-    assert not controller.last_event.metadata["lastActionSuccess"], (
-        "Should not be able to teleport into a wall."
-    )
+    assert not controller.last_event.metadata[
+        "lastActionSuccess"
+    ], "Should not be able to teleport into a wall."
+
 
 @pytest.mark.parametrize("controller", [wsgi_controller, fifo_controller])
 def test_open(controller):
@@ -905,7 +916,6 @@ def test_get_interactable_poses(controller):
         600 > len(poses) > 400
     ), "Should have around 400 interactable poses next to the fridge!"
 
-
     # teleport to a random pose
     pose = poses[len(poses) // 2]
     event = controller.step("TeleportFull", **pose)
@@ -991,3 +1001,29 @@ def test_get_interactable_poses(controller):
     assert (
         1300 > len(event.metadata["actionReturn"]) > 1100
     ), "GetInteractablePoses with large maxDistance is off!"
+
+
+@pytest.mark.parametrize("controller", [wsgi_controller, fifo_controller])
+def test_get_object_in_frame(controller):
+    controller.reset(scene="FloorPlan28", agentMode="default")
+    event = controller.step(
+        action="TeleportFull",
+        position=dict(x=-1, y=0.900998235, z=-1.25),
+        rotation=dict(x=0, y=90, z=0),
+        horizon=0,
+        standing=True,
+    )
+    assert event, "TeleportFull should have succeeded!"
+
+    query = controller.step("GetObjectInFrame", x=0.6, y=0.6)
+    assert not query, "x=0.6, y=0.6 should fail!"
+
+    query = controller.step("GetObjectInFrame", x=0.6, y=0.4)
+    assert query["actionReturn"].startswith(
+        "Cabinet"
+    ), "x=0.6, y=0.4 should have a cabinet!"
+
+    query = controller.step("GetObjectInFrame", x=0.3, y=0.5)
+    assert query["actionReturn"].startswith(
+        "Fridge"
+    ), "x=0.3, y=0.5 should have a fridge!"

--- a/ai2thor/util/lock.py
+++ b/ai2thor/util/lock.py
@@ -1,6 +1,8 @@
 
 import os
-if os.name == "nt":
+from platform import system
+
+if system() == "Windows":
     class fcntl:
         LOCK_UN = 0
         LOCK_SH = 0

--- a/ai2thor/util/lock.py
+++ b/ai2thor/util/lock.py
@@ -1,6 +1,26 @@
 
 import os
-import fcntl
+if os.name == "nt":
+    class fcntl:
+        LOCK_UN = 0
+        LOCK_SH = 0
+        LOCK_NB = 0
+        LOCK_EX = 0
+
+        @staticmethod
+        def fcntl(fd, op, arg=0):
+            return 0
+        
+        def ioctl(fd, op, arg=0, mutable_flag=True):
+            return 0 if mutable_flag else ""
+        
+        def flock(fd, op):
+            return
+        
+        def lockf(fd, operation, length=0, start=0, whence=0):
+            return
+else:
+    import fcntl
 
 
 class Lock:

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1671,6 +1671,92 @@ namespace UnityStandardAssets.Characters.FirstPerson
 			//body.AddForceAtPosition (m_CharacterController.velocity * 15f, hit.point, ForceMode.Acceleration);//might have to adjust the force vector scalar later
 		}
 
+        // Helper method that parses objectId parameter to return the sim object that it target.
+        // The action is halted if the objectId does not appear in the scene.
+        protected SimObjPhysics getTargetObject(string objectId, bool forceAction = false) {
+            // an objectId was given, so find that target in the scene if it exists
+            if (!physicsSceneManager.ObjectIdToSimObjPhysics.ContainsKey(objectId)) {
+                throw new ArgumentException($"objectId: {objectId} is not the objectId on any object in the scene!");
+            }
+
+            // if object is in the scene and visible, assign it to 'target'
+            SimObjPhysics target = null;
+            foreach (SimObjPhysics sop in VisibleSimObjs(objectId: objectId, forceVisible: forceAction)) {
+                target = sop;
+            }
+
+            // target not found!
+            if (target == null) {
+                throw new NullReferenceException("Target object not found within the specified visibility.");
+            }
+
+            return target;
+        }
+
+        // Helper method that parses (x and y) parameters to return the
+        // sim object that they target.
+        protected SimObjPhysics getTargetObject(float x, float y, bool forceAction) {
+            if (x < 0 || x > 1 || y < 0 || y > 1) {
+                throw new ArgumentOutOfRangeException("x/y must be in [0:1]");
+            }
+            SimObjPhysics target = null;
+            ScreenToWorldTarget((float) x, (float) y, ref target, !forceAction);
+            return target;
+        }
+
+        // used for all actions that need a sim object target
+        // instead of objectId, use screen coordinates to raycast toward potential targets
+        // will set the target object by reference if raycast is successful
+        protected bool ScreenToWorldTarget(float x, float y, ref SimObjPhysics target, bool requireWithinViewportRange) {
+            // reverse the y so that the origin (0, 0) can be passed in as the top left of the screen
+            y = 1.0f - y;
+
+            // cast ray from screen coordinate into world space. If it hits an object
+            Ray ray = m_Camera.ViewportPointToRay(new Vector3(x, y, 0.0f));
+            RaycastHit hit;
+
+            // if something was touched, actionFinished(true) always
+            if (Physics.Raycast(ray, out hit, Mathf.Infinity, 1 << 0 | 1 << 8 | 1 << 10, QueryTriggerInteraction.Ignore)) {
+                if (hit.transform.GetComponent<SimObjPhysics>()) {
+                    // wait! First check if the point hit is withing visibility bounds (camera viewport, max distance etc)
+                    // this should basically only happen if the handDistance value is too big
+                    if (requireWithinViewportRange && !CheckIfTargetPositionIsInViewportRange(hit.point)) {
+                        throw new InvalidOperationException($"Target sim object at screen coordinate: ({x}, {y}) is not within the viewport");
+                    }
+
+                    // it is within viewport, so we are good, assign as target
+                    target = hit.transform.GetComponent<SimObjPhysics>();
+                }
+            }
+
+            // try again, this time cast for placeable surface for things like countertops or interior of cabinets
+            // if no target was found in the layers above, try the SimObjInvisible layer. 
+            // additionally, if a target was found above, but that target was one of the SimObjPhysics Types that can have
+            // PlaceableSurfaces on it, also make sure to check again
+            if (target == null || hasPlaceableSurface.Contains(target.Type)) {
+                if (Physics.Raycast(ray, out hit, Mathf.Infinity, 1 << 11, QueryTriggerInteraction.Ignore)) {
+                    if (hit.transform.GetComponentInParent<SimObjPhysics>()) {
+                        // wait! First check if the point hit is withing visibility bounds (camera viewport, max distance etc)
+                        // this should basically only happen if the handDistance value is too big
+                        if (requireWithinViewportRange && !CheckIfTargetPositionIsInViewportRange(hit.point)) {
+                            throw new InvalidOperationException($"Target sim object at screen coordinate: ({x}, {y}) is not within the viewport");
+                        }
+                        // it is within viewport, so we are good, assign as target
+                        target = hit.transform.GetComponentInParent<SimObjPhysics>();
+                    }
+                }
+            }
+
+            // force update objects to be visible/interactable correctly
+            VisibleSimObjs(false);
+            return true;
+        }
+
+        public void GetTargetObject(float x, float y, bool forceAction = false) {
+            SimObjPhysics target = getTargetObject(x: x, y: y, forceAction: forceAction);
+            actionFinishedEmit(success: true, actionReturn: target.ObjectID);
+        }
+
 		protected void snapAgentToGrid()
 		{
             if (this.snapToGrid) {

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1752,7 +1752,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             return true;
         }
 
-        public void GetTargetObject(float x, float y, bool forceAction = false) {
+        public void GetObjectInFrame(float x, float y, bool forceAction = false) {
             SimObjPhysics target = getTargetObject(x: x, y: y, forceAction: forceAction);
             actionFinishedEmit(success: true, actionReturn: target.ObjectID);
         }

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4599,54 +4599,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             // #endif
         }
 
-        // used for all actions that need a sim object target
-        // instead of objectId, use screen coordinates to raycast toward potential targets
-        // will set the target object by reference if raycast is succesful
-        public bool ScreenToWorldTarget(float x, float y, ref SimObjPhysics target, bool requireWithinViewportRange) {
-            // reverse the y so that the origin (0, 0) can be passed in as the top left of the screen
-            y = 1.0f - y;
-
-            // cast ray from screen coordinate into world space. If it hits an object
-            Ray ray = m_Camera.ViewportPointToRay(new Vector3(x, y, 0.0f));
-            RaycastHit hit;
-
-            // if something was touched, actionFinished(true) always
-            if (Physics.Raycast(ray, out hit, Mathf.Infinity, 1 << 0 | 1 << 8 | 1 << 10, QueryTriggerInteraction.Ignore)) {
-                if (hit.transform.GetComponent<SimObjPhysics>()) {
-                    // wait! First check if the point hit is withing visibility bounds (camera viewport, max distance etc)
-                    // this should basically only happen if the handDistance value is too big
-                    if (requireWithinViewportRange && !CheckIfTargetPositionIsInViewportRange(hit.point)) {
-                        throw new InvalidOperationException($"Target sim object at screen coordinate: ({x}, {y}) is not within the viewport");
-                    }
-
-                    // it is within viewport, so we are good, assign as target
-                    target = hit.transform.GetComponent<SimObjPhysics>();
-                }
-            }
-
-            // try again, this time cast for placeable surface for things like countertops or interior of cabinets
-            // if no target was found in the layers above, try the SimObjInvisible layer. 
-            // additionally, if a target was found above, but that target was one of the SimObjPhysics Types that can have
-            // PlaceableSurfaces on it, also make sure to check again
-            if (target == null || hasPlaceableSurface.Contains(target.Type)) {
-                if (Physics.Raycast(ray, out hit, Mathf.Infinity, 1 << 11, QueryTriggerInteraction.Ignore)) {
-                    if (hit.transform.GetComponentInParent<SimObjPhysics>()) {
-                        // wait! First check if the point hit is withing visibility bounds (camera viewport, max distance etc)
-                        // this should basically only happen if the handDistance value is too big
-                        if (requireWithinViewportRange && !CheckIfTargetPositionIsInViewportRange(hit.point)) {
-                            throw new InvalidOperationException($"Target sim object at screen coordinate: ({x}, {y}) is not within the viewport");
-                        }
-                        // it is within viewport, so we are good, assign as target
-                        target = hit.transform.GetComponentInParent<SimObjPhysics>();
-                    }
-                }
-            }
-
-            // force update objects to be visible/interactable correctly
-            VisibleSimObjs(false);
-            return true;
-        }
-
         public void PickupObject(ServerAction action) //use serveraction objectid
         {
             //specify target to pickup via objectId or coordinates

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -2654,30 +2654,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             public float armsLength;//the amount the hand moved from it's starting position to hit the object touched
         }
 
-        //checks if the target position in space is within the agent's current viewport
-        public bool CheckIfTargetPositionIsInViewportRange(Vector3 targetPosition)
-        {
-            //now check if the target position is within bounds of the Agent's forward (z) view
-            Vector3 tmp = m_Camera.transform.position;
-            tmp.y = targetPosition.y;
-
-            if (Vector3.Distance(tmp, targetPosition) > maxVisibleDistance) // + 0.3)
-            {
-                errorMessage = "The target position is outside the agent's max visible distance.";
-                return false;
-            }
-
-            //now make sure that the targetPosition is within the Agent's x/y view, restricted by camera
-            Vector3 vp = m_Camera.WorldToViewportPoint(targetPosition);
-            if(vp.z < 0 || vp.x > 1.0f || vp.y < 0.0f || vp.y > 1.0f || vp.y < 0.0f)
-            {
-                errorMessage = "The target position is outside the viewport.";
-                return false;
-            }
-
-            return true;
-        }
-
         //checks if agent hand that is holding an object can move to a target location. Returns false if any obstructions
         public bool CheckIfAgentCanMoveHand(Vector3 targetPosition, bool mustBeVisible = false) {
             bool result = false;

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -26,13 +26,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         public MeshRenderer MyFaceMesh;
         public int AdvancePhysicsStepCount;
         public GameObject[] TargetCircles = null;
-        //these object types can have a placeable surface mesh associated ith it
-        //this is to be used with ScreenToWorldTarget to filter out raycasts correctly
-        private List<SimObjType> hasPlaceableSurface = new List<SimObjType>()
-        {
-            SimObjType.Bathtub, SimObjType.Sink, SimObjType.Drawer, SimObjType.Cabinet, 
-            SimObjType.CounterTop, SimObjType.Shelf
-        };
 
         //change visibility check to use this distance when looking down
         //protected float DownwardViewDistance = 2.0f;

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -5080,39 +5080,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             actionFinished(true);
         }
 
-        // Helper method that parses objectId parameter to return the sim object that it target.
-        // The action is halted if the objectId does not appear in the scene.
-        private SimObjPhysics getTargetObject(string objectId, bool forceAction = false) {
-            // an objectId was given, so find that target in the scene if it exists
-            if (!physicsSceneManager.ObjectIdToSimObjPhysics.ContainsKey(objectId)) {
-                throw new ArgumentException($"objectId: {objectId} is not the objectId on any object in the scene!");
-            }
-
-            // if object is in the scene and visible, assign it to 'target'
-            SimObjPhysics target = null;
-            foreach (SimObjPhysics sop in VisibleSimObjs(objectId: objectId, forceVisible: forceAction)) {
-                target = sop;
-            }
-
-            // target not found!
-            if (target == null) {
-                throw new NullReferenceException("Target object not found within the specified visibility.");
-            }
-
-            return target;
-        }
-
-        // Helper method that parses (x and y) parameters to return the
-        // sim object that they target.
-        private SimObjPhysics getTargetObject(float x, float y, bool forceAction) {
-            if (x < 0 || x > 1 || y < 0 || y > 1) {
-                throw new ArgumentOutOfRangeException("x/y must be in [0:1]");
-            }
-            SimObjPhysics target = null;
-            ScreenToWorldTarget((float) x, (float) y, ref target, !forceAction);
-            return target;
-        }
-
         // syntactic sugar for open object with openness = 0.
         public void CloseObject(string objectId, bool forceAction = false) {
             OpenObject(objectId: objectId, forceAction: forceAction, openness: 0);


### PR DESCRIPTION
Basically exposes the functionality for `getTargetObject(x, y)`, as requested in #483.

Also, I plan to deprecate every single action that uses `x`, `y`, and `objectId`, in favor of people first calling:
```python
query = controller.step("GetObjectInFrame", x=x, y=y, forceAction=True)
if query:
    objectId = query.metadata['actionReturn']
    controller.step('OpenObject', objectId=objectId)
```

Note that I have overwritten `__bool__` so that it points to `event.metadata['lastActionSuccess']`.