### PR TITLE
Fixed getReachablePositions error message bug

### DIFF
--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -388,18 +388,21 @@ namespace UnityStandardAssets.Characters.FirstPerson
                             continue;
                         }
 
+                        //Check 2: Is p + d within the bounds of the scene?
                         bool inBounds = agentManager.SceneBounds.Contains(newPosition);
 
-                        //Check 2: Is p + d within the bounds of the scene?
                         if (errorMessage == "" && !inBounds) {
                             errorMessage = "In " +
                                 UnityEngine.SceneManagement.SceneManager.GetActiveScene().name +
                                 ", position " + newPosition.ToString() +
                                 " can be reached via capsule cast but is beyond the scene bounds.";
+                            
+                            shouldEnqueue = false;
+                            continue;
                         }
 
                         //Check 3: Can the carried object fit into p + d's four cardinal orientations?
-                        shouldEnqueue = inBounds && (
+                        shouldEnqueue = (
                             handObjectCanFitInPosition(newPosition, 0.0f) ||
                             handObjectCanFitInPosition(newPosition, 90.0f) ||
                             handObjectCanFitInPosition(newPosition, 180.0f) ||

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -328,7 +328,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             Queue<Vector3> pointsQueue = new Queue<Vector3>();
             pointsQueue.Enqueue(transform.position);
 
-            //float dirSkinWidthMultiplier = 1.0f + sw;
+            // float dirSkinWidthMultiplier = 1.0f + sw;
             Vector3[] directions = {
                 new Vector3(1.0f, 0.0f, 0.0f),
                 new Vector3(0.0f, 0.0f, 1.0f),
@@ -341,28 +341,34 @@ namespace UnityStandardAssets.Characters.FirstPerson
             int layerMask = 1 << 8;
             int stepsTaken = 0;
 
-            //Traverse entire room in every direction with every step, stopping at any points that repeat and continuing on from ones that don't yet
+            // Traverse entire room in each direction with every step, stopping at any points that are repeats and
+            // continuing on from ones that aren't
             while (pointsQueue.Count != 0) {
                 stepsTaken += 1;
                 Vector3 p = pointsQueue.Dequeue();
-                //Check if p is a point already reached from a different direction
+
+                // Check if p is a point already reached from a different direction
                 if (!goodPoints.Contains(p)) {
-                    //Add p to HashSet of reachable positions
+                    // Add p to HashSet of reachable positions
                     goodPoints.Add(p);
-                    //Initialize hashset ("list") of objects that agent is currently colliding with (but don't epxect it to have anything yet)
+
+                    // Initialize HashSet of objects that agent is colliding with on Awake()
                     HashSet<Collider> objectsAlreadyColliding = new HashSet<Collider>(objectsCollidingWithAgent());
-                    //From p, move in each cardinal direction by d (gridSize * gridMultiplier)
+                    
+                    // From p, move in each cardinal direction by d (gridSize * gridMultiplier)
                     foreach (Vector3 d in directions) {
                         Vector3 newPosition = p + d * gridSize * gridMultiplier;
-                        //If p + d is a point already reached from a different direction, move on to the next direction from p
+
+                        // If p + d is a point already reached from a different direction, move on to the next direction from p
                         if (seenPoints.Contains(newPosition)) {
                             continue;
                         }
 
-                        //Since p + d is a new point, run the checks to see if it is reachable by the agent
+                        // Since p + d is a new point, run the checks to see if it is reachable by the agent
                         seenPoints.Add(newPosition);
 
-                        //Check 1: Does agent hit any non-agent, non-floor collider between p and p + d (other than what it was already colliding with on Awake())?
+                        // Check 1: Does agent hit any non-agent, non-floor collider between p and p + d (other than
+                        // what it was already colliding with on Awake())?
                         RaycastHit[] hits = capsuleCastAllForAgent(
                             cc,
                             sw,
@@ -383,12 +389,13 @@ namespace UnityStandardAssets.Characters.FirstPerson
                             }
                         }
 
-                        //If CapsuleCast check failed, move on to next direction from p (otherwise Check 2's error message could return a false-positive)
-                        if(shouldEnqueue == false) {
+                        // If CapsuleCast check failed, move on to next direction from p (otherwise Check 2's error message
+                        // could return a false-positive)
+                        if (!shouldEnqueue) {
                             continue;
                         }
 
-                        //Check 2: Is p + d within the bounds of the scene?
+                        // Check 2: Is p + d within the bounds of the scene?
                         bool inBounds = agentManager.SceneBounds.Contains(newPosition);
 
                         if (errorMessage == "" && !inBounds) {
@@ -397,11 +404,10 @@ namespace UnityStandardAssets.Characters.FirstPerson
                                 ", position " + newPosition.ToString() +
                                 " can be reached via capsule cast but is beyond the scene bounds.";
                             
-                            shouldEnqueue = false;
                             continue;
                         }
 
-                        //Check 3: Can the carried object fit into p + d's four cardinal orientations?
+                        // Check 3: Can the carried object fit into p + d's four cardinal orientations?
                         shouldEnqueue = (
                             handObjectCanFitInPosition(newPosition, 0.0f) ||
                             handObjectCanFitInPosition(newPosition, 90.0f) ||
@@ -409,11 +415,11 @@ namespace UnityStandardAssets.Characters.FirstPerson
                             handObjectCanFitInPosition(newPosition, 270.0f)
                         );
 
-                        //If all checks are successful, add p + d to the queue
+                        // If all checks are successful, add p + d to the queue
                         if (shouldEnqueue) {
                             pointsQueue.Enqueue(newPosition);
 
-                            //If visualize is enabled, draw line between p and p + d
+                            // If visualize is enabled, draw line between p and p + d
                             if (visualize) {
                                 var gridRenderer = Instantiate(GridRenderer, Vector3.zero, Quaternion.identity);
                                 var gridLineRenderer = gridRenderer.GetComponentInChildren<LineRenderer>();
@@ -438,7 +444,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                     }
                 }
 
-                //default maxStepCount to scale based on gridSize
+                // default maxStepCount to scale based on gridSize
                 if (stepsTaken > Math.Floor(maxStepCount/(gridSize * gridSize))) {
                     errorMessage = "Too many steps taken in GetReachablePositions.";
                     break;
@@ -717,7 +723,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             float[] xs = new float[] { grid_x1, grid_x1 + gridSize };
             float[] zs = new float[] { grid_z1, grid_z1 + gridSize };
             List<Vector3> validMovements = new List<Vector3>();
-            
+
             foreach (float x in xs)
             {
                 foreach (float z in zs)

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -351,10 +351,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 // floating-point errors)
                 bool doesNotContain = true;
                 foreach (Vector3 goodPoint in goodPoints) {
-                    if (
-                        Mathf.Approximately(p.x, goodPoint.x) &&
-                        Mathf.Approximately(p.y, goodPoint.y) &&
-                        Mathf.Approximately(p.z, goodPoint.z)) {
+                    if (Vector3.Distance(p, goodPoint) < 1e-4f) {
                         doesNotContain = false;
                     }
                 }
@@ -3428,11 +3425,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 bool doesNotContain = true;
                 foreach (Vector3 goodPoint in goodPoints)
                 {
-                    if (
-                        Mathf.Approximately(p.x, goodPoint.x) &&
-                        Mathf.Approximately(p.y, goodPoint.y) &&
-                        Mathf.Approximately(p.z, goodPoint.z))
-                    {
+                    if (Vector3.Distance(p, goodPoint) < 1e-4f) {
                         doesNotContain = false;
                     }
                 }

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -347,8 +347,21 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 stepsTaken += 1;
                 Vector3 p = pointsQueue.Dequeue();
 
-                // Check if p is a point already reached from a different direction
-                if (!goodPoints.Contains(p)) {
+                // Check if p is a point already reached from a different direction (this method accounts for
+                // floating-point errors)
+                bool doesNotContain = true;
+
+                foreach (Vector3 goodPoint in goodPoints) {
+                    if (
+                        Mathf.Approximately(p.x, goodPoint.x) &&
+                        Mathf.Approximately(p.y, goodPoint.y) &&
+                        Mathf.Approximately(p.z, goodPoint.z)) {
+                        doesNotContain = false;
+                    }
+                }
+
+                if (doesNotContain) {
+
                     // Add p to HashSet of reachable positions
                     goodPoints.Add(p);
 

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -341,11 +341,6 @@ namespace UnityStandardAssets.Characters.FirstPerson
             int layerMask = 1 << 8;
             int stepsTaken = 0;
 
-            //Visualize SceneBounds
-            //GameObject boundsVis = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            //boundsVis.transform.position = agentManager.SceneBounds.center;
-            //boundsVis.transform.localScale = 2 * agentManager.SceneBounds.extents;
-
             //Traverse entire room in every direction with every step, stopping at any points that repeat and continuing on from ones that don't yet
             while (pointsQueue.Count != 0) {
                 stepsTaken += 1;

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -350,7 +350,6 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 // Check if p is a point already reached from a different direction (this method accounts for
                 // floating-point errors)
                 bool doesNotContain = true;
-
                 foreach (Vector3 goodPoint in goodPoints) {
                     if (
                         Mathf.Approximately(p.x, goodPoint.x) &&
@@ -410,7 +409,6 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
                         // Check 2: Is p + d within the bounds of the scene?
                         bool inBounds = agentManager.SceneBounds.Contains(newPosition);
-
                         if (errorMessage == "" && !inBounds) {
                             errorMessage = "In " +
                                 UnityEngine.SceneManagement.SceneManager.GetActiveScene().name +
@@ -3405,9 +3403,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             return PhysicsExtensions.OverlapCapsule(GetComponent<CapsuleCollider>(), layerMask, QueryTriggerInteraction.Ignore);
         }
 
-        public bool  getReachablePositionToObjectVisible(SimObjPhysics targetSOP, out Vector3 pos, float gridMultiplier = 1.0f, int maxStepCount = 10000) {
-
-
+        public bool getReachablePositionToObjectVisible(SimObjPhysics targetSOP, out Vector3 pos, float gridMultiplier = 1.0f, int maxStepCount = 10000) {
             CapsuleCollider cc = GetComponent<CapsuleCollider>();
             float sw = m_CharacterController.skinWidth;
             Queue<Vector3> pointsQueue = new Queue<Vector3>();
@@ -3428,7 +3424,20 @@ namespace UnityStandardAssets.Characters.FirstPerson
             while (pointsQueue.Count != 0) {
                 stepsTaken += 1;
                 Vector3 p = pointsQueue.Dequeue();
-                if (!goodPoints.Contains(p)) {
+
+                bool doesNotContain = true;
+                foreach (Vector3 goodPoint in goodPoints)
+                {
+                    if (
+                        Mathf.Approximately(p.x, goodPoint.x) &&
+                        Mathf.Approximately(p.y, goodPoint.y) &&
+                        Mathf.Approximately(p.z, goodPoint.z))
+                    {
+                        doesNotContain = false;
+                    }
+                }
+
+                if (doesNotContain) {
                     goodPoints.Add(p);
                     transform.position = p;
                     var rot = transform.rotation;
@@ -3479,6 +3488,11 @@ namespace UnityStandardAssets.Characters.FirstPerson
                                 break;
                             }
                         }
+
+                        if (!shouldEnqueue) {
+                            continue;
+                        }
+
                         bool inBounds = agentManager.SceneBounds.Contains(newPosition);
                         if (errorMessage == "" && !inBounds) {
                             errorMessage = "In " +


### PR DESCRIPTION
I added an additional `continue` check to a foreach loop, so that a point on the floorGrid that had already failed a check for agent-reachability could break out of its iteration, before it could potentially return a false-positive error message at check #2 saying it had completed check #1 but failed #2.