### PR TITLE
Save state of gameObject's layer for all colliders during oobb generation

### DIFF
--- a/unity/Assets/Scripts/SimObjPhysics.cs
+++ b/unity/Assets/Scripts/SimObjPhysics.cs
@@ -297,9 +297,15 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
             // Get all colliders on the sop, excluding colliders if they are not enabled 
             // List<Collider> cols = new List<Collider>();
             List<KeyValuePair<Collider, LayerMask>> cols = new List<KeyValuePair<Collider, LayerMask>>();
+            // save the state of all the layers prior to modifying
             foreach (Collider c in this.transform.GetComponentsInChildren<Collider>()) {
                 if (c.enabled) {
                     cols.Add(new KeyValuePair<Collider, LayerMask>(c, c.transform.gameObject.layer));
+                }
+            }
+
+            foreach (Collider c in this.transform.GetComponentsInChildren<Collider>()) {
+                if (c.enabled) {
                     // move these colliders to the NonInteractive layer so upon teleporting to the origin, nothing is disturbed
                     c.transform.gameObject.layer = LayerMask.NameToLayer("NonInteractive");
                 }


### PR DESCRIPTION
Prior to moving gameObjects to the NonInteractive layer, save their state.  This fixes an issue where a component that has two colliders gets restored incorrectly to the NonInteractive layer since the second iteration through the loop causes the gameObject to get restored to the NonInteractive layer.