### PR TITLE
Possible dispatcher invalid arg fix

### DIFF
--- a/unity/Assets/Scripts/ActionDispatcher.cs
+++ b/unity/Assets/Scripts/ActionDispatcher.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using System.Collections.Generic;
 using System;
+using System.Linq;
 using UnityEngine;
 using Newtonsoft.Json.Linq;
 
@@ -306,6 +307,16 @@ public static class ActionDispatcher {
             serverAction.dynamicServerAction = dynamicServerAction;
             arguments[0] = serverAction;
         }  else {
+            var paramDict = methodParams.ToDictionary(param => param.Name, param => param);
+            var invalidArgs = dynamicServerAction
+                .Keys()
+                .Where(argName => !paramDict.ContainsKey(argName))
+                .ToList();
+            if (invalidArgs.Count > 0) {
+                throw new InvalidArgumentsException(
+                    invalidArgs
+                );
+            }
             for(int i = 0; i < methodParams.Length; i++) {
                 System.Reflection.ParameterInfo pi = methodParams[i];
                 if (dynamicServerAction.ContainsKey(pi.Name)) {
@@ -399,6 +410,14 @@ public class ToObjectArgumentActionException : Exception {
 public class MissingArgumentsActionException : Exception {
     public List<string> ArgumentNames;
     public MissingArgumentsActionException(List<string> argumentNames) {
+        this.ArgumentNames = argumentNames;
+    }
+}
+
+[Serializable]
+public class InvalidArgumentsException : Exception {
+    public List<string> ArgumentNames;
+    public InvalidArgumentsException(List<string> argumentNames) {
         this.ArgumentNames = argumentNames;
     }
 }

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -16,6 +16,7 @@ using Newtonsoft.Json.Serialization;
 using System.Reflection;
 using System.Text;
 using UnityEngine.Networking;
+using System.Linq;
 
 public class AgentManager : MonoBehaviour
 {
@@ -1680,6 +1681,14 @@ public class DynamicServerAction
 
     public T ToObject<T>() {
         return this.jObject.ToObject<T>();
+    }
+
+    public IEnumerable<string> Keys() {
+        return this.jObject.Properties().Select(p => p.Name).ToList();
+    }
+
+    public int Count() {
+        return this.jObject.Count;
     }
     
 }

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1771,6 +1771,11 @@ namespace UnityStandardAssets.Characters.FirstPerson
             {
                 ActionDispatcher.Dispatch(target: target, dynamicServerAction: controlCommand);
             }
+            catch (InvalidArgumentsException e) {
+                errorMessage = $"action: ${controlCommand.action} called with invalid arguments:" + string.Join(",", e.ArgumentNames.ToArray());
+                errorCode = ServerActionErrorCode.InvalidArgument;
+                actionFinished(false);
+            }
             catch (ToObjectArgumentActionException e)
             {
                 Dictionary<string, string> typeMap = new Dictionary<string, string>{


### PR DESCRIPTION
Making dispatcher fail when an argument that does not exist as a parameter for a particular action, is passed to Dispatch.