### PR TITLE
Clears RandomizeColors on reset()

### DIFF
--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -53,6 +53,7 @@ public class AgentManager : MonoBehaviour {
     public HashSet<string> agentManagerActions = new HashSet<string> { "Reset", "Initialize", "AddThirdPartyCamera", "UpdateThirdPartyCamera", "ChangeResolution" };
 
     public bool doResetMaterials = false;
+    public bool doResetColors = false;
 
     public const float DEFAULT_FOV = 90;
     public const float MAX_FOV = 180;
@@ -643,12 +644,21 @@ public class AgentManager : MonoBehaviour {
     public void resetMaterials() {
         ColorChanger colorChangeComponent = physicsSceneManager.GetComponent<ColorChanger>();
         colorChangeComponent.ResetMaterials();
+        doResetMaterials = false;
+        doResetColors = false;
+    }
+
+    public void resetColors() {
+        ColorChanger colorChangeComponent = physicsSceneManager.GetComponent<ColorChanger>();
+        colorChangeComponent.ResetColors();
+        doResetColors = false;
     }
 
     public void Reset(ServerAction response) {
         if (doResetMaterials) {
             resetMaterials();
-            doResetMaterials = false;
+        } else if (doResetColors) {
+            resetColors();
         }
         StartCoroutine(ResetCoroutine(response));
     }

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -772,6 +772,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         public void RandomizeColors() {
             ColorChanger colorChangeComponent = physicsSceneManager.GetComponent<ColorChanger>();
             colorChangeComponent.RandomizeColor();
+            agentManager.doResetMaterials = true;
             actionFinished(true);
         }
 
@@ -926,8 +927,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
         public void ResetColors() {
-            ColorChanger colorChangeComponent = physicsSceneManager.GetComponent<ColorChanger>();
-            colorChangeComponent.ResetColors();
+            agentManager.resetColors();
             actionFinished(true);
         }
 


### PR DESCRIPTION
Matches the same `reset` functionality present in `RandomizeMaterials`.

While this breaks backwards compatibility, I'd consider it more of a bug fix, since calling `RandomizeColors` -> `reset()` -> `ResetColors` currently cannot reset the colors to their original ones. Moreover, this action is seldom used at this point and, I don't think, has even been used in a project yet.