### PR TITLE
#webgl-deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,3 @@ We have done our best to fix all bugs and issues. However, you might still encou
 
 AI2-THOR is an open-source project backed by [the Allen Institute for Artificial Intelligence (AI2)](http://www.allenai.org).
 AI2 is a non-profit institute with the mission to contribute to humanity through high-impact AI research and engineering.
-

--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ We have done our best to fix all bugs and issues. However, you might still encou
 
 AI2-THOR is an open-source project backed by [the Allen Institute for Artificial Intelligence (AI2)](http://www.allenai.org).
 AI2 is a non-profit institute with the mission to contribute to humanity through high-impact AI research and engineering.
+

--- a/unity/Assets/Scripts/DebugFPSAgentController.cs
+++ b/unity/Assets/Scripts/DebugFPSAgentController.cs
@@ -87,8 +87,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             return hit.point + new Vector3(0, yOffset, 0);
 		}
 
-        public void HideHUD()
-        {
+        public void HideHUD() {
             if (InputMode_Text != null) {
                 InputMode_Text.SetActive(false);
             }
@@ -101,33 +100,27 @@ namespace UnityStandardAssets.Characters.FirstPerson
             }
         }
 
-        public void SetScroll2DEnabled(bool enabled)
-        {
+        public void SetScroll2DEnabled(bool enabled) {
             this.scroll2DEnabled = enabled;
         }
 
-        public void OnEnable()
-        {
-            
-                FPSEnabled = true;
-                Cursor.visible = false;
-                Cursor.lockState = CursorLockMode.Locked;
-                
-                InputMode_Text = GameObject.Find("DebugCanvasPhysics/InputModeText");
-                InputFieldObj = GameObject.Find("DebugCanvasPhysics/InputField");
-                if (InputMode_Text) {
-                    InputMode_Text.GetComponent<Text>().text = "FPS Mode";
-                }
+        public void OnEnable() {
+            FPSEnabled = true;
+            Cursor.visible = false;
+            Cursor.lockState = CursorLockMode.Locked;
 
+            InputMode_Text = GameObject.Find("DebugCanvasPhysics/InputModeText");
+            InputFieldObj = GameObject.Find("DebugCanvasPhysics/InputField");
+            if (InputMode_Text) {
+                InputMode_Text.GetComponent<Text>().text = "FPS Mode";
+            }
 
-                Debug_Canvas = GameObject.Find("DebugCanvasPhysics");
-  
-                Debug_Canvas.GetComponent<Canvas>().enabled = true;
-              
+            Debug_Canvas = GameObject.Find("DebugCanvasPhysics");
+
+            Debug_Canvas.GetComponent<Canvas>().enabled = true;
         }
 
-        public void OnDisable()
-        {
+        public void OnDisable() {
             DisableMouseControl();
             //  if (InputFieldObj) {
             //     InputFieldObj.SetActive(true);
@@ -166,77 +159,35 @@ namespace UnityStandardAssets.Characters.FirstPerson
             }
 
 			//swap between text input and not
-            /*
-			if (
-                Input.GetKeyDown(KeyCode.BackQuote)
-                // || Input.GetKeyDown(KeyCode.Escape)
-            )
-            {
-				//Switch to Text Mode
-                if (FPSEnabled)
-                {
-                    if (InputMode_Text) {
-                        InputMode_Text.GetComponent<Text>().text = "FPS Mode";
+            #if !UNITY_WEBGL
+                if (
+                    Input.GetKeyDown(KeyCode.BackQuote)
+                    || Input.GetKeyDown(KeyCode.Escape)
+                ) {
+                    //Switch to Text Mode
+                    if (FPSEnabled) {
+                        DisableMouseControl();
+                        return;
+                    } else {               
+                        EnableMouseControl();
+                        return;
                     }
-                    FPSEnabled = false;
-                    Cursor.visible = true;
-                    Cursor.lockState = CursorLockMode.None;
-                    return;
                 }
-                else
-                 {               
-                    if (InputMode_Text) {
-					    InputMode_Text.GetComponent<Text>().text = "FPS Mode (mouse free)";
-                    }
-                    FPSEnabled = true;
-                    Cursor.visible = false;
-                    Cursor.lockState = CursorLockMode.Locked;
-                    return;
-                }
-            }*/
+            #endif
 
             // 1D Scroll for hand movement
-            if (!scroll2DEnabled && this.PhysicsController.WhatAmIHolding() != null)
-            {
+            if (!scroll2DEnabled && this.PhysicsController.WhatAmIHolding() != null) {
                 var scrollAmount = Input.GetAxis("Mouse ScrollWheel");
 
                 var eps = 1e-6;
                 if (Mathf.Abs(scrollAmount) > eps) {
-                    ServerAction action = new ServerAction
-                    {
+                    ServerAction action = new ServerAction {
                         action = "MoveHandAhead",
                         moveMagnitude = scrollAmount
                     };
                     this.PhysicsController.ProcessControlCommand(action);
                 }
-
             }
-            
-
-            // if (Input.GetKeyDown(KeyCode.R))
-            // {
-            //     var action = new ServerAction
-            //     {
-            //         action = "InitialRandomSpawn",
-            //         randomSeed = 0,
-            //         forceVisible = false,
-            //         numPlacementAttempts = 5,
-            //         placeStationary = true
-            //     };
-            //     PhysicsController.ProcessControlCommand(action);
-            // }
-
-            // if(Input.GetKey(KeyCode.Space))
-            // {
-            //     Cursor.visible = true;
-            //     Cursor.lockState = CursorLockMode.None;
-            // }
-
-            // if(Input.GetKeyUp(KeyCode.Space))
-            // {
-            //     Cursor.visible = false;
-            //     Cursor.lockState = CursorLockMode.Locked;
-            // }
 		}
 
 		private void Update()	

--- a/unity/Assets/Scripts/DebugFPSAgentController.cs
+++ b/unity/Assets/Scripts/DebugFPSAgentController.cs
@@ -42,7 +42,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
         private Vector3 m_MoveDir = Vector3.zero;
         private CharacterController m_CharacterController;
         private PhysicsRemoteFPSAgentController PhysicsController;
-        private bool scroll2DEnabled = true;
+        private bool scroll2DEnabled = false;
 
         protected bool enableHighlightShader = true;
 
@@ -134,23 +134,25 @@ namespace UnityStandardAssets.Characters.FirstPerson
             //  }
         }
 
-        public void EnableMouseControl()
-        {
+        public void EnableMouseControl() {
+            if (InputMode_Text) {
+                InputMode_Text.GetComponent<Text>().text = "FPS Mode (mouse free)";
+            }
             FPSEnabled = true;
             Cursor.visible = false;
             Cursor.lockState = CursorLockMode.Locked;
         }
 
-        public void DisableMouseControl()
-        {
-            Debug.Log("Disabled mouse");
+        public void DisableMouseControl() {
+            if (InputMode_Text) {
+                InputMode_Text.GetComponent<Text>().text = "FPS Mode";
+            }
             FPSEnabled = false;
             Cursor.visible = true;
             Cursor.lockState = CursorLockMode.None;
         }
 
-        private void DebugKeyboardControls()
-		{
+        private void DebugKeyboardControls() {
             if (InputFieldObj != null) {
                 InputField inField = InputFieldObj.GetComponentInChildren<InputField>();
                 if (inField != null) {
@@ -162,8 +164,13 @@ namespace UnityStandardAssets.Characters.FirstPerson
                     }
                 }
             }
+
 			//swap between text input and not
-			if (Input.GetKeyDown(KeyCode.BackQuote) || Input.GetKeyDown(KeyCode.Escape))
+            /*
+			if (
+                Input.GetKeyDown(KeyCode.BackQuote)
+                // || Input.GetKeyDown(KeyCode.Escape)
+            )
             {
 				//Switch to Text Mode
                 if (FPSEnabled)
@@ -186,8 +193,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                     Cursor.lockState = CursorLockMode.Locked;
                     return;
                 }
-
-            }
+            }*/
 
             // 1D Scroll for hand movement
             if (!scroll2DEnabled && this.PhysicsController.WhatAmIHolding() != null)
@@ -207,30 +213,30 @@ namespace UnityStandardAssets.Characters.FirstPerson
             }
             
 
-            if (Input.GetKeyDown(KeyCode.R))
-            {
-                var action = new ServerAction
-                {
-                    action = "InitialRandomSpawn",
-                    randomSeed = 0,
-                    forceVisible = false,
-                    numPlacementAttempts = 5,
-                    placeStationary = true
-                };
-                PhysicsController.ProcessControlCommand(action);
-            }
+            // if (Input.GetKeyDown(KeyCode.R))
+            // {
+            //     var action = new ServerAction
+            //     {
+            //         action = "InitialRandomSpawn",
+            //         randomSeed = 0,
+            //         forceVisible = false,
+            //         numPlacementAttempts = 5,
+            //         placeStationary = true
+            //     };
+            //     PhysicsController.ProcessControlCommand(action);
+            // }
 
-            if(Input.GetKey(KeyCode.Space))
-            {
-                Cursor.visible = true;
-                Cursor.lockState = CursorLockMode.None;
-            }
+            // if(Input.GetKey(KeyCode.Space))
+            // {
+            //     Cursor.visible = true;
+            //     Cursor.lockState = CursorLockMode.None;
+            // }
 
-            if(Input.GetKeyUp(KeyCode.Space))
-            {
-                Cursor.visible = false;
-                Cursor.lockState = CursorLockMode.Locked;
-            }
+            // if(Input.GetKeyUp(KeyCode.Space))
+            // {
+            //     Cursor.visible = false;
+            //     Cursor.lockState = CursorLockMode.Locked;
+            // }
 		}
 
 		private void Update()	

--- a/unity/ProjectSettings/EditorBuildSettings.asset
+++ b/unity/ProjectSettings/EditorBuildSettings.asset
@@ -336,6 +336,231 @@ EditorBuildSettings:
     path: Assets/Scenes/FloorPlan420_physics.unity
     guid: 872a8069b335347b5a000f33edede24a
   - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train1_1.unity
+    guid: 1288466ffb5b47541ae004189e095cbc
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train1_2.unity
+    guid: cd9a02051b9c1c24c95a609703ab3813
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train1_3.unity
+    guid: b16d57a2b0b719c4f98a44216d3444c6
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train1_4.unity
+    guid: c6597958fa286834b9670762c768d0e8
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train1_5.unity
+    guid: cd019f514f1259a4b8e30ec98e116844
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train2_1.unity
+    guid: 8581807b8713d494a80d059dc9c22cca
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train2_2.unity
+    guid: 88d84880263634b80a7bb74d16d01d87
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train2_3.unity
+    guid: 676abbd18cee141ee8583bbfd63e273a
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train2_4.unity
+    guid: ce35890fa5a304ceb9920e209ef80527
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train2_5.unity
+    guid: 5d3c998b557c7475db2617522257ea2d
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train3_1.unity
+    guid: dc3cfae065cab4513b492fb64554f956
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train3_2.unity
+    guid: 0a7744160e36a4875b4504e9244f8597
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train3_3.unity
+    guid: fd214267af5ac40689bb37257f460cb3
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train3_4.unity
+    guid: 6b58fa7f01193495cad38ab147310ebb
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train3_5.unity
+    guid: 136d5fc48a2e74e258c1a76f41f511da
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train4_1.unity
+    guid: 40f007333d4924457b0094fded9e439b
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train4_2.unity
+    guid: cac926ff12ff9418e8ba1f5dc5131123
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train4_3.unity
+    guid: c15721188e6b5454b8726a0702d591f8
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train4_4.unity
+    guid: 87c84aac341d548959ee85cfbdd27e13
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train4_5.unity
+    guid: edfd50d7940dc4ea89a9cfed72e1ef2a
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train5_1.unity
+    guid: 647f839e008c3457ba4313c06c2c0b64
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train5_2.unity
+    guid: 503318ad4f38546b09238940ca7e988f
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train5_3.unity
+    guid: 78a5ae3f0e93749d49e461176463869a
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train5_4.unity
+    guid: 4ff454739494c4f5abbe189d499dee5b
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train5_5.unity
+    guid: 567a4e2a50c4f41e18aab7bb26b229e4
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train6_1.unity
+    guid: 3089612f3a2a5234fb87f6bf842286e2
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train6_2.unity
+    guid: d3bc5d0d4faf5ef4d9c4fe46d8a7e8e3
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train6_3.unity
+    guid: 659d0eeb6c787ed44be58a36f82e0666
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train6_4.unity
+    guid: ebe76a32dffb60742aec8e43dbfeaee6
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train6_5.unity
+    guid: a30e6fc0dcf6b9c4aa6cb1b99d440cab
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train7_1.unity
+    guid: 4247e1ad7143ecc4c9ef43acb738f1d1
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train7_2.unity
+    guid: ec77e4bddb41a87428462deadf6ccb01
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train7_3.unity
+    guid: 50c654249f45b834c9b9d66ce90be9c9
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train7_4.unity
+    guid: 7510d3f21794dc0489aa01ba4de0c75b
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train7_5.unity
+    guid: ce0103a774585d84e8b5e1f59563b09b
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train8_1.unity
+    guid: 7fa4be8b0df363e419a374ee2be84881
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train8_2.unity
+    guid: b9914e2da14d4ee4e8d7de3d5ce845d9
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train8_3.unity
+    guid: b2a2add0bda2f614cbd01ff4998ea846
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train8_4.unity
+    guid: fbef95410eeedeb41b48e24a118b614d
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train8_5.unity
+    guid: 7faaad59e61a14748af4fc576f6ce0a0
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train9_1.unity
+    guid: 3f3ed5cb913fe634e8518b740e51d1f6
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train9_2.unity
+    guid: fa19ace479c12854d8876e4ee107b304
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train9_3.unity
+    guid: c7a733e2ca875ce4982c010965c0ee46
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train9_4.unity
+    guid: b2570af0420072446854fc54fba30bdd
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train9_5.unity
+    guid: f8510829b36306e4c83c669b856cc327
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train10_1.unity
+    guid: e8fb90bd2dfb58a41a8dfa758588833f
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train10_2.unity
+    guid: 3e3f7ddab33e633428d21e9c764c910e
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train10_3.unity
+    guid: 5feae710c603cf6429b5ce294edb847f
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train10_4.unity
+    guid: d990aeff50474fa4d9f1153c88bca7c9
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train10_5.unity
+    guid: b8c645a11adba4e4ca85d0b456f2df7a
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train11_1.unity
+    guid: 3a1545c8f67403b49b8a39db596246a0
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train11_2.unity
+    guid: 001317bce02fb124095f1caab6f66047
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train11_3.unity
+    guid: 43b4a3f538d307546ba92bb524dc0199
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train11_4.unity
+    guid: bc50d746cce881a409bdd7b00c3652eb
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train11_5.unity
+    guid: 6b29282069b674743ae9aa656a5f21f7
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train12_1.unity
+    guid: 72948722704040d4dbd1773704f91eab
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train12_2.unity
+    guid: 01e8f0a8b7ac38a499ef49918507ca44
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train12_3.unity
+    guid: 5d156e1d7ff67bb44ad5ea5a11324e30
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train12_4.unity
+    guid: 683948e82130c864b9cc425d0bb02b73
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Train12_5.unity
+    guid: 4f659e3ff7893d849995f2ec2e339806
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Val1_1.unity
+    guid: 2ff9d49f69d6441049fe18f35060ca17
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Val1_2.unity
+    guid: 41aeff8f1ab7942a589012575d9aab3b
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Val1_3.unity
+    guid: 9af9f639bcd8e41b9909ddb355933fe7
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Val1_4.unity
+    guid: 2d1f752e6abed4195a113da3422076f8
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Val1_5.unity
+    guid: 75fb0f858690c47cfac3815a23215222
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Val2_1.unity
+    guid: f43c4484516954f1f8c139766a9f7776
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Val2_2.unity
+    guid: 29375d65daeb142479074665b7019b3b
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Val2_3.unity
+    guid: d066e37309b344949be9f90a3a550943
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Val2_4.unity
+    guid: 78c52f63640e34e4e8580bcdc275fce0
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Val2_5.unity
+    guid: f02202020d59b412183de80728cf4efa
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Val3_1.unity
+    guid: b4ecc491073ac471f9d0581aef2080bd
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Val3_2.unity
+    guid: 11c7d8ed473244272b7dd3c1e7e7b2e4
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Val3_3.unity
+    guid: a61b5fbca4c704c58832cfeab1b7d1a2
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Val3_4.unity
+    guid: 3d273bc088228423080a1814cf156e36
+  - enabled: 1
+    path: Assets/Scenes/FloorPlan_Val3_5.unity
+    guid: f7d0a4d349cc14cb395bb5a3e3a67bc7
+  - enabled: 1
     path: Assets/Scenes/FloorPlan421_physics.unity
     guid: bb510ceb4ab804ab1b824e7993bb3c5c
   - enabled: 1

--- a/unity/ProjectSettings/ProjectSettings.asset
+++ b/unity/ProjectSettings/ProjectSettings.asset
@@ -13,7 +13,7 @@ PlayerSettings:
   useOnDemandResources: 0
   accelerometerFrequency: 60
   companyName: Allen Institute for Artificial Intelligence
-  productName: AI2-THOR
+  productName: AI2-Thor
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}

--- a/unity/ProjectSettings/ProjectSettings.asset
+++ b/unity/ProjectSettings/ProjectSettings.asset
@@ -21,7 +21,7 @@ PlayerSettings:
   m_ShowUnitySplashLogo: 0
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 0
-  m_SplashScreenLogoStyle: 0
+  m_SplashScreenLogoStyle: 1
   m_SplashScreenDrawMode: 0
   m_SplashScreenBackgroundAnimationZoom: 1
   m_SplashScreenLogoAnimationZoom: 1

--- a/unity/ProjectSettings/ProjectSettings.asset
+++ b/unity/ProjectSettings/ProjectSettings.asset
@@ -13,15 +13,15 @@ PlayerSettings:
   useOnDemandResources: 0
   accelerometerFrequency: 60
   companyName: Allen Institute for Artificial Intelligence
-  productName: AI2-Thor
+  productName: AI2-THOR
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 1
-  m_ShowUnitySplashLogo: 1
+  m_ShowUnitySplashScreen: 0
+  m_ShowUnitySplashLogo: 0
   m_SplashScreenOverlayOpacity: 1
-  m_SplashScreenAnimation: 1
-  m_SplashScreenLogoStyle: 1
+  m_SplashScreenAnimation: 0
+  m_SplashScreenLogoStyle: 0
   m_SplashScreenDrawMode: 0
   m_SplashScreenBackgroundAnimationZoom: 1
   m_SplashScreenLogoAnimationZoom: 1
@@ -613,7 +613,7 @@ PlayerSettings:
   webGLDebugSymbols: 0
   webGLEmscriptenArgs: 
   webGLModulesDirectory: 
-  webGLTemplate: APPLICATION:Default
+  webGLTemplate: APPLICATION:Minimal
   webGLAnalyzeBuildSize: 0
   webGLUseEmbeddedResources: 0
   webGLCompressionFormat: 1


### PR DESCRIPTION
Updates to enhance the demo.

Allows for:
* All scenes to be rendered in the demo
* Removes the default loading page (I override it with a custom loading page)
* Modifies/removes some keyboard commands so that they are controllable solely through javascript. Examples include ``` and `Escape`, which used to be how one started the demo. However, there are problems with the `Escape` keyword, since it's used by the browser to allow a user to show it's cursor (after we've hidden it, and we cannot override this browser command).