### PR TITLE
Added Box-Casting to CheckIfAgentCanRotate method, and consolidated logic to work for both pitching and yawing

### DIFF
--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4782,7 +4782,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 target.GetComponent<Rigidbody>().isKinematic = wasKinematic;
                 target.transform.position = savedPos;
                 target.transform.rotation = savedRot;
-                Debug.Log(target.isInAgentHand + "...is it true or false...?");
                 target.transform.SetParent(savedParent);
                 ItemInHand = null;
                 DropContainedObjects(

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -481,11 +481,15 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         private bool checkArcForCollisions(BoxCollider bb, Vector3 origin, float degrees, int dirSign, Vector3 dirAxis)
         {
             bool result = true;
+            float arcIncrementDistance;
             Vector3 bbWorldCenter = bb.transform.TransformPoint(bb.center);
             Vector3 bbHalfExtents = bb.size / 2.0f;
 
             //Generate arc points in the positive y-axis rotation
             OrientedPoint[] pointsOnArc = GenerateArcPoints(bbWorldCenter, bb.transform.rotation, origin, degrees, dirSign, dirAxis);
+
+            //Save the arc-distance to a value to reduce computation in the for-loop, since it's the same between every OrientedPoint
+            arcIncrementDistance = (pointsOnArc[1].position - pointsOnArc[0].position).magnitude;
 
             //Raycast from first point in pointsOnArc, stepwise to last point. If any collisions are hit, immediately return 
             for (int i = 0; i < pointsOnArc.Length - 1; i++)
@@ -495,7 +499,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                 //Debug.DrawLine(pointsOnArc[i].position, pointsOnArc[i+1].position, Color.magenta, 500.0f);
 
-                if (Physics.BoxCast(pointsOnArc[i].position, bbHalfExtents, pointsOnArc[i + 1].position - pointsOnArc[i].position, out hit, Quaternion.Lerp(pointsOnArc[i].orientation, pointsOnArc[i + 1].orientation, 0.5f), (pointsOnArc[i + 1].position - pointsOnArc[i].position).magnitude, 1 << 8 | 1 << 10, QueryTriggerInteraction.Ignore))
+                if (Physics.BoxCast(pointsOnArc[i].position, bbHalfExtents, pointsOnArc[i + 1].position - pointsOnArc[i].position, out hit, Quaternion.Lerp(pointsOnArc[i].orientation, arcIncrementDistance, 1 << 8 | 1 << 10, QueryTriggerInteraction.Ignore))
                     {
                         if (hit.transform.GetComponent<SimObjPhysics>())
                         {

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -499,7 +499,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                 //Debug.DrawLine(pointsOnArc[i].position, pointsOnArc[i+1].position, Color.magenta, 500.0f);
 
-                if (Physics.BoxCast(pointsOnArc[i].position, bbHalfExtents, pointsOnArc[i + 1].position - pointsOnArc[i].position, out hit, Quaternion.Lerp(pointsOnArc[i].orientation, arcIncrementDistance, 1 << 8 | 1 << 10, QueryTriggerInteraction.Ignore))
+                if (Physics.BoxCast(pointsOnArc[i].position, bbHalfExtents, pointsOnArc[i + 1].position - pointsOnArc[i].position, out hit,
+                    Quaternion.Lerp(pointsOnArc[i].orientation, pointsOnArc[i + 1].orientation, 0.5f), arcIncrementDistance, 1 << 8 | 1 << 10,
+                    QueryTriggerInteraction.Ignore))
                     {
                         if (hit.transform.GetComponent<SimObjPhysics>())
                         {

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -487,8 +487,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             //Generate arc points in the positive y-axis rotation
             OrientedPoint[] pointsOnArc = GenerateArcPoints(bbWorldCenter, bb.transform.rotation, origin, degrees, dirSign, dirAxis);
 
-            Debug.Log("Hello world!");
-
             //Raycast from first point in pointsOnArc, stepwise to last point. If any collisions are hit, immediately return 
             for (int i = 0; i < pointsOnArc.Length - 1; i++)
             {
@@ -497,7 +495,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                 //Debug.DrawLine(pointsOnArc[i].position, pointsOnArc[i+1].position, Color.magenta, 500.0f);
 
-                if (Physics.BoxCast(pointsOnArc[i].position, bbHalfExtents, pointsOnArc[i + 1].position - pointsOnArc[i].position, out hit, pointsOnArc[i].orientation, (pointsOnArc[i + 1].position - pointsOnArc[i].position).magnitude, 1 << 8 | 1 << 10, QueryTriggerInteraction.Ignore))
+                if (Physics.BoxCast(pointsOnArc[i].position, bbHalfExtents, pointsOnArc[i + 1].position - pointsOnArc[i].position, out hit, Quaternion.Lerp(pointsOnArc[i].orientation, pointsOnArc[i + 1].orientation, 0.5f), (pointsOnArc[i + 1].position - pointsOnArc[i].position).magnitude, 1 << 8 | 1 << 10, QueryTriggerInteraction.Ignore))
                     {
                         if (hit.transform.GetComponent<SimObjPhysics>())
                         {
@@ -555,12 +553,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 arcPoints[i].orientation = rotPoint.transform.rotation;
                 //arcPoints[i] = RotatePointAroundPivot(startingPoint, origin, new Vector3(0, currentIncrementAngle, 0));
                 //arcPoints[(i - 1) / 2].orientation = rotPoint.transform.rotation;
-            }
-
-            //Update orientations of OrientedPoints so each reflects the average orientation over the course of its arc-increment (except for the final point, whose orientation isn't used)
-            for (int i = 0; i < arcPoints.Length - 1; i++)
-            {
-                arcPoints[i].orientation = Quaternion.Lerp(arcPoints[i].orientation, arcPoints[i + 1].orientation, 0.5f);
 
                 ////Visualize box volumes
                 //GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -533,7 +533,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         //Returns an array of OrientedPoints along the arc of the rotation for a given starting point about an origin point for a total given angle
         private OrientedPoint[] GenerateArcPoints(Vector3 startingPoint, Quaternion startingRotation, Vector3 origin, float angle, int dirSign, Vector3 dirAxis)
         {
-            float incrementAngle = angle/10f; //divide the total amount we are rotating by 20 to get 10 points on the arc for positions, and another 10 for the correct BoxCast orientations
+            float incrementAngle = angle/10f; //divide the total amount we are rotating by 10 to get 10 points on the arc for positions
             OrientedPoint[] arcPoints = new OrientedPoint[11]; //we just always want 10 points in addition to our starting corner position (11 total) to check against per corner
             float currentIncrementAngle;
 

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -17,6 +17,12 @@ using RandomExtensions;
 
 namespace UnityStandardAssets.Characters.FirstPerson {
     [RequireComponent(typeof(CharacterController))]
+    public class OrientedPoint
+    {
+        public Vector3 position = new Vector3();
+        public Quaternion orientation = new Quaternion();
+    }
+
     public class PhysicsRemoteFPSAgentController : BaseFPSAgentController {
         [SerializeField] protected GameObject[] ToSetActive = null;
         protected Dictionary<string, Dictionary<int, Material[]>> maskedObjects = new Dictionary<string, Dictionary<int, Material[]>>();
@@ -138,7 +144,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             physicsSceneManager.GetComponent<PhysicsSceneManager>().AllowDecayTemperature = allowDecayTemperature;
             actionFinished(true);
         }
-
 
         private void LateUpdate() {
             //make sure this happens in late update so all physics related checks are done ahead of time
@@ -347,7 +352,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             //force the degree increment to the nearest tenths place
             //this is to prevent too small of a degree increment change that could cause float imprecision
-            action.degrees = Mathf.Round(action.degrees * 10.0f)/ 10.0f;
+            action.degrees = Mathf.Round(action.degrees * 10.0f) / 10.0f;
 
             if(!checkForUpDownAngleLimit("down", action.degrees))
             {
@@ -462,136 +467,107 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 //only default hand if not manually Interacting with things
                 if(!action.manualInteract)
                 DefaultAgentHand();
-                
+
                 base.RotateLeft(action);
             } 
 
             else 
             {
-                errorMessage = "a held item: " + ItemInHand.transform.name + " with something if agent rotates Left " + action.degrees+ " degrees";
+                errorMessage = "a held item: " + ItemInHand.transform.name + " with something if agent rotates Left " + action.degrees + " degrees";
                 actionFinished(false);
             }
         }
 
-        private bool checkArcForCollisions(Vector3[] corners, Vector3 origin, float degrees, string dir)
+        private bool checkArcForCollisions(BoxCollider bb, Vector3 origin, float degrees, int dirSign, Vector3 dirAxis)
         {
             bool result = true;
-            
-            //generate arc points in the positive y axis rotation
-            foreach(Vector3 v in corners)
+            Vector3 bbWorldCenter = bb.transform.TransformPoint(bb.center);
+            Vector3 bbHalfExtents = bb.size / 2.0f;
+
+            //Generate arc points in the positive y-axis rotation
+            OrientedPoint[] pointsOnArc = GenerateArcPoints(bbWorldCenter, bb.transform.rotation, origin, degrees, dirSign, dirAxis);
+
+            Debug.Log("Hello world!");
+
+            //Raycast from first point in pointsOnArc, stepwise to last point. If any collisions are hit, immediately return 
+            for (int i = 0; i < pointsOnArc.Length - 1; i++)
             {
-                Vector3[] pointsOnArc = GenerateArcPoints(v, origin, degrees, dir);
+                RaycastHit hit;
+                //do boxcasts from the first point, sequentially, to the last
 
-                //raycast from first point in pointsOnArc, stepwise to the last point. If any collisions are hit, immediately return
-                for(int i = 0; i < pointsOnArc.Length; i++)
-                {
-                    //debug draw spheres to show path of arc
-                    // GameObject Sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-                    // Sphere.transform.position = pointsOnArc[i];
-                    // Sphere.transform.localScale = new Vector3(0.02f, 0.02f, 0.02f);
-                    // Sphere.GetComponent<SphereCollider>().enabled = false;
-                    
-                    RaycastHit hit;
+                //Debug.DrawLine(pointsOnArc[i].position, pointsOnArc[i+1].position, Color.magenta, 500.0f);
 
-                    //do linecasts from the first point, sequentially, to the last
-                    if(i < pointsOnArc.Length - 1)
+                if (Physics.BoxCast(pointsOnArc[i].position, bbHalfExtents, pointsOnArc[i + 1].position - pointsOnArc[i].position, out hit, pointsOnArc[i].orientation, (pointsOnArc[i + 1].position - pointsOnArc[i].position).magnitude, 1 << 8 | 1 << 10, QueryTriggerInteraction.Ignore))
                     {
-                        //Debug.DrawLine(pointsOnArc[i], pointsOnArc[i+1], Color.magenta, 50f);
-
-                        if(Physics.Linecast(pointsOnArc[i], pointsOnArc[i+1], out hit, 1 << 8 | 1 << 10, QueryTriggerInteraction.Ignore))
+                        if (hit.transform.GetComponent<SimObjPhysics>())
                         {
-                            if(hit.transform.GetComponent<SimObjPhysics>())
-                            {
-                                //if we hit the item in our hand, skip
-                                if(hit.transform.GetComponent<SimObjPhysics>().transform == ItemInHand.transform)
+                            //if we hit the item in our hand, skip
+                            if (hit.transform.GetComponent<SimObjPhysics>().transform == ItemInHand.transform)
                                 continue;
-                            }
-
-                            if(hit.transform == this.transform)
-                            {
-                                //don't worry about clipping the object into this agent
-                                continue;
-                            }
-
-                            result = false;
-                            break;
                         }
+
+                        if (hit.transform == this.transform)
+                        {
+                            //don't worry about clipping the object into this agent
+                            continue;
+                        }
+
+                        result = false;
+                        break;
                     }
-                }
+            }
+
+            //OverlapBox check for final rotated state of GameObject, since arc-points are using averaged orientations, and the final state of orientation is high-priority
+            rotPoint.transform.position = bbWorldCenter;
+            rotPoint.transform.rotation = bb.transform.rotation;
+            //Rotate the rotPoint around the origin by the current increment's angle, relative to the correct axis
+            rotPoint.transform.RotateAround(origin, dirAxis, dirSign * degrees);
+
+            if (Physics.OverlapBox(rotPoint.position, bbHalfExtents, rotPoint.transform.rotation, 1 << 8 | 1 << 10, QueryTriggerInteraction.Ignore).Length != 0)
+            {
+                
+                result = false;
             }
 
             return result;
         }
 
-        //for use with each of the 8 corners of a picked up object's bounding box - returns an array of Vector3 points along the arc of the rotation for a given starting point
-        //given a starting Vector3, rotate about an origin point for a total given angle. maxIncrementAngle is the maximum value of the increment between points on the arc. 
-        //if leftOrRight is true - rotate around Y (rotate left/right), false - rotate around X (look up/down)
-        private Vector3[] GenerateArcPoints(Vector3 startingPoint, Vector3 origin, float angle, string dir)
+        //Returns an array of OrientedPoints along the arc of the rotation for a given starting point about an origin point for a total given angle
+        private OrientedPoint[] GenerateArcPoints(Vector3 startingPoint, Quaternion startingRotation, Vector3 origin, float angle, int dirSign, Vector3 dirAxis)
         {
-            float incrementAngle = angle/10f; //divide the total amount we are rotating by 10 to get 10 points on the arc
-            Vector3[] arcPoints = new Vector3[11]; //we just always want 10 points in addition to our starting corner position (11 total) to check against per corner
+            float incrementAngle = angle/10f; //divide the total amount we are rotating by 20 to get 10 points on the arc for positions, and another 10 for the correct BoxCast orientations
+            OrientedPoint[] arcPoints = new OrientedPoint[11]; //we just always want 10 points in addition to our starting corner position (11 total) to check against per corner
             float currentIncrementAngle;
 
-            if (dir == "left") //Yawing left (Rotating across XZ plane around Y-pivot)
+            //Calculate positions of all 10 OrientedPoints
+            for (int i = 0; i < arcPoints.Length; i++)
             {
-                for (int i = 0; i < arcPoints.Length; i++)
-                {
-                    currentIncrementAngle = i * -incrementAngle;
-                    //move the rotPoint to the current corner's position
-                    rotPoint.transform.position = startingPoint;
-                    //rotate the rotPoint around the origin the current increment's angle, relative to the correct axis
-                    rotPoint.transform.RotateAround(origin, transform.up, currentIncrementAngle);
-                    //set the current arcPoint's vector3 to the rotated point
-                    arcPoints[i] = rotPoint.transform.position;
-                    //arcPoints[i] = RotatePointAroundPivot(startingPoint, origin, new Vector3(0, currentIncrementAngle, 0));
-                }
+                currentIncrementAngle = i * dirSign * incrementAngle;
+                //Move and orient the rotPoint to the bb's position and orientation
+                rotPoint.transform.position = startingPoint;
+                rotPoint.transform.rotation = startingRotation;
+                //Rotate the rotPoint around the origin by the current increment's angle, relative to the correct axis
+                rotPoint.transform.RotateAround(origin, dirAxis, currentIncrementAngle);
+
+                arcPoints[i] = new OrientedPoint();
+                //set the current arcPoint's position to the rotated point
+                arcPoints[i].position = rotPoint.transform.position;
+                arcPoints[i].orientation = rotPoint.transform.rotation;
+                //arcPoints[i] = RotatePointAroundPivot(startingPoint, origin, new Vector3(0, currentIncrementAngle, 0));
+                //arcPoints[(i - 1) / 2].orientation = rotPoint.transform.rotation;
             }
 
-            if (dir == "right") //Yawing right (Rotating across XZ plane around Y-pivot)
+            //Update orientations of OrientedPoints so each reflects the average orientation over the course of its arc-increment (except for the final point, whose orientation isn't used)
+            for (int i = 0; i < arcPoints.Length - 1; i++)
             {
-                for (int i = 0; i < arcPoints.Length; i++)
-                {
-                    currentIncrementAngle = i * incrementAngle;
-                    //move the rotPoint to the current corner's position
-                    rotPoint.transform.position = startingPoint;
-                    //rotate the rotPoint around the origin the current increment's angle, relative to the correct axis
-                    rotPoint.transform.RotateAround(origin, transform.up, currentIncrementAngle);
-                    //set the current arcPoint's vector3 to the rotated point
-                    arcPoints[i] = rotPoint.transform.position;
-                    //arcPoints[i] = RotatePointAroundPivot(startingPoint, origin, new Vector3(0, currentIncrementAngle, 0));
-                }
-            }
+                arcPoints[i].orientation = Quaternion.Lerp(arcPoints[i].orientation, arcPoints[i + 1].orientation, 0.5f);
 
-            else if(dir =="up") //Pitching up(Rotating across YZ plane around X-pivot)
-            {
-                for (int i = 0; i < arcPoints.Length; i++)
-                {
-                    //reverse the increment angle because of the right handedness orientation of the local x-axis
-                    currentIncrementAngle = i * -incrementAngle;
-                    //move the rotPoint to the current corner's position
-                    rotPoint.transform.position = startingPoint;
-                    //rotate the rotPoint around the origin the current increment's angle, relative to the correct axis
-                    rotPoint.transform.RotateAround(origin, transform.right, currentIncrementAngle);
-                    //set the current arcPoint's vector3 to the rotated point
-                    arcPoints[i] = rotPoint.transform.position;
-                    //arcPoints[i] = RotatePointAroundPivot(startingPoint, origin, new Vector3(0, currentIncrementAngle, 0));
-                }
-            }
-
-            else if(dir == "down") //Pitching down (Rotating across YZ plane around X-pivot)
-            {
-                for (int i = 0; i < arcPoints.Length; i++)
-                {
-                    //reverse the increment angle because of the right handedness orientation of the local x-axis
-                    currentIncrementAngle = i * incrementAngle;
-                    //move the rotPoint to the current corner's position
-                    rotPoint.transform.position = startingPoint;
-                    //rotate the rotPoint around the origin the current increment's angle, relative to the correct axis
-                    rotPoint.transform.RotateAround(origin, transform.right, currentIncrementAngle);
-                    //set the current arcPoint's vector3 to the rotated point
-                    arcPoints[i] = rotPoint.transform.position;
-                    //arcPoints[i] = RotatePointAroundPivot(startingPoint, origin, new Vector3(0, currentIncrementAngle, 0));
-                }
+                ////Visualize box volumes
+                //GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                //cube.transform.position = arcPoints[i].position;
+                //cube.transform.rotation = arcPoints[i].orientation;
+                //cube.transform.localScale = new Vector3(size.x, size.y, size.z);
+                //cube.GetComponent<Renderer>().material.color = UnityEngine.Random.ColorHSV();
             }
 
             return arcPoints;
@@ -627,21 +603,48 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             bool result = true;
 
+            //Get held object's bounding box
             BoxCollider bb = ItemInHand.GetComponent<SimObjPhysics>().BoundingBox.GetComponent<BoxCollider>();
 
-            //get world coordinates of object in hand's bounding box corners
-            Vector3[] corners = UtilityFunctions.CornerCoordinatesOfBoxColliderToWorld(bb);
+            //Establish the directionality of specified rotation
+            int dirSign = -1;
+            Vector3 dirAxis = transform.up;
+            Vector3 origin = m_CharacterController.transform.position;
 
-            //ok now we have each corner, let's rotate them the specified direction
-            if(direction == "right" || direction == "left")
+            //Yawing left (Rotating negatively across XZ plane around CharacterController)
+            if (direction == "left")
             {
-                result = checkArcForCollisions(corners, m_CharacterController.transform.position, degrees, direction);
+                dirSign = -1;
+                dirAxis = transform.up;
+                origin = m_CharacterController.transform.position;
             }
 
-            else if(direction == "up" || direction == "down")
+            //Yawing right (Rotating positively across XZ plane around CharacterController)
+            else if (direction == "right")
             {
-                result = checkArcForCollisions(corners, m_Camera.transform.position, degrees, direction);
+                dirSign = 1;
+                dirAxis = transform.up;
+                origin = m_CharacterController.transform.position;
             }
+
+            //Pitching up (Rotating negatively across YZ plane around camera)
+            else if (direction == "up")
+            {
+                dirSign = -1;
+                dirAxis = transform.right;
+                origin = m_Camera.transform.position;
+            }
+
+            //Pitching down (Rotating positively across YZ plane around camera)
+            else if (direction == "down")
+            {
+                dirSign = 1;
+                dirAxis = transform.right;
+                origin = m_Camera.transform.position;
+            }
+
+            result = checkArcForCollisions(bb, origin, degrees, dirSign, dirAxis);
+
             //no checks flagged anything, good to go, return true i guess
             return result;
         }
@@ -4779,6 +4782,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 target.GetComponent<Rigidbody>().isKinematic = wasKinematic;
                 target.transform.position = savedPos;
                 target.transform.rotation = savedRot;
+                Debug.Log(target.isInAgentHand + "...is it true or false...?");
                 target.transform.SetParent(savedParent);
                 ItemInHand = null;
                 DropContainedObjects(


### PR DESCRIPTION
The current collision check for the arc of held objects during an agent rotation or look-up/look-down action is to take the eight corner points of the object's bounding box, and Raycast each one along their respective arc-trajectories. This is ineffective, however, if the arc overlaps with a thin or narrow object that does not intersect with any of the corner points. I updated the logic to use BoxCasts instead, so that instead of casting points, the entire bounding box of the object is cast along the arc.

Additionally, the current logic was essentially duplicated four times to accommodate the slight differences in the operations involved in turning left and right, and looking up and down. I consolidated the logic to work with all four operations by adding relevant variables and assigning them the correct values early on, based on the input string (i.e. "left", "right, "up", "down").