### PR TITLE
removing log statements for imageSynthesis encode time

### DIFF
--- a/unity/Assets/Scripts/ImageSynthesis/ImageSynthesis.cs
+++ b/unity/Assets/Scripts/ImageSynthesis/ImageSynthesis.cs
@@ -459,7 +459,7 @@ public class ImageSynthesis : MonoBehaviour {
 
         tex.ReadPixels(new Rect(0, 0, tex.width, tex.height), 0, 0);
         tex.Apply();
-        Debug.Log("imageSynth encode time" + (Time.realtimeSinceStartup - startTime));
+        // Debug.Log("imageSynth encode time" + (Time.realtimeSinceStartup - startTime));
 
         startTime = Time.realtimeSinceStartup;
 
@@ -471,7 +471,7 @@ public class ImageSynthesis : MonoBehaviour {
             bytes = tex.GetRawTextureData();
         }
 
-        Debug.Log("imageSynth format time" + (Time.realtimeSinceStartup - startTime));
+        // Debug.Log("imageSynth format time" + (Time.realtimeSinceStartup - startTime));
 
 
         // restore state and cleanup


### PR DESCRIPTION
These log statements generate an enormous amount of noise in the logs - on the allenact-bench server, the unity.log file had grown to 25GB in just a few runs.