### PR TITLE
Refactoring Invalid ActionDispacher

### DIFF
--- a/unity/Assets/Scripts/ActionDispatcher.cs
+++ b/unity/Assets/Scripts/ActionDispatcher.cs
@@ -322,7 +322,7 @@ public static class ActionDispatcher {
             var paramDict = methodParams.ToDictionary(param => param.Name, param => param);
             var invalidArgs = dynamicServerAction
                 .Keys()
-                .Where(argName => !paramDict.ContainsKey(argName) && argName != "action")
+                .Where(argName => !paramDict.ContainsKey(argName) && !DynamicServerAction.AllowedExtraneousParameters.Contains(argName))
                 .ToList();
             if (invalidArgs.Count > 0) {
                 Func<ParameterInfo, string> paramToString =

--- a/unity/Assets/Scripts/ActionDispatcher.cs
+++ b/unity/Assets/Scripts/ActionDispatcher.cs
@@ -321,8 +321,8 @@ public static class ActionDispatcher {
         } else {
             var paramDict = methodParams.ToDictionary(param => param.Name, param => param);
             var invalidArgs = dynamicServerAction
-                .Keys()
-                .Where(argName => !paramDict.ContainsKey(argName) && !DynamicServerAction.AllowedExtraneousParameters.Contains(argName))
+                .ArgumentKeys()
+                .Where(argName => !paramDict.ContainsKey(argName))
                 .ToList();
             if (invalidArgs.Count > 0) {
                 Func<ParameterInfo, string> paramToString =
@@ -339,7 +339,7 @@ public static class ActionDispatcher {
                 );
 
                 throw new InvalidArgumentsException(
-                    dynamicServerAction.Keys().Where(argName => argName != "action"),
+                    dynamicServerAction.ArgumentKeys(),
                     invalidArgs,
                     methodParams.Select(paramToString),
                     matchingMethodOverWrites

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1543,7 +1543,8 @@ The properties(agentId, sequenceId, action) exist to encapsulate the key names.
 */
 public class DynamicServerAction {
 
-    // To distinguish between args for reflection function call and global control arguments
+    // These parameters are allowed to exist as both parameters to an Action and as global
+    // paramaters.  This also excludes them from the InvalidArgument logic used in the ActionDispatcher
     public static readonly IReadOnlyCollection<string> AllowedExtraneousParameters = new HashSet<string>(){
         "sequenceId",
         "renderImage",

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1103,15 +1103,6 @@ public class AgentManager : MonoBehaviour {
 
     }
 
-    // To distinguish between args for reflection function call and global control arguments
-    private HashSet<string> injectedArguments = new HashSet<string>(){
-        "sequenceId",
-        "renderImage",
-        "agentId",
-        "renderObjectImage",
-        "renderClassImage",
-        "renderNormalsImage"
-    };
 
     // Uniform entry point for both the test runner and the python server for step dispatch calls
     public void ProcessControlCommand(DynamicServerAction controlCommand) {
@@ -1122,21 +1113,19 @@ public class AgentManager : MonoBehaviour {
         this.renderImage = controlCommand.renderImage;
         this.activeAgentId = controlCommand.agentId;
 
-        var args = new DynamicServerAction(
-            new JObject(
-                controlCommand.jObject.Properties().Where(p => !injectedArguments.Contains(p.Name))
-            )
-        );
-
         if (agentManagerActions.Contains(controlCommand.action)) {
             // let's look in this class for the action
-            this.activeAgent().ProcessControlCommand(controlCommand: args, target: this);
+            this.activeAgent().ProcessControlCommand(controlCommand: controlCommand, target: this);
         } else {
             // we only allow renderInstanceSegmentation to be flipped on
             // on a per step() basis, since by default the param is null
             // so we don't know if a request is meant to turn the param off
             // or if it is just the value by default
-            if (controlCommand.renderInstanceSegmentation == true) {
+            // We only assign if its true to handle the case when renderInstanceSegmentation
+            // was initialized to be true, but any particular step() may not set it
+            // so we don't want to disable it inadvertently
+
+            if (controlCommand.renderInstanceSegmentation) {
                 this.renderInstanceSegmentation = true;
             }
 
@@ -1150,7 +1139,7 @@ public class AgentManager : MonoBehaviour {
             }
 
             // let's look in the agent's set of actions for the action
-            this.activeAgent().ProcessControlCommand(controlCommand: args);
+            this.activeAgent().ProcessControlCommand(controlCommand: controlCommand);
         }
     }
 
@@ -1553,6 +1542,19 @@ to dispatch to the appropriate action based on the passed in params.
 The properties(agentId, sequenceId, action) exist to encapsulate the key names.
 */
 public class DynamicServerAction {
+
+    // To distinguish between args for reflection function call and global control arguments
+    public static readonly IReadOnlyCollection<string> AllowedExtraneousParameters = new HashSet<string>(){
+        "sequenceId",
+        "renderImage",
+        "agentId",
+        "renderObjectImage",
+        "renderClassImage",
+        "renderNormalsImage",
+        "renderInstanceSegmentation",
+        "action"
+    };
+
     public JObject jObject {
         get;
         private set;

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1639,6 +1639,13 @@ public class DynamicServerAction {
     public T ToObject<T>() {
         return this.jObject.ToObject<T>();
     }
+    
+    // this is primarily used when detecting invalid arguments
+    // if Initialize is ever changed we should refactor this since renderInstanceSegmentation is a 
+    // valid argument for Initialize as well as a global parameter
+    public IEnumerable<string> ArgumentKeys() {
+        return this.jObject.Properties().Select(p => p.Name).Where(argName => !AllowedExtraneousParameters.Contains(argName)).ToList();
+    }
 
     public IEnumerable<string> Keys() {
         return this.jObject.Properties().Select(p => p.Name).ToList();

--- a/unity/Assets/Scripts/ImageSynthesis/ImageSynthesis.cs
+++ b/unity/Assets/Scripts/ImageSynthesis/ImageSynthesis.cs
@@ -141,7 +141,7 @@ public class ImageSynthesis : MonoBehaviour {
         // Note: Check that all image synthesis works with third party cameras, as the image synth assumes that it is taking default settings
         // from the Agent's camera, and a ThirdPartyCamera does not have the same defaults, which may cause some errors
         if (go.transform.parent.GetComponent<FirstPersonCharacterCull>())
-            // add the FirstPersonCharacterCull so this camera's agent is not rendered- other agents when multi agent is enabled should still be rendered
+        // add the FirstPersonCharacterCull so this camera's agent is not rendered- other agents when multi agent is enabled should still be rendered
         {
             go.AddComponent<FirstPersonCharacterCull>(go.transform.parent.GetComponent<FirstPersonCharacterCull>());
         }

--- a/unity/Assets/Scripts/SimObjPhysics.cs
+++ b/unity/Assets/Scripts/SimObjPhysics.cs
@@ -915,7 +915,7 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
     void LateUpdate() {
         // only update lastVelocity if physicsAutosimulation = true, otherwise let the Advance Physics function take care of it;
         if (sceneManager.physicsSimulationPaused == false)
-            // record this object's current velocity
+        // record this object's current velocity
         {
             lastVelocity = Math.Abs(myRigidbody.angularVelocity.sqrMagnitude + myRigidbody.velocity.sqrMagnitude);
         }

--- a/unity/Assets/UnitTests/TestBase.cs
+++ b/unity/Assets/UnitTests/TestBase.cs
@@ -10,20 +10,12 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
-namespace Tests
-{
-    public class TestBase
-    {
+namespace Tests {
+    public class TestBase {
         protected int sequenceId = 0;
         protected bool lastActionSuccess;
         protected string error;
 
-        // WARNING do not use this for testing as it adds the DebugInputField 
-        // and it's definitions as a dependency
-        public IEnumerator ExecuteDebugAction(string action) {
-            var debugInputField = GameObject.FindObjectOfType<DebugInputField>();
-            yield return debugInputField.ExecuteBatch(new List<string>{action});
-        }
 
         public IEnumerator step(Dictionary<string, object> action) {
             var agentManager = GameObject.FindObjectOfType<AgentManager>();
@@ -48,8 +40,8 @@ namespace Tests
         }
 
         [SetUp]
-        public virtual void Setup(){
-            UnityEngine.SceneManagement.SceneManager.LoadScene ("FloorPlan1_physics");
+        public virtual void Setup() {
+            UnityEngine.SceneManagement.SceneManager.LoadScene("FloorPlan1_physics");
         }
 
     }

--- a/unity/Assets/UnitTests/TestDispatcher.cs
+++ b/unity/Assets/UnitTests/TestDispatcher.cs
@@ -6,11 +6,9 @@ using UnityEngine;
 using UnityEngine.TestTools;
 using UnityStandardAssets.Characters.FirstPerson;
 
-namespace Tests
-{
-    public class TestDispatcher : TestBase
-    {
-         [UnityTest]
+namespace Tests {
+    public class TestDispatcher : TestBase {
+        [UnityTest]
         public IEnumerator TestDispatchInvalidArguments() {
             yield return initalizeDefaultDiscrete();
             var controller = GameObject.FindObjectOfType<PhysicsRemoteFPSAgentController>();
@@ -21,15 +19,14 @@ namespace Tests
                 {"z", 0.3f},
                 {"forceAction", false},
                 {"placeStationary", true}
-            }; 
-            Assert.Throws<InvalidArgumentsException> (() => {
+            };
+            Assert.Throws<InvalidArgumentsException>(() => {
                 ActionDispatcher.Dispatch(controller, new DynamicServerAction(args));
             });
         }
 
         [UnityTest]
-        public IEnumerator TestStepInvalidArguments()
-        {
+        public IEnumerator TestStepInvalidArguments() {
             yield return initalizeDefaultDiscrete();
 
             var args = new Dictionary<string, object>() {
@@ -39,7 +36,7 @@ namespace Tests
                 {"z", 0.3f},
                 {"forceAction", false},
                 {"placeStationary", true}
-            }; 
+            };
 
             yield return step(args);
             BaseFPSAgentController agent = GameObject.FindObjectOfType<BaseFPSAgentController>();

--- a/unity/Assets/UnitTests/TestPutObject.cs
+++ b/unity/Assets/UnitTests/TestPutObject.cs
@@ -6,20 +6,17 @@ using UnityEngine;
 using UnityEngine.TestTools;
 using UnityStandardAssets.Characters.FirstPerson;
 
-namespace Tests
-{
-    public class TestPutObject : TestBase
-    {
+namespace Tests {
+    public class TestPutObject : TestBase {
         [UnityTest]
-        public IEnumerator TestPutObject_PutNearXY_True()
-        {
+        public IEnumerator TestPutObject_PutNearXY_True() {
             Dictionary<string, object> action = new Dictionary<string, object>();
 
             action["action"] = "Initialize";
             action["fieldOfView"] = 90f;
             action["snapToGrid"] = true;
             yield return step(action);
-            
+
             action.Clear();
 
             action["action"] = "RotateRight";
@@ -64,8 +61,7 @@ namespace Tests
         }
 
         [UnityTest]
-        public IEnumerator TestPutObject_PutNearXY_False()
-        {
+        public IEnumerator TestPutObject_PutNearXY_False() {
             Dictionary<string, object> action = new Dictionary<string, object>();
 
             action["action"] = "Initialize";
@@ -122,8 +118,7 @@ namespace Tests
         // note: if a user passes in both 'z' and 'maxDistance' then they may get a silent, unintended behavior.
         // we should decide how to handle extraneous parameters in the future
         [UnityTest]
-        public IEnumerator PlaceHeldObject_Deprecated_Z_objectId()
-        {
+        public IEnumerator PlaceHeldObject_Deprecated_Z_objectId() {
             Dictionary<string, object> action = new Dictionary<string, object>();
 
             action["action"] = "Initialize";
@@ -167,8 +162,7 @@ namespace Tests
         }
 
         [UnityTest]
-        public IEnumerator PlaceHeldObject_Deprecated_Z_XY()
-        {
+        public IEnumerator PlaceHeldObject_Deprecated_Z_XY() {
             Dictionary<string, object> action = new Dictionary<string, object>();
 
             action["action"] = "Initialize";
@@ -213,8 +207,7 @@ namespace Tests
         }
 
         [UnityTest]
-        public IEnumerator PlaceHeldObject_Deprecated_Z_XY_PutNearXY_True()
-        {
+        public IEnumerator PlaceHeldObject_Deprecated_Z_XY_PutNearXY_True() {
             Dictionary<string, object> action = new Dictionary<string, object>();
 
             action["action"] = "Initialize";

--- a/unity/Assets/UnitTests/TestRotate.cs
+++ b/unity/Assets/UnitTests/TestRotate.cs
@@ -6,17 +6,27 @@ using UnityEngine;
 using UnityEngine.TestTools;
 using UnityStandardAssets.Characters.FirstPerson;
 
-namespace Tests
-{
-    public class TestRotate : TestBase
-    {
+namespace Tests {
+    public class TestRotate : TestBase {
         [UnityTest]
-        public IEnumerator TestRotateRight()
-        {
-            yield return ExecuteDebugAction("init");
+        public IEnumerator TestRotateRight() {
+            Dictionary<string, object> action = new Dictionary<string, object>();
+
+            action["action"] = "Initialize";
+            action["fieldOfView"] = 90f;
+            action["snapToGrid"] = true;
+            yield return step(action);
+
             BaseFPSAgentController agent = GameObject.FindObjectOfType<BaseFPSAgentController>();
             agent.gameObject.transform.rotation = Quaternion.Euler(Vector3.zero);
-            yield return ExecuteDebugAction("rr");
+
+            action.Clear();
+
+            action["action"] = "RotateRight";
+            yield return step(action);
+
+            action.Clear();
+
             Assert.AreEqual((int)agent.gameObject.transform.rotation.eulerAngles.y, 90);
         }
     }


### PR DESCRIPTION
Refactor invalid ActionDispatcher params logic to allow renderInstanceSegmentation to be both an action param and per step param.