### PR TITLE
local-build-test task / local-build with scenes

### DIFF
--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -558,12 +558,19 @@ class Controller(object):
 
         return self._scenes_in_build
 
+    @staticmethod
+    def normalize_scene(scene):
+
+        if re.match(r"^FloorPlan[0-9]+$", scene):
+            scene = scene + "_physics"
+
+        return scene
+
     def reset(self, scene=None, **init_params):
         if scene is None:
             scene = self.scene
 
-        if re.match(r"^FloorPlan[0-9]+$", scene):
-            scene = scene + "_physics"
+        scene = Controller.normalize_scene(scene)
 
         # scenes in build can be an empty set when GetScenesInBuild doesn't exist as an action
         # for old builds

--- a/ai2thor/tests/constants.py
+++ b/ai2thor/tests/constants.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
 
+TEST_SCENE = "FloorPlan28_physics"
 TESTS_DIR = os.path.abspath(os.path.dirname(Path(__file__)))
 TESTS_DATA_DIR = os.path.join(TESTS_DIR, "data")

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -9,14 +9,12 @@ import warnings
 import jsonschema
 import numpy as np
 from ai2thor.controller import Controller
-from ai2thor.tests.constants import TESTS_DATA_DIR
+from ai2thor.tests.constants import TESTS_DATA_DIR, TEST_SCENE
 from ai2thor.wsgi_server import WsgiServer
 from ai2thor.fifo_server import FifoServer
 from PIL import ImageChops, ImageFilter, Image
 import glob
 import re
-
-TEST_SCENE = "FloorPlan28"
 
 # Defining const classes to lessen the possibility of a misspelled key
 class Actions:
@@ -97,10 +95,7 @@ BASE_FP28_LOCATION = dict(
 
 
 def teleport_to_base_location(controller: Controller):
-    assert (
-        controller.last_event.metadata["sceneName"].replace("_physics", "")
-        == TEST_SCENE
-    )
+    assert controller.last_event.metadata["sceneName"] == TEST_SCENE
 
     controller.step("TeleportFull", **BASE_FP28_LOCATION)
     assert controller.last_event.metadata["lastActionSuccess"]
@@ -1301,7 +1296,7 @@ def test_get_interactable_poses(controller):
 def test_2d_semantic_hulls(controller):
     from shapely.geometry import Polygon
 
-    controller.reset("FloorPlan28")
+    controller.reset(TEST_SCENE)
     obj_name_to_obj_id = {
         o["name"]: o["objectId"] for o in controller.last_event.metadata["objects"]
     }
@@ -1483,7 +1478,7 @@ def test_get_object_in_frame(controller):
 
 @pytest.mark.parametrize("controller", fifo_wsgi)
 def test_get_coordinate_from_raycast(controller):
-    controller.reset(scene="FloorPlan28")
+    controller.reset(scene=TEST_SCENE)
     event = controller.step(
         action="TeleportFull",
         position=dict(x=-1.5, y=0.900998235, z=-1.5),
@@ -1518,7 +1513,7 @@ def test_get_coordinate_from_raycast(controller):
 
 @pytest.mark.parametrize("controller", fifo_wsgi)
 def test_get_reachable_positions_with_directions_relative_agent(controller):
-    controller.reset("FloorPlan28")
+    controller.reset(TEST_SCENE)
 
     event = controller.step("GetReachablePositions")
     num_reachable_aligned = len(event.metadata["actionReturn"])
@@ -1546,7 +1541,7 @@ def test_get_reachable_positions_with_directions_relative_agent(controller):
 
 @pytest.mark.parametrize("controller", fifo_wsgi)
 def test_manipulathor_move(controller):
-    event = controller.reset(scene="FloorPlan28", agentMode="arm")
+    event = controller.reset(scene=TEST_SCENE, agentMode="arm")
     assert_near(
         point1={"x": -1.5, "y": 0.9009982347488403, "z": -1.5},
         point2=event.metadata["agent"]["position"],
@@ -1561,7 +1556,7 @@ def test_manipulathor_move(controller):
 
 @pytest.mark.parametrize("controller", fifo_wsgi)
 def test_manipulathor_rotate(controller):
-    event = controller.reset(scene="FloorPlan28", agentMode="arm")
+    event = controller.reset(scene=TEST_SCENE, agentMode="arm")
     assert_near(
         point1={"x": -0.0, "y": 180.0, "z": 0.0},
         point2=event.metadata["agent"]["rotation"],

--- a/tasks.py
+++ b/tasks.py
@@ -120,6 +120,7 @@ def _build(unity_path, arch, build_dir, build_name, env={}):
         "%s -quit -batchmode -logFile %s.log -projectpath %s -executeMethod Build.%s"
         % (_unity_path(), build_name, project_path, arch)
     )
+
     target_path = os.path.join(build_dir, build_name)
 
     full_env = os.environ.copy()
@@ -374,13 +375,26 @@ def local_build_name(prefix, arch):
 
 
 @task
-def local_build(context, prefix="local", arch="OSXIntel64"):
+def local_build_test(context, prefix="local", arch="OSXIntel64"):
+    from ai2thor.tests.constants import TEST_SCENE
+
+    local_build(context, prefix, arch, [TEST_SCENE])
+
+
+@task(iterable=["scenes"])
+def local_build(context, prefix="local", arch="OSXIntel64", scenes=None):
+    import ai2thor.controller
+
     build = ai2thor.build.Build(arch, prefix, False)
     env = dict()
     if os.path.isdir("unity/Assets/Private/Scenes"):
         env["INCLUDE_PRIVATE_SCENES"] = "true"
 
     build_dir = os.path.join("builds", build.name)
+    if scenes:
+        env["BUILD_SCENES"] = ",".join(
+            map(ai2thor.controller.Controller.normalize_scene, scenes)
+        )
 
     if _build("unity", arch, build_dir, build.name, env=env):
         print("Build Successful")
@@ -468,7 +482,8 @@ def webgl_build(
     if verbose:
         print(scenes)
 
-    env = dict(SCENE=scenes)
+    env = dict(BUILD_SCENES=scenes)
+
     if crowdsource_build:
         env["DEFINES"] = "CROWDSOURCE_TASK"
     if _build("unity", arch, directory, build_name, env=env):
@@ -599,9 +614,9 @@ def push_pip_commit(context):
         pip_name = os.path.basename(g)
         logger.info("pushing pip file %s" % g)
         with open(g, "rb") as f:
-            s3.Object(ai2thor.build.PYPI_S3_BUCKET, os.path.join("ai2thor", pip_name)).put(
-                Body=f, ACL=acl
-            )
+            s3.Object(
+                ai2thor.build.PYPI_S3_BUCKET, os.path.join("ai2thor", pip_name)
+            ).put(Body=f, ACL=acl)
 
 
 @task
@@ -1466,9 +1481,7 @@ def real_2_sim(
     import cv2
     from ai2thor.util.transforms import transform_real_2_sim
 
-    depth_metadata_fn = os.path.join(
-        source_dir, "metadata_{}.json".format(index)
-    )
+    depth_metadata_fn = os.path.join(source_dir, "metadata_{}.json".format(index))
     color_real_fn = os.path.join(source_dir, "color_{}.png".format(index))
     color_sim_fn = os.path.join(output_dir, "color_teleport.png".format(index))
     with open(depth_metadata_fn, "r") as f:
@@ -1698,7 +1711,7 @@ def benchmark(
     out="benchmark.json",
     verbose=False,
     local_build=False,
-    commit_id=ai2thor.build.COMMIT_ID
+    commit_id=ai2thor.build.COMMIT_ID,
 ):
     import ai2thor.controller
     import random
@@ -1731,14 +1744,16 @@ def benchmark(
 
     args = {}
     if editor_mode:
-        args['port'] = 8200
-        args['start_unity'] = False
+        args["port"] = 8200
+        args["start_unity"] = False
     elif local_build:
-        args['local_build'] = local_build
+        args["local_build"] = local_build
     else:
-        args['commit_id'] = commit_id
+        args["commit_id"] = commit_id
 
-    env = ai2thor.controller.Controller(width=screen_width, height=screen_height, **args)
+    env = ai2thor.controller.Controller(
+        width=screen_width, height=screen_height, **args
+    )
 
     # Kitchens:       FloorPlan1 - FloorPlan30
     # Living rooms:   FloorPlan201 - FloorPlan230
@@ -1963,6 +1978,7 @@ def webgl_build_deploy_demo(ctx, verbose=False, force=False, content_addressable
         directory="builds/demo",
         content_addressable=content_addressable,
     )
+
     webgl_deploy(
         ctx, source_dir="builds/demo", target_dir="demo", verbose=verbose, force=force
     )


### PR DESCRIPTION
Typically when I want to run the tests or just experiment with a few scenes in a Unity Player I will modify Build.cs to include just the scenes I care about.  This PR modifies the `local-build` task to accept a scene(s) argument and introduces a new task `local-build-test` that just builds the player with the TEST_SCENE (currently FloorPlan28). The following is now possible

```python
invoke local-build -s FloorPlan28
invoke local-build -s FloorPlan28_physics -s FloorPlan1
```