### PR TITLE
csharp_prefer_braces / brace fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,9 @@ root = true
 [*]
 indent_style = space
 
+[unity/Assets/Scripts/**.cs]
+csharp_prefer_braces = true:error
+
 [*.cs]
 indent_size = 4
 

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -301,8 +301,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             Debug.Log($"lastActionSuccess: '{success}'");
             if (!success) {
                 Debug.Log($"Action failed with error message '{this.errorMessage}'.");
-            } else if (actionReturn != null)
+            } else if (actionReturn != null) {
                 Debug.Log($"actionReturn: '{actionReturn}'");
+            }
 #endif
         }
 
@@ -1759,8 +1760,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
 
             if (hit.gameObject.GetComponent<StructureObject>()) {
-                if (hit.gameObject.GetComponent<StructureObject>().WhatIsMyStructureObjectTag == StructureObjectTag.Floor)
+                if (hit.gameObject.GetComponent<StructureObject>().WhatIsMyStructureObjectTag == StructureObjectTag.Floor) {
                     return;
+                }
             }
 
 
@@ -1945,8 +1947,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         inViewport: true,
                         x: x,
                         y: y,
-                        target: ref target))
+                        target: ref target)) {
                         return false;
+                    }
 
                     // now check if the object is flagged as Visible by the visibility point logic
                     if (checkVisible && !forceAction && !IsInteractable(target)) {
@@ -1987,11 +1990,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             // this does not account for objects behind transparent objects like shower glass, as the raycast check
             // will hit the transparent object FIRST
 
-            if (target != null)
+            if (target != null) {
                 actionFinishedEmit(success: true, actionReturn: target.ObjectID);
+            }
 
-            if (target == null)
+            if (target == null) {
                 actionFinishedEmit(success: false, actionReturn: errorMessage);
+            }
         }
 
         public void GetCoordinateFromRaycast(float x, float y) {
@@ -2708,8 +2713,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             LayerMask mask = (1 << 8) | (1 << 9) | (1 << 10);
 
             // change mask if its a floor so it ignores the receptacle trigger boxes on the floor
-            if (sop.Type == SimObjType.Floor)
+            if (sop.Type == SimObjType.Floor) {
                 mask = (1 << 8) | (1 << 10);
+            }
 
 
             // check raycast against both visible and invisible layers, to check against ReceptacleTriggerBoxes which are normally

--- a/unity/Assets/Scripts/BatchRename.cs
+++ b/unity/Assets/Scripts/BatchRename.cs
@@ -50,8 +50,9 @@ public class BatchRename : ScriptableWizard {
 
         helpString = "";
 
-        if (Selection.objects != null)
+        if (Selection.objects != null) {
             helpString = "Number of objects selected: " + Selection.objects.Length;
+        }
     }
 
 
@@ -61,8 +62,9 @@ public class BatchRename : ScriptableWizard {
     void OnWizardCreate() {
 
         // If selection is empty, then exit
-        if (Selection.objects == null)
+        if (Selection.objects == null) {
             return;
+        }
 
         // Current Increment
         int PostFix = StartNumber;

--- a/unity/Assets/Scripts/Break.cs
+++ b/unity/Assets/Scripts/Break.cs
@@ -54,8 +54,9 @@ public class Break : MonoBehaviour {
         }
 
         if (gameObject.GetComponent<Dirty>()) {
-            if (DirtyPrefabToSwapTo == null)
+            if (DirtyPrefabToSwapTo == null) {
                 Debug.LogError(gameObject.name + " is missing a DirtyPrefabToSpawnTo!");
+            }
         }
 #endif
 
@@ -143,8 +144,9 @@ public class Break : MonoBehaviour {
 
         BaseFPSAgentController primaryAgent = GameObject.Find("PhysicsSceneManager").GetComponent<AgentManager>().ReturnPrimaryAgent();
         if (primaryAgent.imageSynthesis) {
-            if (primaryAgent.imageSynthesis.enabled)
+            if (primaryAgent.imageSynthesis.enabled) {
                 primaryAgent.imageSynthesis.OnSceneChange();
+            }
         }
     }
 

--- a/unity/Assets/Scripts/Cabinet.cs
+++ b/unity/Assets/Scripts/Cabinet.cs
@@ -93,8 +93,9 @@ public class Cabinet : MonoBehaviour {
             open = ParentObj.Animator.GetBool("AnimState1");
         }
 
-        if (!Application.isPlaying && !Animate)
+        if (!Application.isPlaying && !Animate) {
             return;
+        }
 
         switch (SceneManager.Current.AnimationMode) {
             case SceneAnimationMode.Instant:
@@ -163,8 +164,9 @@ public class Cabinet : MonoBehaviour {
                 break;
         }
 
-        if (animatingDistance >= 360f)
+        if (animatingDistance >= 360f) {
             animatingDistance -= 360f;
+        }
 
         ParentObj.IsAnimating = (animatingDistance > 0.0025f);
     }

--- a/unity/Assets/Scripts/CanOpen_Object.cs
+++ b/unity/Assets/Scripts/CanOpen_Object.cs
@@ -79,8 +79,9 @@ public class CanOpen_Object : MonoBehaviour {
         }
 #endif
 
-        if (!isOpen)
+        if (!isOpen) {
             currentOpenness = 0.0f;
+        }
 
         //// make sure correct bounding box is referenced depending on if initial state at scene start is open or closed
         //// set initial state by toggling the isOpen bool on this component, and also adjusting the rotation/position of any openable parts accordingly

--- a/unity/Assets/Scripts/CanToggleOnOff.cs
+++ b/unity/Assets/Scripts/CanToggleOnOff.cs
@@ -149,8 +149,9 @@ public class CanToggleOnOff : MonoBehaviour {
 
     public void Toggle() {
         // if this object is controlled by another object, do nothing and report failure?
-        if (!SelfControlled)
+        if (!SelfControlled) {
             return;
+        }
 
         // check if there are moving parts
         // check if there are lights/materials etc to swap out
@@ -164,12 +165,13 @@ public class CanToggleOnOff : MonoBehaviour {
                             "islocal", true,
                             "time", animationTime,
                             "easetype", "linear", "onComplete", "setisOn", "onCompleteTarget", gameObject));
-                        } else
+                        } else {
                             iTween.RotateTo(MovingParts[i], iTween.Hash(
-                            "rotation", OffPositions[i],
-                            "islocal", true,
-                            "time", animationTime,
-                            "easetype", "linear"));
+                                "rotation", OffPositions[i],
+                                "islocal", true,
+                                "time", animationTime,
+                                "easetype", "linear"));
+                        }
                     }
 
                     if (movementType == MovementType.Slide) {
@@ -179,12 +181,13 @@ public class CanToggleOnOff : MonoBehaviour {
                             "islocal", true,
                             "time", animationTime,
                             "easetype", "linear", "onComplete", "setisOn", "onCompleteTarget", gameObject));
-                        } else
+                        } else {
                             iTween.MoveTo(MovingParts[i], iTween.Hash(
-                            "position", OffPositions[i],
-                            "islocal", true,
-                            "time", animationTime,
-                            "easetype", "linear"));
+                                "position", OffPositions[i],
+                                "islocal", true,
+                                "time", animationTime,
+                                "easetype", "linear"));
+                        }
                     }
                 }
             }
@@ -203,12 +206,13 @@ public class CanToggleOnOff : MonoBehaviour {
                             "islocal", true,
                             "time", animationTime,
                             "easetype", "linear", "onComplete", "setisOn", "onCompleteTarget", gameObject));
-                        } else
+                        } else {
                             iTween.RotateTo(MovingParts[i], iTween.Hash(
-                            "rotation", OnPositions[i],
-                            "islocal", true,
-                            "time", animationTime,
-                            "easetype", "linear"));
+                                "rotation", OnPositions[i],
+                                "islocal", true,
+                                "time", animationTime,
+                                "easetype", "linear"));
+                        }
                     }
 
                     if (movementType == MovementType.Slide) {
@@ -218,12 +222,13 @@ public class CanToggleOnOff : MonoBehaviour {
                             "islocal", true,
                             "time", animationTime,
                             "easetype", "linear", "onComplete", "setisOn", "onCompleteTarget", gameObject));
-                        } else
+                        } else {
                             iTween.MoveTo(MovingParts[i], iTween.Hash(
-                            "position", OnPositions[i],
-                            "islocal", true,
-                            "time", animationTime,
-                            "easetype", "linear"));
+                                "position", OnPositions[i],
+                                "islocal", true,
+                                "time", animationTime,
+                                "easetype", "linear"));
+                        }
                     }
                 }
             }

--- a/unity/Assets/Scripts/ColdZone.cs
+++ b/unity/Assets/Scripts/ColdZone.cs
@@ -19,8 +19,9 @@ public class ColdZone : MonoBehaviour {
             SimObjPhysics sop = other.GetComponentInParent<SimObjPhysics>();
             sop.CurrentTemperature = ObjectMetadata.Temperature.Cold;
 
-            if (sop.HowManySecondsUntilRoomTemp != sop.GetTimerResetValue())
+            if (sop.HowManySecondsUntilRoomTemp != sop.GetTimerResetValue()) {
                 sop.HowManySecondsUntilRoomTemp = sop.GetTimerResetValue();
+            }
 
             sop.SetStartRoomTempTimer(false);
         }

--- a/unity/Assets/Scripts/Contains.cs
+++ b/unity/Assets/Scripts/Contains.cs
@@ -45,8 +45,9 @@ public class Contains : MonoBehaviour {
     void OnEnable() {
         // if the parent of this object has a SimObjPhysics component, grab a reference to it
         if (myParent == null) {
-            if (gameObject.GetComponentInParent<SimObjPhysics>().transform.gameObject)
+            if (gameObject.GetComponentInParent<SimObjPhysics>().transform.gameObject) {
                 myParent = gameObject.GetComponentInParent<SimObjPhysics>().transform.gameObject;
+            }
         }
 
     }
@@ -142,8 +143,9 @@ public class Contains : MonoBehaviour {
     // used by ObjectSpecificReceptacle, so objects like stove burners, coffee machine, etc.
     public bool isOccupied() {
         bool result = false;
-        if (CurrentlyContainedGameObjects().Count > 0)
+        if (CurrentlyContainedGameObjects().Count > 0) {
             result = true;
+        }
 
         return result;
     }
@@ -294,8 +296,9 @@ public class Contains : MonoBehaviour {
             // didn't hit anything that could obstruct, so this point is good to go
             if (!ReturnPointsCloseToAgent) {
                 PossibleSpawnPoints.Add(new ReceptacleSpawnPoint(BottomPoint, b, this, myParent.GetComponent<SimObjPhysics>()));
-            } else if (NarrowDownValidSpawnPoints(BottomPoint))
+            } else if (NarrowDownValidSpawnPoints(BottomPoint)) {
                 PossibleSpawnPoints.Add(new ReceptacleSpawnPoint(BottomPoint, b, this, myParent.GetComponent<SimObjPhysics>()));
+            }
         }
 
         //****** */debug draw the spawn points as well
@@ -327,8 +330,9 @@ public class Contains : MonoBehaviour {
         tmpForCamera.y = point.y;
 
         // automatically rule out a point if it's beyond our max distance of visibility
-        if (Vector3.Distance(point, tmpForCamera) >= maxvisdist)
+        if (Vector3.Distance(point, tmpForCamera) >= maxvisdist) {
             return false;
+        }
 
         // ok cool, it's within distance to the agent, now let's check 
         // if the point is within the viewport of the agent as well
@@ -339,8 +343,9 @@ public class Contains : MonoBehaviour {
         if (point.y < agentCam.transform.position.y - 0.05f) {
             // do this check if the point's y value is below the camera's y value
             // this check will be a raycast vision check from the camera to the point exactly
-            if (agentController.CheckIfPointIsInViewport(point))
+            if (agentController.CheckIfPointIsInViewport(point)) {
                 return true;
+            }
         } else {
             // do this check if the point's y value is above the agent camera. This means we are
             // trying to place an object on a shelf or something high up that we can't quite reach
@@ -348,8 +353,9 @@ public class Contains : MonoBehaviour {
 
             // might want to adjust this offset amount, or even move this check to ensure object visibility after the
             // checkspawnarea corners are generated?
-            if (agentController.CheckIfPointIsInViewport(point + new Vector3(0, 0.05f, 0)))
+            if (agentController.CheckIfPointIsInViewport(point + new Vector3(0, 0.05f, 0))) {
                 return true;
+            }
         }
 
         return false;
@@ -368,10 +374,11 @@ public class Contains : MonoBehaviour {
         float halfZ = (myBox.size.z * 0.5f);
         if (point.x < halfX && point.x > -halfX &&
             point.y < halfY && point.y > -halfY &&
-            point.z < halfZ && point.z > -halfZ)
+            point.z < halfZ && point.z > -halfZ) {
             return true;
-        else
+        } else {
             return false;
+        }
     }
 
     public bool CheckIfPointIsAboveReceptacleTriggerBox(Vector3 point) {
@@ -384,10 +391,11 @@ public class Contains : MonoBehaviour {
         float halfZ = (myBox.size.z * 0.5f);
         if (point.x < halfX && point.x > -halfX &&
             point.y < BIGY && point.y > -BIGY &&
-            point.z < halfZ && point.z > -halfZ)
+            point.z < halfZ && point.z > -halfZ) {
             return true;
-        else
+        } else {
             return false;
+        }
     }
 
 #if UNITY_EDITOR

--- a/unity/Assets/Scripts/Convertable.cs
+++ b/unity/Assets/Scripts/Convertable.cs
@@ -32,8 +32,9 @@ public class Convertable : MonoBehaviour {
     }
 
     void Update() {
-        if (parentObj == null)
+        if (parentObj == null) {
             parentObj = gameObject.GetComponent<SimObj>();
+        }
 
         // anim state is 1-4
         int animState = -1;

--- a/unity/Assets/Scripts/CopyLightingSettings.cs
+++ b/unity/Assets/Scripts/CopyLightingSettings.cs
@@ -33,12 +33,14 @@ static class CopyLightingSettings {
     [MenuItem(k_CopySettingsMenuPath, priority = 200)]
     static void CopySettings() {
         UnityEngine.Object lightmapSettings;
-        if (!TryGetSettings(typeof(LightmapEditorSettings), "GetLightmapSettings", out lightmapSettings))
+        if (!TryGetSettings(typeof(LightmapEditorSettings), "GetLightmapSettings", out lightmapSettings)) {
             return;
+        }
 
         UnityEngine.Object renderSettings;
-        if (!TryGetSettings(typeof(RenderSettings), "GetRenderSettings", out renderSettings))
+        if (!TryGetSettings(typeof(RenderSettings), "GetRenderSettings", out renderSettings)) {
             return;
+        }
 
         s_SourceLightmapSettings = new SerializedObject(lightmapSettings);
         s_SourceRenderSettings = new SerializedObject(renderSettings);
@@ -47,12 +49,14 @@ static class CopyLightingSettings {
     [MenuItem(k_PasteSettingsMenuPath, priority = 201)]
     static void PasteSettings() {
         UnityEngine.Object lightmapSettings;
-        if (!TryGetSettings(typeof(LightmapEditorSettings), "GetLightmapSettings", out lightmapSettings))
+        if (!TryGetSettings(typeof(LightmapEditorSettings), "GetLightmapSettings", out lightmapSettings)) {
             return;
+        }
 
         UnityEngine.Object renderSettings;
-        if (!TryGetSettings(typeof(RenderSettings), "GetRenderSettings", out renderSettings))
+        if (!TryGetSettings(typeof(RenderSettings), "GetRenderSettings", out renderSettings)) {
             return;
+        }
 
         CopyInternal(s_SourceLightmapSettings, new SerializedObject(lightmapSettings));
         CopyInternal(s_SourceRenderSettings, new SerializedObject(renderSettings));
@@ -76,8 +80,9 @@ static class CopyLightingSettings {
                 }
             }
 
-            if (copyProperty)
+            if (copyProperty) {
                 dest.CopyFromSerializedProperty(prop);
+            }
         }
 
         dest.ApplyModifiedProperties();

--- a/unity/Assets/Scripts/DebugFPSAgentController.cs
+++ b/unity/Assets/Scripts/DebugFPSAgentController.cs
@@ -275,8 +275,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             m_MoveDir += Physics.gravity * m_GravityMultiplier * Time.deltaTime;
 
             // added this check so that move is not called if/when the Character Controller's capsule is disabled. Right now the capsule is being disabled when open/close animations are in progress so yeah there's that
-            if (m_CharacterController.enabled == true)
+            if (m_CharacterController.enabled == true) {
                 m_CharacterController.Move(m_MoveDir * Time.deltaTime);
+            }
         }
 
 

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -371,11 +371,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         ServerAction action = new ServerAction();
 
                         if (splitcommand.Length == 2) {
-                            if (splitcommand[1] == "s")
+                            if (splitcommand[1] == "s") {
                                 action.objectType = "screen";
+                            }
 
-                            if (splitcommand[1] == "r")
+                            if (splitcommand[1] == "r") {
                                 action.objectType = "receptacle";
+                            }
                         } else {
                             action.objectType = "receptacle";
                         }
@@ -461,8 +463,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                         if (splitcommand.Length == 2) {
                             action.objectVariation = int.Parse(splitcommand[1]);
-                        } else
+                        } else {
                             action.objectVariation = 0;
+                        }
 
                         action.y = 0f;// UnityEngine.Random.Range(0, 360);
                         CurrentActiveController().ProcessControlCommand(action);
@@ -1256,8 +1259,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                         if (splitcommand.Length == 2) {
                             action["objectId"] = splitcommand[1];
-                        } else
+                        } else {
                             action["objectId"] = PhysicsController.ObjectIdOfClosestReceptacleObject();
+                        }
 
                         // set this to false if we want to place it and let physics resolve by having it fall a short distance into position
 
@@ -1368,19 +1372,23 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         else if (splitcommand.Length == 3) {
                             action["randomSeed"] = int.Parse(splitcommand[1]);
 
-                            if (splitcommand[2] == "t")
+                            if (splitcommand[2] == "t") {
                                 action["forceVisible"] = true;
+                            }
 
-                            if (splitcommand[2] == "f")
+                            if (splitcommand[2] == "f") {
                                 action["forceVisible"] = false;
+                            }
                         } else if (splitcommand.Length == 4) {
                             action["randomSeed"] = int.Parse(splitcommand[1]);
 
-                            if (splitcommand[2] == "t")
+                            if (splitcommand[2] == "t") {
                                 action["forceVisible"] = true;
+                            }
 
-                            if (splitcommand[2] == "f")
+                            if (splitcommand[2] == "f") {
                                 action["forceVisible"] = false;
+                            }
 
                             action["numPlacementAttempts"] = int.Parse(splitcommand[3]);
                         } else {
@@ -1461,11 +1469,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         action["action"] = "ToggleHideAndSeekObjects";
 
                         if (splitcommand.Length == 2) {
-                            if (splitcommand[1] == "t")
+                            if (splitcommand[1] == "t") {
                                 action["forceVisible"] = true;
+                            }
 
-                            if (splitcommand[1] == "f")
+                            if (splitcommand[1] == "f") {
                                 action["forceVisible"] = false;
+                            }
                         } else {
                             action["forceVisible"] = false;
                         }
@@ -1717,8 +1727,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                         if (splitcommand.Length > 1) {
                             action.moveMagnitude = float.Parse(splitcommand[1]);
-                        } else
+                        } else {
                             action.moveMagnitude = 0.25f;
+                        }
 
                         // action.manualInteract = true;
 
@@ -1734,8 +1745,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                         if (splitcommand.Length > 1) {
                             action.moveMagnitude = float.Parse(splitcommand[1]);
-                        } else
+                        } else {
                             action.moveMagnitude = 0.25f;
+                        }
 
                         CurrentActiveController().ProcessControlCommand(action);
                         break;
@@ -1748,8 +1760,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                         if (splitcommand.Length > 1) {
                             action.moveMagnitude = float.Parse(splitcommand[1]);
-                        } else
+                        } else {
                             action.moveMagnitude = 0.25f;
+                        }
 
                         CurrentActiveController().ProcessControlCommand(action);
                         break;
@@ -1777,8 +1790,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                         if (splitcommand.Length > 1) {
                             action.moveMagnitude = float.Parse(splitcommand[1]);
-                        } else
+                        } else {
                             action.moveMagnitude = 0.25f;
+                        }
 
                         action.forceAction = true;
 
@@ -1794,8 +1808,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                         if (splitcommand.Length > 1) {
                             action.moveMagnitude = float.Parse(splitcommand[1]);
-                        } else
+                        } else {
                             action.moveMagnitude = 0.25f;
+                        }
 
                         action.forceAction = true;
 
@@ -1810,8 +1825,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                         if (splitcommand.Length > 1) {
                             action.moveMagnitude = float.Parse(splitcommand[1]);
-                        } else
+                        } else {
                             action.moveMagnitude = 0.25f;
+                        }
 
                         action.forceAction = true;
 
@@ -1826,8 +1842,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                         if (splitcommand.Length > 1) {
                             action.moveMagnitude = float.Parse(splitcommand[1]);
-                        } else
+                        } else {
                             action.moveMagnitude = 0.25f;
+                        }
 
                         action.forceAction = true;
 
@@ -2229,8 +2246,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                         if (splitcommand.Length > 1) {
                             action["moveMagnitude"] = float.Parse(splitcommand[1]);
-                        } else
+                        } else {
                             action["moveMagnitude"] = 0.1f;
+                        }
 
                         // action.x = 0f;
                         // action.y = 0f;
@@ -2249,8 +2267,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                         if (splitcommand.Length > 1) {
                             action["moveMagnitude"] = float.Parse(splitcommand[1]);
-                        } else
+                        } else {
                             action["moveMagnitude"] = 0.1f;
+                        }
 
                         // action.x = 0f;
                         // action.y = 0f;
@@ -2267,8 +2286,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                         if (splitcommand.Length > 1) {
                             action["moveMagnitude"] = float.Parse(splitcommand[1]);
-                        } else
+                        } else {
                             action["moveMagnitude"] = 0.1f;
+                        }
 
                         // action.x = -1f;
                         // action.y = 0f;
@@ -2285,8 +2305,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                         if (splitcommand.Length > 1) {
                             action["moveMagnitude"] = float.Parse(splitcommand[1]);
-                        } else
+                        } else {
                             action["moveMagnitude"] = 0.1f;
+                        }
 
                         // action.x = 1f;
                         // action.y = 0f;
@@ -2323,8 +2344,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                         if (splitcommand.Length > 1) {
                             action["moveMagnitude"] = float.Parse(splitcommand[1]);
-                        } else
+                        } else {
                             action["moveMagnitude"] = 0.1f;
+                        }
 
                         // action.x = 0f;
                         // action.y = 1f;
@@ -2341,8 +2363,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                         if (splitcommand.Length > 1) {
                             action["moveMagnitude"] = float.Parse(splitcommand[1]);
-                        } else
+                        } else {
                             action["moveMagnitude"] = 0.1f;
+                        }
 
                         // action.x = 0f;
                         // action.y = -1f;
@@ -2391,8 +2414,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                         if (splitcommand.Length > 1) {
                             action.moveMagnitude = float.Parse(splitcommand[1]);
-                        } else
+                        } else {
                             action.moveMagnitude = 120f;
+                        }
 
                         CurrentActiveController().ProcessControlCommand(action);
                         break;
@@ -2984,15 +3008,17 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                             if (splitcommand.Length > 2) {
                                 action.speed = float.Parse(splitcommand[2]);
                             }
-                            if (splitcommand.Length > 3)
+                            if (splitcommand.Length > 3) {
                                 action.returnToStart = bool.Parse(splitcommand[3]);
+                            }
 
-                            if (splitcommand.Length > 4)
+                            if (splitcommand.Length > 4) {
                                 action.disableRendering = bool.Parse(splitcommand[4]);
+                            }
 
-                            if (splitcommand.Length > 5)
+                            if (splitcommand.Length > 5) {
                                 action.restrictMovement = bool.Parse(splitcommand[5]);
-
+                            }
                         } else {
                             action.y = 0.9f;
                             action.speed = 1.0f;

--- a/unity/Assets/Scripts/DroneFPSAgentController.cs
+++ b/unity/Assets/Scripts/DroneFPSAgentController.cs
@@ -63,16 +63,18 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
         public override void RotateRight(ServerAction action) {
             // if controlCommand.degrees is default (0), rotate by the default rotation amount set on initialize
-            if (action.degrees == 0f)
+            if (action.degrees == 0f) {
                 action.degrees = rotateStepDegrees;
+            }
 
             base.RotateRight(action);
         }
 
         public override void RotateLeft(ServerAction action) {
             // if controlCommand.degrees is default (0), rotate by the default rotation amount set on initialize
-            if (action.degrees == 0f)
+            if (action.degrees == 0f) {
                 action.degrees = rotateStepDegrees;
+            }
 
             base.RotateLeft(action);
         }

--- a/unity/Assets/Scripts/Fill.cs
+++ b/unity/Assets/Scripts/Fill.cs
@@ -85,8 +85,10 @@ public class Fill : MonoBehaviour {
                 // coffee is hot!
                 SimObjPhysics sop = gameObject.GetComponent<SimObjPhysics>();
                 sop.CurrentTemperature = ObjectMetadata.Temperature.Hot;
-                if (sop.HowManySecondsUntilRoomTemp != sop.GetTimerResetValue())
+                if (sop.HowManySecondsUntilRoomTemp != sop.GetTimerResetValue()) {
                     sop.HowManySecondsUntilRoomTemp = sop.GetTimerResetValue();
+                }
+
                 sop.SetStartRoomTempTimer(false);
             }
 
@@ -96,8 +98,9 @@ public class Fill : MonoBehaviour {
         }
 
         // whichLiquid is not in the dictionary
-        else
+        else {
             return false;
+        }
 
 
         // if the dict doesn't contain this key pair uuuuuh

--- a/unity/Assets/Scripts/FirstPersonCharacterCull.cs
+++ b/unity/Assets/Scripts/FirstPersonCharacterCull.cs
@@ -26,14 +26,13 @@ public class FirstPersonCharacterCull : MonoBehaviour {
     public MeshRenderer[] DroneRenderers;
 
     public void SwitchRenderersToHide(string mode) {
-        if (mode == "default" || mode == "arm")
+        if (mode == "default" || mode == "arm") {
             RenderersToHide = TallRenderers;
-
-        else if (mode == "locobot")
+        } else if (mode == "locobot") {
             RenderersToHide = BotRenderers;
-
-        else if (mode == "drone")
+        } else if (mode == "drone") {
             RenderersToHide = DroneRenderers;
+        }
     }
 
     void OnPreRender() // Just before this camera starts to render...

--- a/unity/Assets/Scripts/FreezeObject.cs
+++ b/unity/Assets/Scripts/FreezeObject.cs
@@ -15,8 +15,9 @@ public class FreezeObject : MonoBehaviour {
     private Vector3 m_Position = Vector3.zero;
     private Quaternion m_Rotation = Quaternion.identity;
     void Awake() {
-        if (Application.isPlaying)
+        if (Application.isPlaying) {
             Destroy(this);
+        }
     }
     void Update() {
         if (!Application.isEditor) {
@@ -25,23 +26,29 @@ public class FreezeObject : MonoBehaviour {
         }
         if (FreezePosition) {
             // Save current position if enabled
-            if ((FreezePosition != m_OldFreezePosition) || (space != m_OldSpace))
+            if ((FreezePosition != m_OldFreezePosition) || (space != m_OldSpace)) {
                 m_Position = (space == Space.World) ? transform.position : transform.localPosition;
+            }
+
             // Freeze the position
-            if (space == Space.World)
+            if (space == Space.World) {
                 transform.position = m_Position;
-            else
+            } else {
                 transform.localPosition = m_Position;
+            }
         }
         if (FreezeRotation) {
             // Save current rotation if enabled
-            if ((FreezeRotation != m_OldFreezeRotation) || (space != m_OldSpace))
+            if ((FreezeRotation != m_OldFreezeRotation) || (space != m_OldSpace)) {
                 m_Rotation = (space == Space.World) ? transform.rotation : transform.localRotation;
+            }
+
             // Freeze the rotation
-            if (space == Space.World)
+            if (space == Space.World) {
                 transform.rotation = m_Rotation;
-            else
+            } else {
                 transform.localRotation = m_Rotation;
+            }
         }
         m_OldSpace = space;
         m_OldFreezePosition = FreezePosition;

--- a/unity/Assets/Scripts/Fridge.cs
+++ b/unity/Assets/Scripts/Fridge.cs
@@ -23,8 +23,9 @@ public class Fridge : MonoBehaviour {
 
     void Update() {
         bool open = false;
-        if (!ParentObj.IsAnimated)
+        if (!ParentObj.IsAnimated) {
             return;
+        }
 
         open = ParentObj.Animator.GetBool("AnimState1");
 
@@ -55,8 +56,9 @@ public class Fridge : MonoBehaviour {
                     distanceToTarget = Mathf.Max(distanceToTarget, Vector3.Distance(Doors[i].localPosition, drawerTargetPosition));
                 }
 
-                if (distanceToTarget >= 360f)
+                if (distanceToTarget >= 360f) {
                     distanceToTarget -= 360f;
+                }
 
                 ParentObj.IsAnimating = distanceToTarget > 0.0025f;
                 break;

--- a/unity/Assets/Scripts/GroupCommand.cs
+++ b/unity/Assets/Scripts/GroupCommand.cs
@@ -5,11 +5,17 @@ using UnityEngine;
 public static class GroupCommand {
     [MenuItem("GameObject/Group Selected %g")]
     private static void GroupSelected() {
-        if (!Selection.activeTransform) return;
+        if (!Selection.activeTransform) {
+            return;
+        }
+
         var go = new GameObject(Selection.activeTransform.name + " Group");
         Undo.RegisterCreatedObjectUndo(go, "Group Selected");
         go.transform.SetParent(Selection.activeTransform.parent, false);
-        foreach (var transform in Selection.transforms) Undo.SetTransformParent(transform, go.transform, "Group Selected");
+        foreach (var transform in Selection.transforms) {
+            Undo.SetTransformParent(transform, go.transform, "Group Selected");
+        }
+
         Selection.activeGameObject = go;
     }
 }

--- a/unity/Assets/Scripts/HeatZone.cs
+++ b/unity/Assets/Scripts/HeatZone.cs
@@ -23,8 +23,9 @@ public class HeatZone : MonoBehaviour {
             SimObjPhysics sop = other.GetComponentInParent<SimObjPhysics>();
             sop.CurrentTemperature = ObjectMetadata.Temperature.Hot;
 
-            if (sop.HowManySecondsUntilRoomTemp != sop.GetTimerResetValue())
+            if (sop.HowManySecondsUntilRoomTemp != sop.GetTimerResetValue()) {
                 sop.HowManySecondsUntilRoomTemp = sop.GetTimerResetValue();
+            }
 
             sop.SetStartRoomTempTimer(false);
             //

--- a/unity/Assets/Scripts/IgnoreCollision.cs
+++ b/unity/Assets/Scripts/IgnoreCollision.cs
@@ -27,8 +27,9 @@ public class IgnoreCollision : MonoBehaviour {
         // if the object to ignore has been manually set already
         if (objectToIgnoreCollisionsWith != null) {
             // do this if we are ignoring a sim object like a dresser with drawers in it
-            if (objectToIgnoreCollisionsWith.GetComponent<SimObjPhysics>())
+            if (objectToIgnoreCollisionsWith.GetComponent<SimObjPhysics>()) {
                 otherCollidersToIgnore = objectToIgnoreCollisionsWith.GetComponent<SimObjPhysics>().MyColliders;
+            }
 
             // do this if we are ignoring the agent
             if (objectToIgnoreCollisionsWith.GetComponent<BaseFPSAgentController>()) {
@@ -38,8 +39,9 @@ public class IgnoreCollision : MonoBehaviour {
         }
 
 #if UNITY_EDITOR
-        else
+        else {
             Debug.LogError("IgnoreCollision on " + gameObject.transform.name + " is missing an objectToIgnoreCollisionsWith!");
+        }
 #endif
         // // otherwise, default to finding the SimObjPhysics component in the nearest parent to use as the object to ignore
         // else

--- a/unity/Assets/Scripts/ImageSynthesis/ColorEncoding.cs
+++ b/unity/Assets/Scripts/ImageSynthesis/ColorEncoding.cs
@@ -19,8 +19,9 @@ public class ColorEncoding {
 
     public static Color EncodeIDAsColor(int instanceId) {
         var uid = instanceId * 2;
-        if (uid < 0)
+        if (uid < 0) {
             uid = -uid + 1;
+        }
 
         var sid =
             (SparsifyBits((byte)(uid >> 16), 3) << 2) |

--- a/unity/Assets/Scripts/ImageSynthesis/ImageSynthesis.cs
+++ b/unity/Assets/Scripts/ImageSynthesis/ImageSynthesis.cs
@@ -82,16 +82,19 @@ public class ImageSynthesis : MonoBehaviour {
 
 
         // default fallbacks, if shaders are unspecified
-        if (!uberReplacementShader)
+        if (!uberReplacementShader) {
             uberReplacementShader = Shader.Find("Hidden/UberReplacement");
+        }
 
-        if (!opticalFlowShader)
+        if (!opticalFlowShader) {
             opticalFlowShader = Shader.Find("Hidden/OpticalFlow");
+        }
 
 #if UNITY_EDITOR
 
-        if (!depthShader)
+        if (!depthShader) {
             depthShader = Shader.Find("Hidden/DepthBW");
+        }
 #else
             if (!depthShader)
                 depthShader = Shader.Find("Hidden/Depth");
@@ -117,8 +120,9 @@ public class ImageSynthesis : MonoBehaviour {
 
     void LateUpdate() {
 #if UNITY_EDITOR
-        if (DetectPotentialSceneChangeInEditor())
+        if (DetectPotentialSceneChangeInEditor()) {
             OnSceneChange();
+        }
 
 #endif // UNITY_EDITOR
 
@@ -138,7 +142,9 @@ public class ImageSynthesis : MonoBehaviour {
         // from the Agent's camera, and a ThirdPartyCamera does not have the same defaults, which may cause some errors
         if (go.transform.parent.GetComponent<FirstPersonCharacterCull>())
             // add the FirstPersonCharacterCull so this camera's agent is not rendered- other agents when multi agent is enabled should still be rendered
+        {
             go.AddComponent<FirstPersonCharacterCull>(go.transform.parent.GetComponent<FirstPersonCharacterCull>());
+        }
 
         var newCamera = go.GetComponent<Camera>();
         newCamera.cullingMask = 1;// render everything, including PlaceableSurfaces
@@ -197,8 +203,9 @@ public class ImageSynthesis : MonoBehaviour {
         mainCamera.depth = 9999; // This ensures the main camera is rendered on screen
 
         foreach (var pass in capturePasses) {
-            if (pass.camera == mainCamera)
+            if (pass.camera == mainCamera) {
                 continue;
+            }
 
             // cleanup capturing camera
             pass.camera.RemoveAllCommandBuffers();
@@ -368,9 +375,11 @@ public class ImageSynthesis : MonoBehaviour {
             height = Screen.height;
         }
 
-        foreach (var pass in capturePasses)
-            if (pass.name == passName)
+        foreach (var pass in capturePasses) {
+            if (pass.name == passName) {
                 return Encode(pass.camera, width, height, pass.supportsAntialiasing, pass.needsRescale, jpg, format, textureReadMode);
+            }
+        }
 
         return (new byte[0]);
     }
@@ -382,8 +391,10 @@ public class ImageSynthesis : MonoBehaviour {
         }
 
         var filenameExtension = System.IO.Path.GetExtension(filename);
-        if (filenameExtension == "")
+        if (filenameExtension == "") {
             filenameExtension = ".png";
+        }
+
         var filenameWithoutExtension = Path.GetFileNameWithoutExtension(filename);
 
         var pathWithoutExtension = Path.Combine(path, filenameWithoutExtension);
@@ -399,8 +410,9 @@ public class ImageSynthesis : MonoBehaviour {
     }
 
     private void Save(string filenameWithoutExtension, string filenameExtension, int width, int height) {
-        foreach (var pass in capturePasses)
+        foreach (var pass in capturePasses) {
             Save(pass.camera, filenameWithoutExtension + pass.name + filenameExtension, width, height, pass.supportsAntialiasing, pass.needsRescale);
+        }
     }
 
     private byte[] Encode(
@@ -453,11 +465,12 @@ public class ImageSynthesis : MonoBehaviour {
 
         // encode texture into PNG/JPG
         byte[] bytes;
-        if (jpg)
+        if (jpg) {
             bytes = tex.EncodeToJPG();
-        else
-            // bytes = tex.EncodeToPNG();
+        } else {
             bytes = tex.GetRawTextureData();
+        }
+
         Debug.Log("imageSynth format time" + (Time.realtimeSinceStartup - startTime));
 
 
@@ -495,8 +508,9 @@ public class ImageSynthesis : MonoBehaviour {
             var go = UnityEditor.Selection.activeGameObject;
             // check if layer or tag of a selected object have changed since the last frame
             var potentialChangeHappened = lastSelectedGOLayer != go.layer || lastSelectedGOTag != go.tag;
-            if (go == lastSelectedGO && potentialChangeHappened)
+            if (go == lastSelectedGO && potentialChangeHappened) {
                 change = true;
+            }
 
             lastSelectedGO = go;
             lastSelectedGOLayer = go.layer;

--- a/unity/Assets/Scripts/InstantiatePrefabTest.cs
+++ b/unity/Assets/Scripts/InstantiatePrefabTest.cs
@@ -623,8 +623,9 @@ public class InstantiatePrefabTest : MonoBehaviour {
         if (SpawnCorners != null) {
             int count = 0;
             foreach (Vector3 point in SpawnCorners) {
-                if (count > 3)
+                if (count > 3) {
                     Gizmos.color = Color.cyan;
+                }
 
                 Gizmos.DrawSphere(point, 0.005f);
                 count++;

--- a/unity/Assets/Scripts/Microwave.cs
+++ b/unity/Assets/Scripts/Microwave.cs
@@ -72,8 +72,9 @@ public class Microwave : MonoBehaviour {
                     Door.rotation = Quaternion.RotateTowards(doorStartRotation, Door.rotation, Time.deltaTime * SimUtil.SmoothAnimationSpeed * 25);
 
                     float distanceToTarget = Vector3.Distance(Door.localEulerAngles, targetDoorRotation);
-                    if (distanceToTarget >= 360f)
+                    if (distanceToTarget >= 360f) {
                         distanceToTarget -= 360f;
+                    }
 
                     if (!waitForDoorToClose || distanceToTarget < 0.005f) {
                         GlassRenderer.sharedMaterials = sharedMats;

--- a/unity/Assets/Scripts/Rearrangeable.cs
+++ b/unity/Assets/Scripts/Rearrangeable.cs
@@ -91,11 +91,13 @@ public class Rearrangeable : MonoBehaviour {
     }
 
     void OnDrawGizmos() {
-        if (Application.isPlaying)
+        if (Application.isPlaying) {
             return;
+        }
 
-        if (ParentSimObj == null || StartPosition == null || EndPosition == null)
+        if (ParentSimObj == null || StartPosition == null || EndPosition == null) {
             return;
+        }
 
         MeshFilter mf = ParentSimObj.GetComponentInChildren<MeshFilter>();
         if (mf != null) {

--- a/unity/Assets/Scripts/RotationTriggerCheck.cs
+++ b/unity/Assets/Scripts/RotationTriggerCheck.cs
@@ -30,8 +30,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 if (other.GetComponentInParent<SimObjPhysics>()) {
                     if (other.GetComponentInParent<SimObjPhysics>().name != ItemInHand.name) {
                         if (other.GetComponent<Collider>()) {
-                            if (!other.GetComponent<Collider>().isTrigger)
+                            if (!other.GetComponent<Collider>().isTrigger) {
                                 isColliding = true;
+                            }
                         }
                         // print(other.GetComponentInParent<SimObjPhysics>().name);
                     }

--- a/unity/Assets/Scripts/SimObj.cs
+++ b/unity/Assets/Scripts/SimObj.cs
@@ -319,8 +319,9 @@ public class SimObj : MonoBehaviour, SimpleSimObj {
     }
 
     protected virtual void OnEnable() {
-        if (SceneManager.Current == null)
+        if (SceneManager.Current == null) {
             return;
+        }
 
         // reset this in case one of our scripts was interrupted
         isAnimating = false;
@@ -488,8 +489,9 @@ public class SimObj : MonoBehaviour, SimpleSimObj {
     void OnDrawGizmos() {
         Gizmos.color = Color.white;
 
-        if (!SimUtil.ShowObjectVisibility)
+        if (!SimUtil.ShowObjectVisibility) {
             VisibleNow = false;
+        }
 
         if (!string.IsNullOrEmpty(error)) {
             Gizmos.color = Color.Lerp(Color.red, Color.clear, 0.5f);

--- a/unity/Assets/Scripts/SimObjPhysics.cs
+++ b/unity/Assets/Scripts/SimObjPhysics.cs
@@ -227,8 +227,9 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
         Bounds bounding = cols[0].bounds;// initialize the bounds to return with our first collider
 
         foreach (Collider c in cols) {
-            if (c.enabled)
+            if (c.enabled) {
                 bounding.Encapsulate(c.bounds);
+            }
         }
 
         // reparent child simobjects
@@ -434,15 +435,18 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
         get {
             if (this.GetComponent<CanToggleOnOff>()) {
                 // if this object is self controlled, it is toggleable
-                if (this.GetComponent<CanToggleOnOff>().ReturnSelfControlled())
+                if (this.GetComponent<CanToggleOnOff>().ReturnSelfControlled()) {
                     return true;
+                }
 
                 // if it is not self controlled (meaning controlled by another sim object) return not toggleable
                 // although if this object is not toggleable, it may still return isToggled as a state (see IsToggled below)
-                else
+                else {
                     return false;
-            } else
+                }
+            } else {
                 return false;
+            }
             // return this.GetComponent<CanToggleOnOff>(); 
         }
     }
@@ -912,7 +916,9 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
         // only update lastVelocity if physicsAutosimulation = true, otherwise let the Advance Physics function take care of it;
         if (sceneManager.physicsSimulationPaused == false)
             // record this object's current velocity
+        {
             lastVelocity = Math.Abs(myRigidbody.angularVelocity.sqrMagnitude + myRigidbody.velocity.sqrMagnitude);
+        }
     }
     private void FixedUpdate() {
         // isInteractable = false;
@@ -923,8 +929,9 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
         Vector3 dir = new Vector3(action.x, action.y, action.z);
         Rigidbody myrb = gameObject.GetComponent<Rigidbody>();
 
-        if (myrb.IsSleeping())
+        if (myrb.IsSleeping()) {
             myrb.WakeUp();
+        }
 
         myrb.isKinematic = false;
         myrb.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
@@ -936,8 +943,9 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
 
         Rigidbody myrb = gameObject.GetComponent<Rigidbody>();
 
-        if (myrb.IsSleeping())
+        if (myrb.IsSleeping()) {
             myrb.WakeUp();
+        }
 
         myrb.isKinematic = false;
         myrb.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
@@ -1093,8 +1101,9 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
         gameObject.transform.tag = "SimObjPhysics";
         gameObject.layer = 8;
 
-        if (!gameObject.GetComponent<Rigidbody>())
+        if (!gameObject.GetComponent<Rigidbody>()) {
             gameObject.AddComponent<Rigidbody>();
+        }
 
         this.GetComponent<Rigidbody>().isKinematic = true;
 
@@ -1162,24 +1171,28 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
         foreach (Transform child in gameObject.transform) {
             if (child.name == "StaticVisPoints") {
                 foreach (Transform svp in child) {
-                    if (!vpoints.Contains(svp))
+                    if (!vpoints.Contains(svp)) {
                         vpoints.Add(svp);
+                    }
                 }
             }
 
             if (child.name == "ReceptacleTriggerBox") {
                 // print("check");
-                if (!recepboxes.Contains(child.gameObject))
+                if (!recepboxes.Contains(child.gameObject)) {
                     recepboxes.Add(child.gameObject);
+                }
             }
 
             // found the cabinet door, go into it and populate triggerboxes, colliders, t colliders, and vis points
             if (child.name == "CabinetDoor") {
-                if (child.GetComponent<Rigidbody>())
+                if (child.GetComponent<Rigidbody>()) {
                     DestroyImmediate(child.GetComponent<Rigidbody>(), true);
+                }
 
-                if (child.GetComponent<SimObjPhysics>())
+                if (child.GetComponent<SimObjPhysics>()) {
                     DestroyImmediate(child.GetComponent<SimObjPhysics>(), true);
+                }
 
                 if (!movparts.Contains(child.gameObject)) {
                     movparts.Add(child.gameObject);
@@ -1188,8 +1201,9 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
                 foreach (Transform c in child) {
                     if (c.name == "Colliders") {
                         foreach (Transform col in c) {
-                            if (!cols.Contains(col.gameObject))
+                            if (!cols.Contains(col.gameObject)) {
                                 cols.Add(col.gameObject);
+                            }
 
                             if (col.childCount == 0) {
                                 GameObject prefabRoot = col.gameObject;
@@ -1221,8 +1235,9 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
 
                     if (c.name == "VisibilityPoints") {
                         foreach (Transform col in c) {
-                            if (!vpoints.Contains(col.transform))
+                            if (!vpoints.Contains(col.transform)) {
                                 vpoints.Add(col.transform);
+                            }
                         }
                     }
                 }
@@ -1238,8 +1253,9 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
         gameObject.GetComponent<CanOpen_Object>().openPositions = new Vector3[movparts.Count];
         gameObject.GetComponent<CanOpen_Object>().closedPositions = new Vector3[movparts.Count];
 
-        if (openPositions.Count != 0)
+        if (openPositions.Count != 0) {
             gameObject.GetComponent<CanOpen_Object>().openPositions = openPositions.ToArray();
+        }
 
         // this.GetComponent<CanOpen>().SetMovementToRotate();
     }
@@ -1284,8 +1300,9 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
         this.SecondaryProperties = new SimObjSecondaryProperty[]
         {SimObjSecondaryProperty.Receptacle};
 
-        if (!gameObject.GetComponent<Rigidbody>())
+        if (!gameObject.GetComponent<Rigidbody>()) {
             gameObject.AddComponent<Rigidbody>();
+        }
 
         this.GetComponent<Rigidbody>().isKinematic = true;
 
@@ -1488,8 +1505,9 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
         gameObject.tag = "SimObjPhysics";
         gameObject.layer = 8;
 
-        if (!gameObject.GetComponent<Rigidbody>())
+        if (!gameObject.GetComponent<Rigidbody>()) {
             gameObject.AddComponent<Rigidbody>();
+        }
 
         gameObject.GetComponent<Rigidbody>().isKinematic = true;
         if (!gameObject.transform.Find("VisibilityPoints")) {
@@ -1561,8 +1579,9 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
         c.tag = "SimObjPhysics";
         c.layer = 8;
 
-        if (!c.GetComponent<Rigidbody>())
+        if (!c.GetComponent<Rigidbody>()) {
             c.AddComponent<Rigidbody>();
+        }
 
         if (!c.transform.Find("Colliders")) {
             GameObject col = new GameObject("Colliders");
@@ -1709,8 +1728,9 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
         c.tag = "SimObjPhysics";
         c.layer = 8;
 
-        if (!c.GetComponent<Rigidbody>())
+        if (!c.GetComponent<Rigidbody>()) {
             c.AddComponent<Rigidbody>();
+        }
 
         if (!c.transform.Find("Colliders")) {
             GameObject col = new GameObject("Colliders");
@@ -1784,8 +1804,9 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
         gameObject.tag = "SimObjPhysics";
         gameObject.layer = 8;
 
-        if (!gameObject.GetComponent<Rigidbody>())
+        if (!gameObject.GetComponent<Rigidbody>()) {
             gameObject.AddComponent<Rigidbody>();
+        }
 
         gameObject.GetComponent<Rigidbody>().isKinematic = true;
 
@@ -2045,16 +2066,25 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
             // if (meshFilter.gameObject.name != "screen_1" && meshFilter.gameObject.name != "screen_2")
             //{
             foreach (Vector3 vertex in meshFilter.sharedMesh.vertices) {
-                if (minMeshXZ.x > meshFilter.gameObject.transform.TransformPoint(vertex).x)
+                if (minMeshXZ.x > meshFilter.gameObject.transform.TransformPoint(vertex).x) {
                     minMeshXZ.x = meshFilter.gameObject.transform.TransformPoint(vertex).x;
-                if (minMeshXZ.z > meshFilter.gameObject.transform.TransformPoint(vertex).z)
+                }
+
+                if (minMeshXZ.z > meshFilter.gameObject.transform.TransformPoint(vertex).z) {
                     minMeshXZ.z = meshFilter.gameObject.transform.TransformPoint(vertex).z;
-                if (maxMeshXYZ.x < meshFilter.gameObject.transform.TransformPoint(vertex).x)
+                }
+
+                if (maxMeshXYZ.x < meshFilter.gameObject.transform.TransformPoint(vertex).x) {
                     maxMeshXYZ.x = meshFilter.gameObject.transform.TransformPoint(vertex).x;
-                if (maxMeshXYZ.y < meshFilter.gameObject.transform.TransformPoint(vertex).y)
+                }
+
+                if (maxMeshXYZ.y < meshFilter.gameObject.transform.TransformPoint(vertex).y) {
                     maxMeshXYZ.y = meshFilter.gameObject.transform.TransformPoint(vertex).y;
-                if (maxMeshXYZ.z < meshFilter.gameObject.transform.TransformPoint(vertex).z)
+                }
+
+                if (maxMeshXYZ.z < meshFilter.gameObject.transform.TransformPoint(vertex).z) {
                     maxMeshXYZ.z = meshFilter.gameObject.transform.TransformPoint(vertex).z;
+                }
 
                 newBoundingBox.Encapsulate(minMeshXZ);
                 newBoundingBox.Encapsulate(maxMeshXYZ);

--- a/unity/Assets/Scripts/SimUtil.cs
+++ b/unity/Assets/Scripts/SimUtil.cs
@@ -98,8 +98,9 @@ public static class SimUtil {
                         maxDistance,
                         out hit);
                     // if we can see it no need for more checks!
-                    if (canSeeItem)
+                    if (canSeeItem) {
                         break;
+                    }
                 }
             }
 
@@ -116,8 +117,9 @@ public static class SimUtil {
                         out hit);
 
                     // if we can see it no need for more checks!
-                    if (canSeeItem)
+                    if (canSeeItem) {
                         break;
+                    }
                 }
             }
 
@@ -247,8 +249,9 @@ public static class SimUtil {
     // checks whether the item
     public static bool CheckItemBounds(SimObj item, Vector3 agentPosition) {
         // if the item doesn't use custom bounds this is an automatic pass
-        if (!item.UseCustomBounds)
+        if (!item.UseCustomBounds) {
             return true;
+        }
 
         // use the item's bounds transform as a bounding box
         // this is NOT axis-aligned so objects rotated strangely may return unexpected results

--- a/unity/Assets/Scripts/SliceObject.cs
+++ b/unity/Assets/Scripts/SliceObject.cs
@@ -140,8 +140,9 @@ public class SliceObject : MonoBehaviour {
         // if image synthesis is active, make sure to update the renderers for image synthesis since now there are new objects with renderes in the scene
         BaseFPSAgentController primaryAgent = GameObject.Find("PhysicsSceneManager").GetComponent<AgentManager>().ReturnPrimaryAgent();
         if (primaryAgent.imageSynthesis) {
-            if (primaryAgent.imageSynthesis.enabled)
+            if (primaryAgent.imageSynthesis.enabled) {
                 primaryAgent.imageSynthesis.OnSceneChange();
+            }
         }
 
     }

--- a/unity/Assets/Scripts/StoveKnob.cs
+++ b/unity/Assets/Scripts/StoveKnob.cs
@@ -33,8 +33,10 @@ public class StoveKnob : MonoBehaviour {
             return;
         }
 
-        if (!simObj.IsAnimated)
+        if (!simObj.IsAnimated) {
             return;
+        }
+
         // set stove range anim state to knob's anim state
         On = simObj.Animator.GetBool("AnimState1");
         StoveRange.Animator.SetBool("AnimState1", On);

--- a/unity/Assets/Scripts/THORDocumentationExporter.cs
+++ b/unity/Assets/Scripts/THORDocumentationExporter.cs
@@ -108,8 +108,9 @@ public class THORDocumentationExporter : MonoBehaviour {
                 // keep track of which scenes contain this object type
                 // key already exists, don't worry about creating new list
                 if (ObjectType_To_Scenes.ContainsKey(currentSimObject.Type)) {
-                    if (!ObjectType_To_Scenes[currentSimObject.Type].Contains(currentSceneName))
+                    if (!ObjectType_To_Scenes[currentSimObject.Type].Contains(currentSceneName)) {
                         ObjectType_To_Scenes[currentSimObject.Type].Add(currentSceneName);
+                    }
                 } else {
                     List<String> listOfScenes = new List<String>();
                     listOfScenes.Add(currentSceneName);

--- a/unity/Assets/Scripts/Television.cs
+++ b/unity/Assets/Scripts/Television.cs
@@ -19,11 +19,13 @@ public class Television : MonoBehaviour {
     // 3 - On, Synced
 
     public void Update() {
-        if (ParentSimObj == null)
+        if (ParentSimObj == null) {
             return;
+        }
 
-        if (OffScreenMat == null || OnScreenMat == null)
+        if (OffScreenMat == null || OnScreenMat == null) {
             return;
+        }
 
         Material mat = OffScreenMat;
 

--- a/unity/Assets/Scripts/UtilityFunctions.cs
+++ b/unity/Assets/Scripts/UtilityFunctions.cs
@@ -22,7 +22,10 @@ public static class UtilityFunctions {
             while (value < n) {
                 result[index++] = value++;
                 stack.Push(value);
-                if (index != m) continue;
+                if (index != m) {
+                    continue;
+                }
+
                 yield return (int[])result.Clone(); // thanks to @xanatos
                 // yield return result;
                 break;
@@ -186,7 +189,10 @@ public static class UtilityFunctions {
     // usage: var copy = myComp.GetCopyOf(someOtherComponent);
     public static T GetCopyOf<T>(this Component comp, T other) where T : Component {
         Type type = comp.GetType();
-        if (type != other.GetType()) return null; // type mis-match
+        if (type != other.GetType()) {
+            return null; // type mis-match
+        }
+
         BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Default | BindingFlags.DeclaredOnly;
         PropertyInfo[] pinfos = type.GetProperties(flags);
         foreach (var pinfo in pinfos) {

--- a/unity/Assets/Scripts/WhatIsInsideMagnetSphere.cs
+++ b/unity/Assets/Scripts/WhatIsInsideMagnetSphere.cs
@@ -46,14 +46,16 @@ public class WhatIsInsideMagnetSphere : MonoBehaviour {
 
                 // populate list of sim objects inside sphere by objectID
                 if (!CurrentlyContainedObjectIds.Contains(sop.objectID)) {
-                    if (sop.PrimaryProperty == SimObjPrimaryProperty.CanPickup)
+                    if (sop.PrimaryProperty == SimObjPrimaryProperty.CanPickup) {
                         CurrentlyContainedObjectIds.Add(sop.objectID);
+                    }
                 }
 
                 // populate list of sim objects inside sphere by object reference
                 if (!CurrentlyContainedSOP.Contains(sop)) {
-                    if (sop.PrimaryProperty == SimObjPrimaryProperty.CanPickup)
+                    if (sop.PrimaryProperty == SimObjPrimaryProperty.CanPickup) {
                         CurrentlyContainedSOP.Add(sop);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Adding [csharp_prefer_braces](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0011#csharp_prefer_braces) to editorconfig as an error.  This will cause violations to appear when a linter is run as well as within IDEs.  Resharper codecleanup was used to fix all the existing violations of the rule.