### PR TITLE
fix to check in SetObjectStates logic

### DIFF
--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4182,8 +4182,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 while (numStillGoing > 0) {
                     foreach (SimObjPhysics sop in animating) {
                         if (animatingType.ContainsKey(sop) &&
-                            (animatingType[sop] == "toggleable" || animatingType[sop] == "openable") && 
-                            sop.GetComponent<CanToggleOnOff>().GetiTweenCount() == 0
+                            (animatingType[sop] == "toggleable" && sop.GetComponent<CanToggleOnOff>().GetiTweenCount() == 0 || animatingType[sop] == "openable") && 
+                            sop.GetComponent<CanOpen_Object>().GetiTweenCount() == 0
                         ) {
                             numStillGoing--;
                         }


### PR DESCRIPTION
originally toggleble and openable objects both attempted to access the CanToggleOnOff component, causing a null reference exception when trying to set states of openable objects that were also not toggleable