### PR TITLE
adding default values to near/far clipping planes

### DIFF
--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -420,8 +420,8 @@ public class AgentManager : MonoBehaviour {
         string skyboxColor,
         bool? orthographic,
         float? orthographicSize,
-        float? nearClippingPlane = null,
-        float? farClippingPlane = null
+        float? nearClippingPlane,
+        float? farClippingPlane
     ) {
         if (orthographic != true && orthographicSize != null) {
             throw new InvalidOperationException(
@@ -489,8 +489,8 @@ public class AgentManager : MonoBehaviour {
         string skyboxColor = null,
         bool orthographic = false,
         float? orthographicSize = null,
-        float? nearClippingPlane = null,
-        float? farClippingPlane = null
+        float nearClippingPlane = 0.1f,
+        float farClippingPlane = 20.0f
     ) {
         // adds error if fieldOfView is out of bounds
         assertFovInBounds(fov: fieldOfView);
@@ -551,7 +551,9 @@ public class AgentManager : MonoBehaviour {
         float? fieldOfView = null,
         string skyboxColor = null,
         bool? orthographic = null,
-        float? orthographicSize = null
+        float? orthographicSize = null,
+        float? nearClippingPlane = null,
+        float? farClippingPlane = null
     ) {
         // adds error if fieldOfView is out of bounds
         if (fieldOfView != null) {
@@ -582,7 +584,9 @@ public class AgentManager : MonoBehaviour {
             fieldOfView: fieldOfView == null ? thirdPartyCamera.fieldOfView : (float)fieldOfView,
             skyboxColor: skyboxColor,
             orthographic: orthographic,
-            orthographicSize: orthographicSize
+            orthographicSize: orthographicSize,
+            nearClippingPlane: nearClippingPlane,
+            farClippingPlane: farClippingPlane
         );
     }
 

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -451,8 +451,18 @@ public class AgentManager : MonoBehaviour {
             camera.nearClipPlane = (float)nearClippingPlane;
         }
 
+        //default to primary agent's near clip plane value
+        else {
+            camera.nearClipPlane = this.primaryAgent.m_Camera.nearClipPlane;
+        }
+
         if (farClippingPlane != null) {
             camera.farClipPlane = (float)farClippingPlane;
+        }
+
+        //default to primary agent's far clip plane value
+        else {
+            camera.farClipPlane = this.primaryAgent.m_Camera.farClipPlane;
         }
 
         // supports a solid color skybox, which work well with videos and images (i.e., white/black/orange/blue backgrounds)
@@ -485,8 +495,8 @@ public class AgentManager : MonoBehaviour {
         string skyboxColor = null,
         bool orthographic = false,
         float? orthographicSize = null,
-        float nearClippingPlane = 0.1f,
-        float farClippingPlane = 20.0f
+        float? nearClippingPlane = null,
+        float? farClippingPlane = null
     ) {
         // adds error if fieldOfView is out of bounds
         assertFovInBounds(fov: fieldOfView);

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -419,7 +419,9 @@ public class AgentManager : MonoBehaviour {
         float fieldOfView,
         string skyboxColor,
         bool? orthographic,
-        float? orthographicSize
+        float? orthographicSize,
+        float? nearClippingPlane = null,
+        float? farClippingPlane = null
     ) {
         if (orthographic != true && orthographicSize != null) {
             throw new InvalidOperationException(
@@ -441,6 +443,21 @@ public class AgentManager : MonoBehaviour {
                 camera.orthographicSize = (float)orthographicSize;
             }
         }
+
+        //updates camera near and far clipping planes
+        //default to near and far clipping planes of agent camera, which are currently
+        //static values and are not exposed in anything like Initialize
+        if(nearClippingPlane == null) {
+            camera.nearClipPlane = 0.1f;
+        }
+
+        else { camera.nearClipPlane = (float) nearClippingPlane;}
+
+        if(farClippingPlane == null) {
+            camera.farClipPlane = 20.0f;
+        }
+
+        else { camera.farClipPlane = (float) farClippingPlane;}
 
         // supports a solid color skybox, which work well with videos and images (i.e., white/black/orange/blue backgrounds)
         if (skyboxColor == "default") {
@@ -471,7 +488,9 @@ public class AgentManager : MonoBehaviour {
         float fieldOfView = DEFAULT_FOV,
         string skyboxColor = null,
         bool orthographic = false,
-        float? orthographicSize = null
+        float? orthographicSize = null,
+        float? nearClippingPlane = null,
+        float? farClippingPlane = null
     ) {
         // adds error if fieldOfView is out of bounds
         assertFovInBounds(fov: fieldOfView);
@@ -494,7 +513,9 @@ public class AgentManager : MonoBehaviour {
             fieldOfView: fieldOfView,
             skyboxColor: skyboxColor,
             orthographic: orthographic,
-            orthographicSize: orthographicSize
+            orthographicSize: orthographicSize,
+            nearClippingPlane: nearClippingPlane,
+            farClippingPlane: farClippingPlane
         );
     }
 

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -447,17 +447,13 @@ public class AgentManager : MonoBehaviour {
         //updates camera near and far clipping planes
         //default to near and far clipping planes of agent camera, which are currently
         //static values and are not exposed in anything like Initialize
-        if(nearClippingPlane == null) {
-            camera.nearClipPlane = 0.1f;
+        if (nearClippingPlane != null) {
+            camera.nearClipPlane = (float)nearClippingPlane;
         }
 
-        else { camera.nearClipPlane = (float) nearClippingPlane;}
-
-        if(farClippingPlane == null) {
-            camera.farClipPlane = 20.0f;
+        if (farClippingPlane != null) {
+            camera.farClipPlane = (float)farClippingPlane;
         }
-
-        else { camera.farClipPlane = (float) farClippingPlane;}
 
         // supports a solid color skybox, which work well with videos and images (i.e., white/black/orange/blue backgrounds)
         if (skyboxColor == "default") {
@@ -1675,7 +1671,7 @@ public class DynamicServerAction {
     public T ToObject<T>() {
         return this.jObject.ToObject<T>();
     }
-    
+
     // this is primarily used when detecting invalid arguments
     // if Initialize is ever changed we should refactor this since renderInstanceSegmentation is a 
     // valid argument for Initialize as well as a global parameter


### PR DESCRIPTION
In regards to 3rd party cameras, this fixes an issue where light and shadow resolutions were dynamically scaled based on the clipping plane values, so defaulting this to the same clipping planes as the agent camera for parity