### PR TITLE
Add GetCoordinateAtPixel query action

### DIFF
--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -1164,5 +1164,5 @@ def test_get_coordinate_at_pixel(controller):
     query = controller.step("GetCoordinateAtPixel", x=0.25, y=0.5)
     assert_near(
         query.metadata["actionReturn"],
-        {"x": -0.596839666, "y": 1.57599819, "z": -0.668121457},
+        {'x': -0.5968407392501831, 'y': 1.5759981870651245, 'z': -1.0484200716018677}
     )

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -1131,3 +1131,38 @@ def test_get_object_in_frame(controller):
     assert query.metadata["actionReturn"].startswith(
         "Fridge"
     ), "x=0.3, y=0.5 should have a fridge!"
+
+
+@pytest.mark.parametrize("controller", [wsgi_controller, fifo_controller])
+def test_get_coordinate_at_pixel(controller):
+    controller.reset(scene="FloorPlan28")
+    event = controller.step(
+        action="TeleportFull",
+        position=dict(x=-1.5, y=0.900998235, z=-1.5),
+        rotation=dict(x=0, y=90, z=0),
+        horizon=0,
+        standing=True,
+    )
+    assert event, "TeleportFull should have succeeded!"
+
+    for x, y in [(1.5, 0.5), (1.1, 0.3), (-0.1, 0.8), (-0.5, -0.3)]:
+        query = controller.step("GetCoordinateAtPixel", x=x, y=y)
+        assert not query, f"x={x}, y={y} should fail!"
+
+    query = controller.step("GetCoordinateAtPixel", x=0.5, y=0.5)
+    assert_near(
+        query.metadata["actionReturn"],
+        {"x": -0.344259053, "y": 1.57599819, "z": -1.49999917},
+    )
+
+    query = controller.step("GetCoordinateAtPixel", x=0.5, y=0.2)
+    assert_near(
+        query.metadata["actionReturn"],
+        {"x": -0.344259053, "y": 2.2694428, "z": -1.49999917},
+    )
+
+    query = controller.step("GetCoordinateAtPixel", x=0.25, y=0.5)
+    assert_near(
+        query.metadata["actionReturn"],
+        {"x": -0.596839666, "y": 1.57599819, "z": -0.668121457},
+    )

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1750,6 +1750,27 @@ namespace UnityStandardAssets.Characters.FirstPerson
             actionFinishedEmit(success: true, actionReturn: target.ObjectID);
         }
 
+        public void GetCoordinateAtPixel(float x, float y) {
+            if (x < 0 || y < 0 || x > 1 || y > 1) {
+                throw new ArgumentOutOfRangeException($"x and y must be in [0:1] not (x={x}, y={y}).");
+            }
+
+            Ray ray = m_Camera.ViewportPointToRay(new Vector3(x, 1 - y, 0));
+            RaycastHit hit;
+            Physics.Raycast(
+                ray: ray,
+                hitInfo: out hit,
+                maxDistance: Mathf.Infinity,
+                layerMask: LayerMask.GetMask("Default", "Agent", "SimObjVisible", "PlaceableSurface"),
+                queryTriggerInteraction: QueryTriggerInteraction.Ignore
+            );
+
+            actionFinishedEmit(
+                success: true,
+                actionReturn: hit.point
+            );
+        }
+
 		protected void snapAgentToGrid()
 		{
             if (this.snapToGrid) {

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -3331,6 +3331,17 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         break;
                     }
 
+                    case "gcap":
+                    {
+                        Dictionary<string, object> action = new Dictionary<string, object>();
+                        action["action"] = "GetCoordinateAtPixel";
+                        action["x"] = float.Parse(splitcommand[1]);
+                        action["y"] = float.Parse(splitcommand[2]);
+
+                        CurrentActiveController().ProcessControlCommand(action);
+                        break;
+                    }
+
                     case "telefull":
                     {
                         Dictionary<string, object> action = new Dictionary<string, object>();


### PR DESCRIPTION
For a given (x, y) point in the last frame, it returns the global coordinate of the object that is first hit by a RayCast going through that (x, y) point.

For instance, let `x=0.25` and `y=0.5` in the image below. The actionReturn would be the first global 3D point hit by a RayCast at `x=0.25` and `y=0.5`, or `x=-0.5968, y=1.5759, z=-1.0484` as read in the editor, in this case.
![image](https://user-images.githubusercontent.com/28768645/109858827-2a3f1e80-7c11-11eb-8c40-9453f386a903.png)


Requested in https://github.com/allenai/ai2thor/issues/483#issuecomment-786962805 and previously proposed by @Lucaweihs (but it ended up not being added to master because his only use for it was debugging).