### PR TITLE
Remove lights from randomizable materials

### DIFF
--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -1632,7 +1632,7 @@ def test_randomize_materials_scenes(controller):
         assert meta["useExternalMaterials"]
         assert not meta["useValMaterials"]
         assert not meta["useTestMaterials"]
-        assert meta["totalMaterialsConsidered"] == 689
+        assert meta["totalMaterialsConsidered"] == 679
 
         controller.reset(scene=f"FloorPlan{p + 21}")
         meta = controller.step("RandomizeMaterials").metadata["actionReturn"]
@@ -1640,7 +1640,7 @@ def test_randomize_materials_scenes(controller):
         assert not meta["useExternalMaterials"]
         assert meta["useValMaterials"]
         assert not meta["useTestMaterials"]
-        assert meta["totalMaterialsConsidered"] == 506
+        assert meta["totalMaterialsConsidered"] == 500
 
         controller.reset(scene=f"FloorPlan{p + 25}")
         meta = controller.step("RandomizeMaterials").metadata["actionReturn"]
@@ -1648,7 +1648,7 @@ def test_randomize_materials_scenes(controller):
         assert not meta["useExternalMaterials"]
         assert meta["useValMaterials"]
         assert not meta["useTestMaterials"]
-        assert meta["totalMaterialsConsidered"] == 506
+        assert meta["totalMaterialsConsidered"] == 500
 
         controller.reset(scene=f"FloorPlan{p + 26}")
         meta = controller.step("RandomizeMaterials").metadata["actionReturn"]
@@ -1656,7 +1656,7 @@ def test_randomize_materials_scenes(controller):
         assert not meta["useExternalMaterials"]
         assert not meta["useValMaterials"]
         assert meta["useTestMaterials"]
-        assert meta["totalMaterialsConsidered"] == 366
+        assert meta["totalMaterialsConsidered"] == 358
 
     controller.reset(scene=f"FloorPlan_Train5_3")
     meta = controller.step("RandomizeMaterials").metadata["actionReturn"]
@@ -1664,7 +1664,7 @@ def test_randomize_materials_scenes(controller):
     assert meta["useExternalMaterials"]
     assert not meta["useValMaterials"]
     assert not meta["useTestMaterials"]
-    assert meta["totalMaterialsConsidered"] == 689
+    assert meta["totalMaterialsConsidered"] == 679
 
     controller.reset(scene=f"FloorPlan_Val2_1")
     meta = controller.step("RandomizeMaterials").metadata["actionReturn"]
@@ -1672,7 +1672,7 @@ def test_randomize_materials_scenes(controller):
     assert not meta["useExternalMaterials"]
     assert meta["useValMaterials"]
     assert not meta["useTestMaterials"]
-    assert meta["totalMaterialsConsidered"] == 506
+    assert meta["totalMaterialsConsidered"] == 500
     controller.step(action="ResetMaterials")
 
 
@@ -1720,20 +1720,20 @@ def test_randomize_materials_params(controller):
     assert not meta["useExternalMaterials"]
     assert meta["useValMaterials"]
     assert meta["useTestMaterials"]
-    assert meta["totalMaterialsConsidered"] == 752
+    assert meta["totalMaterialsConsidered"] == 741
 
     assert not controller.step(action="RandomizeMaterials", useTrainMaterials=False)
     assert controller.step(action="RandomizeMaterials", inRoomTypes=["Kitchen"])
     assert (
         controller.last_event.metadata["actionReturn"]["totalMaterialsConsidered"]
-        == 332
+        == 325
     )
     assert controller.step(
         action="RandomizeMaterials", inRoomTypes=["Kitchen", "LivingRoom"],
     )
     assert (
         controller.last_event.metadata["actionReturn"]["totalMaterialsConsidered"]
-        == 512
+        == 503
     )
     assert not controller.step(action="RandomizeMaterials", inRoomTypes=["LivingRoom"])
     assert not controller.step(action="RandomizeMaterials", inRoomTypes=["RoboTHOR"])
@@ -1746,7 +1746,7 @@ def test_randomize_materials_params(controller):
     assert controller.step(action="RandomizeMaterials", inRoomTypes=["RoboTHOR"])
     assert (
         controller.last_event.metadata["actionReturn"]["totalMaterialsConsidered"]
-        == 352
+        == 350
     )
 
     controller.reset(scene="FloorPlan_Val3_2")
@@ -1757,7 +1757,7 @@ def test_randomize_materials_params(controller):
     assert controller.step(action="RandomizeMaterials", inRoomTypes=["RoboTHOR"])
     assert (
         controller.last_event.metadata["actionReturn"]["totalMaterialsConsidered"]
-        == 320
+        == 318
     )
 
     controller.step(action="ResetMaterials")

--- a/unity/Assets/Scripts/ColorChanger.cs
+++ b/unity/Assets/Scripts/ColorChanger.cs
@@ -270,6 +270,9 @@ public class ColorChanger : MonoBehaviour {
     }
 
     public void RandomizeColor() {
+        if (materials == null) {
+            cacheMaterials();
+        }
         foreach (KeyValuePair<string, Material[]> materialGroup in materials) {
             for (int i = 0; i < materialGroup.Value.Length; i++) {
                 Material mat = materialGroup.Value[i];

--- a/unity/Assets/Scripts/ColorChanger.cs
+++ b/unity/Assets/Scripts/ColorChanger.cs
@@ -50,7 +50,6 @@ public class ColorChanger : MonoBehaviour {
 
                       fabricMaterials,
                       glassMaterials,
-                      lightMaterials,
                       metalMaterials,
 
                       paperMaterials,
@@ -120,7 +119,6 @@ public class ColorChanger : MonoBehaviour {
                 ["Sofa"] = sofaMaterials,
                 ["Fabric"] = fabricMaterials,
                 ["Glass"] = glassMaterials,
-                ["Light"] = lightMaterials,
                 ["Metal"] = metalMaterials,
                 ["Plastic"] = plasticMaterials,
                 ["Wood"] = woodMaterials,


### PR DESCRIPTION
Solves a visual bug that only happens in a few scenes and was discovered after adding the initial `RandomizeMaterials` to the demo. Since some light rays are transparent, and others, apparently, are not, randomizing a transparent light ray to a solid light ray looks... bad.

This PR simply removes lighting materials from materials that may be randomized.

![image](https://user-images.githubusercontent.com/28768645/118378456-d80f6780-b588-11eb-8f03-99aaa7368848.png)

![image](https://user-images.githubusercontent.com/28768645/118378459-e198cf80-b588-11eb-9091-60c11a5367e2.png)
