### PR TITLE
Refactor metadata wrapper

### DIFF
--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -90,9 +90,16 @@ def fifo_controller():
 fifo_wsgi = [_fifo_controller, _wsgi_controller]
 fifo_wsgi_stoch = [_fifo_controller, _wsgi_controller, _stochastic_controller]
 
-BASE_FP28_POSITION = dict(x=-1.5, z=-1.5, y=0.901,)
+BASE_FP28_POSITION = dict(
+    x=-1.5,
+    z=-1.5,
+    y=0.901,
+)
 BASE_FP28_LOCATION = dict(
-    **BASE_FP28_POSITION, rotation={"x": 0, "y": 0, "z": 0}, horizon=0, standing=True,
+    **BASE_FP28_POSITION,
+    rotation={"x": 0, "y": 0, "z": 0},
+    horizon=0,
+    standing=True,
 )
 
 
@@ -198,7 +205,9 @@ def test_deprecated_segmentation_params(fifo_controller):
     # renderClassImage has been renamed to renderSemanticSegmentation
 
     fifo_controller.reset(
-        TEST_SCENE, renderObjectImage=True, renderClassImage=True,
+        TEST_SCENE,
+        renderObjectImage=True,
+        renderClassImage=True,
     )
     event = fifo_controller.last_event
     with warnings.catch_warnings():
@@ -215,7 +224,9 @@ def test_deprecated_segmentation_params2(fifo_controller):
     # renderClassImage has been renamed to renderSemanticSegmentation
 
     fifo_controller.reset(
-        TEST_SCENE, renderSemanticSegmentation=True, renderInstanceSegmentation=True,
+        TEST_SCENE,
+        renderSemanticSegmentation=True,
+        renderInstanceSegmentation=True,
     )
     event = fifo_controller.last_event
 
@@ -256,16 +267,12 @@ def test_fast_emit(fifo_controller):
     event_no_fast_emit = fifo_controller.step(dict(action="LookUp"))
     event_no_fast_emit_2 = fifo_controller.step(dict(action="RotateRight"))
 
-    assert event.metadata._raw_metadata["actionReturn"] is None
-    assert event_fast_emit.metadata._raw_metadata["actionReturn"] == "foo"
-    assert id(event.metadata._raw_metadata["objects"]) == id(
-        event_fast_emit.metadata._raw_metadata["objects"]
-    )
-    assert id(event.metadata._raw_metadata["objects"]) != id(
-        event_no_fast_emit.metadata._raw_metadata["objects"]
-    )
-    assert id(event_no_fast_emit_2.metadata._raw_metadata["objects"]) != id(
-        event_no_fast_emit.metadata._raw_metadata["objects"]
+    assert event.metadata["actionReturn"] is None
+    assert event_fast_emit.metadata["actionReturn"] == "foo"
+    assert id(event.metadata["objects"]) == id(event_fast_emit.metadata["objects"])
+    assert id(event.metadata["objects"]) != id(event_no_fast_emit.metadata["objects"])
+    assert id(event_no_fast_emit_2.metadata["objects"]) != id(
+        event_no_fast_emit.metadata["objects"]
     )
 
 
@@ -614,7 +621,9 @@ def test_open_interactable_with_filter(controller):
     controller.step(dict(action="SetObjectFilter", objectIds=[]))
     assert controller.last_event.metadata["objects"] == []
     controller.step(
-        action="OpenObject", objectId=fridge["objectId"], raise_for_failure=True,
+        action="OpenObject",
+        objectId=fridge["objectId"],
+        raise_for_failure=True,
     )
 
     controller.step(dict(action="ResetObjectFilter", objectIds=[]))
@@ -646,7 +655,9 @@ def test_open_interactable(controller):
     assert fridge["visible"], "Object is not interactable!"
     assert_near(controller.last_event.metadata["agent"]["position"], position)
     event = controller.step(
-        action="OpenObject", objectId=fridge["objectId"], raise_for_failure=True,
+        action="OpenObject",
+        objectId=fridge["objectId"],
+        raise_for_failure=True,
     )
     fridge = next(
         obj
@@ -818,7 +829,7 @@ def test_action_dispatch_find_conflicts_physics(fifo_controller):
         "TestActionDispatchConflict": ["param22"],
     }
 
-    assert event.metadata._raw_metadata["actionReturn"] == known_conflicts
+    assert event.metadata["actionReturn"] == known_conflicts
 
     skip_reset(fifo_controller)
 
@@ -1078,7 +1089,8 @@ def test_teleport(controller):
     # Teleporting too high
     before_position = controller.last_event.metadata["agent"]["position"]
     controller.step(
-        "Teleport", **{**BASE_FP28_LOCATION, "y": 1.0},
+        "Teleport",
+        **{**BASE_FP28_LOCATION, "y": 1.0},
     )
     assert not controller.last_event.metadata[
         "lastActionSuccess"
@@ -1089,7 +1101,8 @@ def test_teleport(controller):
 
     # Teleporting into an object
     controller.step(
-        "Teleport", **{**BASE_FP28_LOCATION, "z": -3.5},
+        "Teleport",
+        **{**BASE_FP28_LOCATION, "z": -3.5},
     )
     assert not controller.last_event.metadata[
         "lastActionSuccess"
@@ -1097,7 +1110,8 @@ def test_teleport(controller):
 
     # Teleporting into a wall
     controller.step(
-        "Teleport", **{**BASE_FP28_LOCATION, "z": 0},
+        "Teleport",
+        **{**BASE_FP28_LOCATION, "z": 0},
     )
     assert not controller.last_event.metadata[
         "lastActionSuccess"


### PR DESCRIPTION
This is in response to the warning generated by [lgtm.com](https://lgtm.com/projects/g/allenai/ai2thor/snapshot/abe62e40bb828e078032e19f12c4c3564e149b22/files/ai2thor/server.py?sort=name&dir=ASC&mode=list#x7715b99afd99f040:1). This removes the `__init__()` and `raw_metadata` member.  If we ever happen to need to expose access to the unfiltered dict we can create a separate method that simply delegates to `super().__getitem__(<key>)`.