### PR TITLE
When setting object poses, reset the parents of all moved objects to the top-level object.

### DIFF
--- a/ai2thor/_quality_settings.py
+++ b/ai2thor/_quality_settings.py
@@ -1,11 +1,13 @@
 # GENERATED FILE - DO NOT EDIT
-DEFAULT_QUALITY = 'Ultra'
-QUALITY_SETTINGS = {'DONOTUSE': 0,
- 'High': 5,
- 'High WebGL': 8,
- 'Low': 2,
- 'Medium': 3,
- 'MediumCloseFitShadows': 4,
- 'Ultra': 7,
- 'Very High': 6,
- 'Very Low': 1}
+DEFAULT_QUALITY = "Ultra"
+QUALITY_SETTINGS = {
+    "DONOTUSE": 0,
+    "High": 5,
+    "High WebGL": 8,
+    "Low": 2,
+    "Medium": 3,
+    "MediumCloseFitShadows": 4,
+    "Ultra": 7,
+    "Very High": 6,
+    "Very Low": 1,
+}

--- a/ai2thor/build.py
+++ b/ai2thor/build.py
@@ -20,6 +20,7 @@ PYPI_S3_BUCKET = "ai2-thor-pypi"
 COMMIT_ID = None
 try:
     import ai2thor._builds
+
     COMMIT_ID = ai2thor._builds.COMMIT_ID
 except ImportError:
     pass

--- a/ai2thor/tests/test_controller.py
+++ b/ai2thor/tests/test_controller.py
@@ -69,10 +69,11 @@ def test_distance():
 def test_key_for_point():
     assert ai2thor.controller.key_for_point(2.567, -3.43) == "2.6 -3.4"
 
+
 def test_invalid_commit():
     caught_exception = False
     try:
-        c = ai2thor.controller.Controller(commit_id='1234567x')
+        c = ai2thor.controller.Controller(commit_id="1234567x")
     except ValueError as e:
         caught_exception = True
 

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -87,9 +87,16 @@ def fifo_controller():
 fifo_wsgi = [_fifo_controller, _wsgi_controller]
 fifo_wsgi_stoch = [_fifo_controller, _wsgi_controller, _stochastic_controller]
 
-BASE_FP28_POSITION = dict(x=-1.5, z=-1.5, y=0.901,)
+BASE_FP28_POSITION = dict(
+    x=-1.5,
+    z=-1.5,
+    y=0.901,
+)
 BASE_FP28_LOCATION = dict(
-    **BASE_FP28_POSITION, rotation={"x": 0, "y": 0, "z": 0}, horizon=0, standing=True,
+    **BASE_FP28_POSITION,
+    rotation={"x": 0, "y": 0, "z": 0},
+    horizon=0,
+    standing=True,
 )
 
 
@@ -192,7 +199,9 @@ def test_deprecated_segmentation_params(fifo_controller):
     # renderClassImage has been renamed to renderSemanticSegmentation
 
     fifo_controller.reset(
-        TEST_SCENE, renderObjectImage=True, renderClassImage=True,
+        TEST_SCENE,
+        renderObjectImage=True,
+        renderClassImage=True,
     )
     event = fifo_controller.last_event
     with warnings.catch_warnings():
@@ -209,7 +218,9 @@ def test_deprecated_segmentation_params2(fifo_controller):
     # renderClassImage has been renamed to renderSemanticSegmentation
 
     fifo_controller.reset(
-        TEST_SCENE, renderSemanticSegmentation=True, renderInstanceSegmentation=True,
+        TEST_SCENE,
+        renderSemanticSegmentation=True,
+        renderInstanceSegmentation=True,
     )
     event = fifo_controller.last_event
 
@@ -627,7 +638,9 @@ def test_open_interactable_with_filter(controller):
     controller.step(dict(action="SetObjectFilter", objectIds=[]))
     assert controller.last_event.metadata["objects"] == []
     controller.step(
-        action="OpenObject", objectId=fridge["objectId"], raise_for_failure=True,
+        action="OpenObject",
+        objectId=fridge["objectId"],
+        raise_for_failure=True,
     )
 
     controller.step(dict(action="ResetObjectFilter"))
@@ -659,7 +672,9 @@ def test_open_interactable(controller):
     assert fridge["visible"], "Object is not interactable!"
     assert_near(controller.last_event.metadata["agent"]["position"], position)
     event = controller.step(
-        action="OpenObject", objectId=fridge["objectId"], raise_for_failure=True,
+        action="OpenObject",
+        objectId=fridge["objectId"],
+        raise_for_failure=True,
     )
     fridge = next(
         obj
@@ -1101,7 +1116,8 @@ def test_teleport(controller):
     # Teleporting too high
     before_position = controller.last_event.metadata["agent"]["position"]
     controller.step(
-        "Teleport", **{**BASE_FP28_LOCATION, "y": 1.0},
+        "Teleport",
+        **{**BASE_FP28_LOCATION, "y": 1.0},
     )
     assert not controller.last_event.metadata[
         "lastActionSuccess"
@@ -1112,7 +1128,8 @@ def test_teleport(controller):
 
     # Teleporting into an object
     controller.step(
-        "Teleport", **{**BASE_FP28_LOCATION, "z": -3.5},
+        "Teleport",
+        **{**BASE_FP28_LOCATION, "z": -3.5},
     )
     assert not controller.last_event.metadata[
         "lastActionSuccess"
@@ -1120,7 +1137,8 @@ def test_teleport(controller):
 
     # Teleporting into a wall
     controller.step(
-        "Teleport", **{**BASE_FP28_LOCATION, "z": 0},
+        "Teleport",
+        **{**BASE_FP28_LOCATION, "z": 0},
     )
     assert not controller.last_event.metadata[
         "lastActionSuccess"
@@ -1729,7 +1747,8 @@ def test_randomize_materials_params(controller):
         == 332
     )
     assert controller.step(
-        action="RandomizeMaterials", inRoomTypes=["Kitchen", "LivingRoom"],
+        action="RandomizeMaterials",
+        inRoomTypes=["Kitchen", "LivingRoom"],
     )
     assert (
         controller.last_event.metadata["actionReturn"]["totalMaterialsConsidered"]
@@ -1740,7 +1759,8 @@ def test_randomize_materials_params(controller):
 
     controller.reset(scene="FloorPlan_Train5_2")
     assert not controller.step(
-        action="RandomizeMaterials", inRoomTypes=["Kitchen", "LivingRoom"],
+        action="RandomizeMaterials",
+        inRoomTypes=["Kitchen", "LivingRoom"],
     )
     assert not controller.step(action="RandomizeMaterials", inRoomTypes=["LivingRoom"])
     assert controller.step(action="RandomizeMaterials", inRoomTypes=["RoboTHOR"])
@@ -1751,7 +1771,8 @@ def test_randomize_materials_params(controller):
 
     controller.reset(scene="FloorPlan_Val3_2")
     assert not controller.step(
-        action="RandomizeMaterials", inRoomTypes=["Kitchen", "LivingRoom"],
+        action="RandomizeMaterials",
+        inRoomTypes=["Kitchen", "LivingRoom"],
     )
     assert not controller.step(action="RandomizeMaterials", inRoomTypes=["LivingRoom"])
     assert controller.step(action="RandomizeMaterials", inRoomTypes=["RoboTHOR"])

--- a/ai2thor/video_controller.py
+++ b/ai2thor/video_controller.py
@@ -168,8 +168,7 @@ class VideoController(Controller):
                 yield self.step(
                     action="TeleportFull",
                     rotation=y0
-                    + rotateDegrees
-                    * self._linear_to_smooth(i + 1, frames, std_dev=1),
+                    + rotateDegrees * self._linear_to_smooth(i + 1, frames, std_dev=1),
                     **p,
                 )
             else:

--- a/arm_test/check_determinism_different_machines.py
+++ b/arm_test/check_determinism_different_machines.py
@@ -95,17 +95,13 @@ def execute_command(controller, command, action_dict_addition):
 
         if "moveSpeed" in action_dict_addition:
             action_dict_addition["speed"] = action_dict_addition["moveSpeed"]
-        controller.step(
-            action="RotateContinuous", degrees=45, **action_dict_addition
-        )
+        controller.step(action="RotateContinuous", degrees=45, **action_dict_addition)
         action_details = dict(
             action="RotateContinuous", degrees=45, **action_dict_addition
         )
     elif command == "ll":
         action_dict_addition = copy.copy(action_dict_addition)
-        controller.step(
-            action="RotateContinuous", degrees=-45, **action_dict_addition
-        )
+        controller.step(action="RotateContinuous", degrees=-45, **action_dict_addition)
         action_details = dict(
             action="RotateContinuous", degrees=-45, **action_dict_addition
         )
@@ -114,9 +110,7 @@ def execute_command(controller, command, action_dict_addition):
         action_details = dict(action="MoveAhead", **action_dict_addition)
 
     elif command == "r":
-        controller.step(
-            action="RotateRight", degrees=45, **action_dict_addition
-        )
+        controller.step(action="RotateRight", degrees=45, **action_dict_addition)
         action_details = dict(action="RotateRight", degrees=45, **action_dict_addition)
     elif command == "l":
         controller.step(action="RotateLeft", degrees=45, **action_dict_addition)
@@ -160,7 +154,6 @@ def execute_command(controller, command, action_dict_addition):
         action_details = dict(
             action="MoveArmBase", y=base_position["h"], **action_dict_addition
         )
-
 
     return action_details
 

--- a/arm_test/check_determinism_event_collision_different_machines.py
+++ b/arm_test/check_determinism_event_collision_different_machines.py
@@ -97,17 +97,13 @@ def execute_command(controller, command, action_dict_addition):
 
         if "moveSpeed" in action_dict_addition:
             action_dict_addition["speed"] = action_dict_addition["moveSpeed"]
-        controller.step(
-            action="RotateContinuous", degrees=45, **action_dict_addition
-        )
+        controller.step(action="RotateContinuous", degrees=45, **action_dict_addition)
         action_details = dict(
             action="RotateContinuous", degrees=45, **action_dict_addition
         )
     elif command == "ll":
         action_dict_addition = copy.copy(action_dict_addition)
-        controller.step(
-            action="RotateContinuous", degrees=-45, **action_dict_addition
-        )
+        controller.step(action="RotateContinuous", degrees=-45, **action_dict_addition)
         action_details = dict(
             action="RotateContinuous", degrees=-45, **action_dict_addition
         )
@@ -116,9 +112,7 @@ def execute_command(controller, command, action_dict_addition):
         action_details = dict(action="MoveAhead", **action_dict_addition)
 
     elif command == "r":
-        controller.step(
-            action="RotateRight", degrees=45, **action_dict_addition
-        )
+        controller.step(action="RotateRight", degrees=45, **action_dict_addition)
         action_details = dict(action="RotateRight", degrees=45, **action_dict_addition)
     elif command == "l":
         controller.step(action="RotateLeft", degrees=45, **action_dict_addition)
@@ -162,7 +156,6 @@ def execute_command(controller, command, action_dict_addition):
         action_details = dict(
             action="MoveArmBase", y=base_position["h"], **action_dict_addition
         )
-
 
     return action_details
 

--- a/scripts/update_private.py
+++ b/scripts/update_private.py
@@ -8,12 +8,21 @@ import os
 import subprocess
 
 private_repo_url = "https://github.com/allenai/ai2thor-private"
-base_dir = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath(__file__)) , ".."))
+base_dir = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
+)
 private_dir = os.path.join(base_dir, "unity", "Assets", "Private")
 
+
 def current_branch():
-    git_dir = os.path.join(base_dir, '.git')
-    return subprocess.check_output(f"git --git-dir={git_dir} rev-parse --abbrev-ref HEAD", shell=True).decode('ascii').strip()
+    git_dir = os.path.join(base_dir, ".git")
+    return (
+        subprocess.check_output(
+            f"git --git-dir={git_dir} rev-parse --abbrev-ref HEAD", shell=True
+        )
+        .decode("ascii")
+        .strip()
+    )
 
 
 def checkout_branch(remote="origin"):
@@ -29,7 +38,7 @@ def checkout_branch(remote="origin"):
         subprocess.check_call(f"git checkout {branch}", shell=True)
         subprocess.check_call(f"git pull {remote} {branch}", shell=True)
     except subprocess.CalledProcessError as e:
-        print(f"No branch exists for private: {branch} - remaining on main" )
+        print(f"No branch exists for private: {branch} - remaining on main")
         subprocess.check_call(f"git fetch {remote} main", shell=True)
         subprocess.check_call(f"git checkout main", shell=True)
         subprocess.check_call(f"git pull {remote} main", shell=True)
@@ -39,6 +48,8 @@ def checkout_branch(remote="origin"):
 
 if __name__ == "__main__":
     if not os.path.isdir(private_dir) and os.path.exists(private_dir):
-        raise Exception(f"Private directory {private_dir} is not a directory - please remove")
+        raise Exception(
+            f"Private directory {private_dir} is not a directory - please remove"
+        )
     else:
         checkout_branch()

--- a/tasks.py
+++ b/tasks.py
@@ -382,7 +382,9 @@ def local_build_test(context, prefix="local", arch="OSXIntel64"):
 
 
 @task(iterable=["scenes"])
-def local_build(context, prefix="local", arch="OSXIntel64", scenes=None, scripts_only=False):
+def local_build(
+    context, prefix="local", arch="OSXIntel64", scenes=None, scripts_only=False
+):
     import ai2thor.controller
 
     build = ai2thor.build.Build(arch, prefix, False)
@@ -392,7 +394,7 @@ def local_build(context, prefix="local", arch="OSXIntel64", scenes=None, scripts
 
     build_dir = os.path.join("builds", build.name)
     if scripts_only:
-        env["BUILD_SCRIPTS_ONLY"] = "true";
+        env["BUILD_SCRIPTS_ONLY"] = "true"
 
     if scenes:
         env["BUILD_SCENES"] = ",".join(
@@ -834,7 +836,6 @@ def link_build_cache(branch):
     cache_base_dir = os.path.join(os.environ["HOME"], "cache")
 
     ci_prune_cache(cache_base_dir)
-
 
     main_cache_dir = os.path.join(cache_base_dir, "main")
     branch_cache_dir = os.path.join(cache_base_dir, encoded_branch)

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1469,6 +1469,13 @@ public class ObjectTypeCount {
 [Serializable]
 [MessagePackObject(keyAsPropertyName: true)]
 public class ObjectPose {
+
+    public ObjectPose() : this("", new Vector3(), new Vector3()) { }
+    public ObjectPose(string objectName, Vector3 position, Vector3 rotation) {
+        this.objectName = objectName;
+        this.position = position;
+        this.rotation = rotation;
+    }
     public string objectName;
     public Vector3 position;
     public Vector3 rotation;
@@ -1650,7 +1657,7 @@ public class DynamicServerAction {
     public T ToObject<T>() {
         return this.jObject.ToObject<T>();
     }
-    
+
     // this is primarily used when detecting invalid arguments
     // if Initialize is ever changed we should refactor this since renderInstanceSegmentation is a 
     // valid argument for Initialize as well as a global parameter

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -817,7 +817,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 ) % 100;
 
                 int sceneGroup = Int32.Parse(
-                    scene.Substring(startIndex: "FloorPlan".Length, length:  scene.Length - "FloorPlan_physics".Length)
+                    scene.Substring(startIndex: "FloorPlan".Length, length: scene.Length - "FloorPlan_physics".Length)
                 ) / 100;
 
                 if (inRoomTypes != null) {

--- a/unity/Assets/Scripts/ColorChanger.cs
+++ b/unity/Assets/Scripts/ColorChanger.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
 using Random = UnityEngine.Random;
- 
+
 public class ColorChanger : MonoBehaviour {
     // These will eventually be turned into sets, such that they are
     // easily checkable at runtime.

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -669,29 +669,29 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 // materials, and you'll have to call "git restore *.mat *maT"
                 // to revert the materials.
                 case "dangerouslyChangeColor":
-                        CurrentActiveController().ProcessControlCommand(new Dictionary<string, object>() {
-                            ["action"] = "RandomizeColors"
-                        });
-                        break;
+                    CurrentActiveController().ProcessControlCommand(new Dictionary<string, object>() {
+                        ["action"] = "RandomizeColors"
+                    });
+                    break;
                 case "resetColor":
-                        CurrentActiveController().ProcessControlCommand(new Dictionary<string, object>() {
-                            ["action"] = "ResetColors"
-                        });
-                        break;
+                    CurrentActiveController().ProcessControlCommand(new Dictionary<string, object>() {
+                        ["action"] = "ResetColors"
+                    });
+                    break;
 
                 // This is dangerous because it will modify the underlying
                 // materials, and you'll have to call "git restore *.mat *maT"
                 // to revert the materials.
                 case "dangerouslyChangeMaterial":
-                        CurrentActiveController().ProcessControlCommand(new Dictionary<string, object>() {
-                            ["action"] = "RandomizeMaterials"
-                        });
-                        break;
+                    CurrentActiveController().ProcessControlCommand(new Dictionary<string, object>() {
+                        ["action"] = "RandomizeMaterials"
+                    });
+                    break;
                 case "resetMaterial":
-                        CurrentActiveController().ProcessControlCommand(new Dictionary<string, object>() {
-                            ["action"] = "ResetMaterials"
-                        });
-                        break;
+                    CurrentActiveController().ProcessControlCommand(new Dictionary<string, object>() {
+                        ["action"] = "ResetMaterials"
+                    });
+                    break;
 
                 case "light": {
                         Dictionary<string, object> action = new Dictionary<string, object>() {

--- a/unity/Assets/Scripts/PhysicsSceneManager.cs
+++ b/unity/Assets/Scripts/PhysicsSceneManager.cs
@@ -318,6 +318,7 @@ public class PhysicsSceneManager : MonoBehaviour {
         SetupScene();
         errorMessage = "";
         bool shouldFail = false;
+        GameObject topObject = GameObject.Find("Objects");
         if (objectPoses != null && objectPoses.Length > 0) {
             // Perform object location sets
             SimObjPhysics[] sceneObjects = FindObjectsOfType<SimObjPhysics>();
@@ -380,6 +381,7 @@ public class PhysicsSceneManager : MonoBehaviour {
                 copy.transform.position = objectPose.position;
                 copy.transform.eulerAngles = objectPose.rotation;
                 copy.gameObject.SetActive(true);
+                copy.gameObject.transform.parent = topObject.transform;
 
                 if (placeStationary) {
                     copy.GetComponent<Rigidbody>().collisionDetectionMode = CollisionDetectionMode.Discrete;

--- a/unity/Assets/Scripts/SimUtil.cs
+++ b/unity/Assets/Scripts/SimUtil.cs
@@ -571,7 +571,7 @@ public static class SimUtil {
         };
 
         // iTHOR scenes
-        foreach (int sceneType in new int[] {0, 200, 300, 400}) {
+        foreach (int sceneType in new int[] { 0, 200, 300, 400 }) {
             for (int i = 1; i <= 30; i++) {
                 string scenePath = $"Assets/Scenes/FloorPlan{sceneType + i}_physics.unity";
                 UnityEditor.SceneManagement.EditorSceneManager.OpenScene(scenePath);

--- a/unity/Assets/UnitTests/TestSetObjectPoses.cs
+++ b/unity/Assets/UnitTests/TestSetObjectPoses.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using System;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityStandardAssets.Characters.FirstPerson;
+
+namespace Tests {
+    public class TestSetObjectPoses : TestBase {
+        [UnityTest]
+        public IEnumerator TestSetObjectPoses_ObjectHierarchyReset_True() {
+            Dictionary<string, object> action = new Dictionary<string, object>();
+
+            BaseFPSAgentController agent = GameObject.FindObjectOfType<BaseFPSAgentController>();
+
+            GameObject topObject = GameObject.Find("Objects");
+            int numObjectsWithBadParents = 0;
+            List<ObjectPose> ops = new List<ObjectPose>();
+            foreach (SimObjPhysics sop in GameObject.FindObjectsOfType<SimObjPhysics>()) {
+                if ((!sop.isStatic) || sop.IsPickupable) {
+                    numObjectsWithBadParents += sop.gameObject.transform.parent != topObject.transform ? 1 : 0;
+                    ops.Add(new ObjectPose(objectName: sop.name, position: sop.transform.position, rotation: sop.transform.eulerAngles));
+                }
+            }
+
+            Assert.That(
+                numObjectsWithBadParents > 0,
+                "Looks like there are not sim objects whose parents are sim objects." + 
+                " This test isn't meaningful without this so you'll need to set it up so that there are."
+            );
+
+            action["action"] = "SetObjectPoses";
+            action["objectPoses"] = ops;
+            action["placeStationary"] = true;
+            yield return step(action);
+
+            foreach (SimObjPhysics sop in GameObject.FindObjectsOfType<SimObjPhysics>()) {
+                if ((!sop.isStatic) || sop.IsPickupable) {
+                    Assert.That(sop.gameObject.transform.parent == topObject.transform);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The `SetObjectPoses` method fails to reset the object hierarchy when moving objects. This can lead to weird results where an object across the room will be the child of a drawer across the room. This can break the semantic hull code as it assumes that all meshes that are within an object in the hierarchy correspond to that object. The solution here is simply to unparent objects when running `SetObjectPoses` (making them children of the top level "Objects" object). I have also run black/C# formatting so there are changes corresponding to this.