### PR TITLE
Look/Rotate fix and updates

### DIFF
--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -3015,18 +3015,10 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
         public void ResetAgentHandPosition() {
             AgentHand.transform.position = DefaultHandPosition.transform.position;
-            SimObjPhysics sop = AgentHand.GetComponentInChildren<SimObjPhysics>();
-            if (sop != null) {
-                sop.gameObject.transform.localPosition = Vector3.zero;
-            }
         }
 
         public void ResetAgentHandRotation() {
-            AgentHand.transform.localRotation = Quaternion.Euler(Vector3.zero);
-            SimObjPhysics sop = AgentHand.GetComponentInChildren<SimObjPhysics>();
-            if (sop != null) {
-                sop.gameObject.transform.rotation = transform.rotation;
-            }
+            AgentHand.transform.rotation = this.transform.rotation;    
         }
 
         //randomly repositions sim objects in the current scene

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -2209,24 +2209,15 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         break;
                     } 
 
-                    //pickup object, if no specific object passed in, it will pick up the closest interactable simobj in the agent's viewport
+                    //pickup object
 				case "pu":
                     {
-                        ServerAction action = new ServerAction();
-                        action.action = "PickupObject";
+                        Dictionary<string, object> action = new Dictionary<string, object>();
+                        action["action"] = "PickupObject";
 						if(splitcommand.Length > 1)
 						{
-							action.objectId = splitcommand[1];
+							action["objectId"] = splitcommand[1];
 						}
-
-						else
-						{
-							//action.objectId = Agent.GetComponent<PhysicsRemoteFPSAgentController>().ObjectIdOfClosestVisibleObject();
-						}
-
-                        action.forceAction = true;
-                        action.x = 0.5f; 
-                        action.y = 0.5f;
                         CurrentActiveController().ProcessControlCommand(action);
                         break;
                     }

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -500,11 +500,14 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     Quaternion.Lerp(pointsOnArc[i].orientation, pointsOnArc[i + 1].orientation, 0.5f), arcIncrementDistance, 1 << 8 | 1 << 10,
                     QueryTriggerInteraction.Ignore))
                     {
-                        if (hit.transform.GetComponent<SimObjPhysics>())
+                        //did we hit a sim obj?
+                        if (hit.transform.GetComponentInParent<SimObjPhysics>())
                         {
-                            //if we hit the item in our hand, skip
-                            if (hit.transform.GetComponent<SimObjPhysics>().transform == ItemInHand.transform)
+                            //if the sim obj we hit is what we are holding, skip
+                            if (hit.transform.GetComponentInParent<SimObjPhysics>().transform == ItemInHand.transform) 
+                            {
                                 continue;
+                            }
                         }
 
                         if (hit.transform == this.transform)
@@ -523,12 +526,32 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             rotPoint.transform.rotation = bb.transform.rotation;
             //Rotate the rotPoint around the origin by the current increment's angle, relative to the correct axis
             rotPoint.transform.RotateAround(origin, dirAxis, dirSign * degrees);
+            Collider [] WhatDidWeHit = Physics.OverlapBox(rotPoint.position, bbHalfExtents, rotPoint.transform.rotation, 1 << 8 | 1 << 10, QueryTriggerInteraction.Ignore);
 
-            if (Physics.OverlapBox(rotPoint.position, bbHalfExtents, rotPoint.transform.rotation, 1 << 8 | 1 << 10, QueryTriggerInteraction.Ignore).Length != 0)
+            foreach(Collider col in WhatDidWeHit)
             {
-                
+                if(col.transform.GetComponentInParent<SimObjPhysics>())
+                {
+                    if(col.transform.GetComponentInParent<SimObjPhysics>().transform == ItemInHand.transform)
+                    {
+                        continue;
+                    }
+                }
+
+                if(col.transform == this.transform)
+                {
+                    continue;
+                }
+
                 result = false;
+                break;
             }
+
+            // if (Physics.OverlapBox(rotPoint.position, bbHalfExtents, rotPoint.transform.rotation, 1 << 8 | 1 << 10, QueryTriggerInteraction.Ignore).Length != 0)
+            // {
+                
+            //     result = false;
+            // }
 
             return result;
         }

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -361,12 +361,12 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             if (CheckIfAgentCanRotate("down", action.degrees)) 
             {
+                base.LookDown(action);
 
                 //only default hand if not manually Interacting with things
                 if(!action.manualInteract)
                 DefaultAgentHand();
 
-                base.LookDown(action);
                 return;
             } 
 
@@ -415,11 +415,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             if (CheckIfAgentCanRotate("up", action.degrees)) 
             {
+                base.LookUp(action);
+
                 //only default hand if not manually Interacting with things
                 if(!action.manualInteract)
                 DefaultAgentHand();
 
-                base.LookUp(action);
+                return;
             }
 
             else
@@ -437,13 +439,16 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             if (CheckIfAgentCanRotate("right", action.degrees)||action.forceAction) 
             {
+
+                base.RotateRight(action);
+
                 //only default hand if not manually Interacting with things
                 if(!action.manualInteract)
                 {
                     DefaultAgentHand();
                 }
 
-                base.RotateRight(action);
+                return;
             } 
 
             else 
@@ -461,11 +466,14 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             if (CheckIfAgentCanRotate("left", action.degrees)||action.forceAction) 
             {
+
+                base.RotateLeft(action);
+
                 //only default hand if not manually Interacting with things
                 if(!action.manualInteract)
                 DefaultAgentHand();
 
-                base.RotateLeft(action);
+                return;
             } 
 
             else 


### PR DESCRIPTION
Fix to bugged behavior when defaulting the agent hand position and rotation after a LookUp/Down action.

Additionally adds a check for the overlap box cast at the end of a rotate check so that it correctly ignores any held object colliders and the agent's collider.