### PR TITLE
local-build with BuildOptions.BuildScriptsOnly 

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -382,7 +382,7 @@ def local_build_test(context, prefix="local", arch="OSXIntel64"):
 
 
 @task(iterable=["scenes"])
-def local_build(context, prefix="local", arch="OSXIntel64", scenes=None):
+def local_build(context, prefix="local", arch="OSXIntel64", scenes=None, scripts_only=False):
     import ai2thor.controller
 
     build = ai2thor.build.Build(arch, prefix, False)
@@ -391,6 +391,9 @@ def local_build(context, prefix="local", arch="OSXIntel64", scenes=None):
         env["INCLUDE_PRIVATE_SCENES"] = "true"
 
     build_dir = os.path.join("builds", build.name)
+    if scripts_only:
+        env["BUILD_SCRIPTS_ONLY"] = "true";
+
     if scenes:
         env["BUILD_SCENES"] = ",".join(
             map(ai2thor.controller.Controller.normalize_scene, scenes)

--- a/unity/Assets/Editor/Build.cs
+++ b/unity/Assets/Editor/Build.cs
@@ -38,7 +38,15 @@ public class Build {
         foreach (string scene in scenes) {
             Debug.Log("Adding Scene " + scene);
         }
-        BuildPipeline.BuildPlayer(scenes.ToArray(), buildName, target, BuildOptions.StrictMode | BuildOptions.UncompressedAssetBundle);
+
+        BuildOptions options = BuildOptions.StrictMode | BuildOptions.UncompressedAssetBundle;
+        if (ScriptsOnly()) {
+            options |= BuildOptions.Development | BuildOptions.BuildScriptsOnly;
+        }
+
+        Debug.Log("Build options " + options);
+
+        BuildPipeline.BuildPlayer(scenes.ToArray(), buildName, target, options);
     }
 
     private static List<string> GetScenes() {
@@ -79,10 +87,21 @@ public class Build {
         }
     }
 
-    private static bool IncludePrivateScenes() {
-        string privateScenes = Environment.GetEnvironmentVariable("INCLUDE_PRIVATE_SCENES");
+    private static bool GetBoolEnvVariable(string key, bool defaultValue = false) {
+        string value = Environment.GetEnvironmentVariable(key);
+        if (value != null) {
+            return value.ToLower() == "true";
+        } else {
+            return defaultValue;
+        }
+    }
 
-        return privateScenes != null && privateScenes.ToLower() == "true";
+    private static bool ScriptsOnly() {
+        return GetBoolEnvVariable("BUILD_SCRIPTS_ONLY");
+    }
+
+    private static bool IncludePrivateScenes() {
+        return GetBoolEnvVariable("INCLUDE_PRIVATE_SCENES");
     }
 
     private static string GetDefineSymbolsFromEnv() {


### PR DESCRIPTION
Adding option to local-build to include BuildScriptsOnly when running a build.  The following is now possible:

```bash
invoke local-build --scripts-only
```

I found that in order for the build run execute with any speedup `BuildOptions.Development` also needed to be included with the options.  
