### PR TITLE
Use python-xlib for X selecting and checking X server

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "flask",
         "numpy",
         "pyyaml",
+        "python-xlib",
         "requests",
         "progressbar2",
         "botocore",


### PR DESCRIPTION
This PR removes xdpyinfo and uses python-xlib to validate (display is running and has the GLX extension loaded).  If no x_display is passed in and a DISPLAY is not present in the environment one will be selected from the list of valid_displays.