### PR TITLE
DropHandObject -> DropHeldObject

### DIFF
--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -1786,7 +1786,7 @@ def test_invalid_arguments(controller):
 
 @pytest.mark.parametrize("controller", fifo_wsgi)
 def test_drop_object(controller):
-    for action in ["DropObject", "DropHandObject"]:
+    for action in ["DropHeldObject", "DropHandObject"]:
         assert not controller.last_event.metadata["inventoryObjects"]
         controller.step(
             action="PickupObject",

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -1785,6 +1785,23 @@ def test_invalid_arguments(controller):
 
 
 @pytest.mark.parametrize("controller", fifo_wsgi)
+def test_drop_object(controller):
+    for action in ["DropObject", "DropHandObject"]:
+        assert not controller.last_event.metadata["inventoryObjects"]
+        controller.step(
+            action="PickupObject",
+            objectId="SoapBottle|-00.84|+00.93|-03.76",
+            forceAction=True,
+        )
+        assert (
+            controller.last_event.metadata["inventoryObjects"][0]["objectId"]
+            == "SoapBottle|-00.84|+00.93|-03.76"
+        )
+        controller.step(action=action)
+        assert not controller.last_event.metadata["inventoryObjects"]
+
+
+@pytest.mark.parametrize("controller", fifo_wsgi)
 def test_segmentation_colors(controller):
     event = controller.reset(renderSemanticSegmentation=True)
     fridge_color = event.object_id_to_color["Fridge"]

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1,4 +1,4 @@
-// Copyright Allen Institute for Artificial Intelligence 2017
+﻿// Copyright Allen Institute for Artificial Intelligence 2017
 
 using System;
 using System.Collections;
@@ -4615,7 +4615,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             return;
         }
 
-        // private IEnumerator checkDropHandObjectAction(SimObjPhysics currentHandSimObj) 
+        // private IEnumerator checkDropObjectAction(SimObjPhysics currentHandSimObj) 
         // {
         //     yield return null; // wait for two frames to pass
         //     yield return null;
@@ -4648,7 +4648,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         //     actionFinished(true);
         // }
 
-        private IEnumerator checkDropHandObjectActionFast(SimObjPhysics currentHandSimObj) {
+        private IEnumerator checkDropObjectActionFast(SimObjPhysics currentHandSimObj) {
             if (currentHandSimObj != null) {
                 Rigidbody rb = currentHandSimObj.GetComponentInChildren<Rigidbody>();
                 Physics.autoSimulation = false;
@@ -4670,7 +4670,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             actionFinished(true);
         }
 
-        public void DropHandObject(ServerAction action) {
+        public void DropObject(ServerAction action) {
             // make sure something is actually in our hands
             if (ItemInHand != null) {
                 // we do need this to check if the item is currently colliding with the agent, otherwise
@@ -4709,7 +4709,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         if (action.autoSimulation) {
                             StartCoroutine(checkIfObjectHasStoppedMoving(ItemInHand.GetComponent<SimObjPhysics>(), 0));
                         } else {
-                            StartCoroutine(checkDropHandObjectActionFast(ItemInHand.GetComponent<SimObjPhysics>()));
+                            StartCoroutine(checkDropObjectActionFast(ItemInHand.GetComponent<SimObjPhysics>()));
                         }
                     } else {
                         actionFinished(true);
@@ -4724,6 +4724,12 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 actionFinished(false);
                 return;
             }
+
+        }
+
+        [ObsoleteAttribute(message: "This action is deprecated. Call DropObject instead.", error: false)]
+        public void DropHandObject(ServerAction action) {
+            DropObject(action);
         }
 
         // by default will throw in the forward direction relative to the Agent's Camera
@@ -4737,8 +4743,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
 
             GameObject go = ItemInHand;
-            DropHandObject(action);
-            // Force is not applied because action success from DropHandObject starts a coroutine that waits for the object to be stationary
+            DropObject(action);
+            // Force is not applied because action success from DropObject starts a coroutine that waits for the object to be stationary
             // to return lastActionSuccess == true that is not what we want for throwing an object, review why this was that way
             // if (this.lastActionSuccess) {
             Vector3 dir = m_Camera.transform.forward;

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4615,7 +4615,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             return;
         }
 
-        // private IEnumerator checkDropObjectAction(SimObjPhysics currentHandSimObj) 
+        // private IEnumerator checkDropHeldObjectAction(SimObjPhysics currentHandSimObj) 
         // {
         //     yield return null; // wait for two frames to pass
         //     yield return null;
@@ -4648,7 +4648,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         //     actionFinished(true);
         // }
 
-        private IEnumerator checkDropObjectActionFast(SimObjPhysics currentHandSimObj) {
+        private IEnumerator checkDropHeldObjectActionFast(SimObjPhysics currentHandSimObj) {
             if (currentHandSimObj != null) {
                 Rigidbody rb = currentHandSimObj.GetComponentInChildren<Rigidbody>();
                 Physics.autoSimulation = false;
@@ -4670,7 +4670,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             actionFinished(true);
         }
 
-        public void DropObject(ServerAction action) {
+        public void DropHeldObject(ServerAction action) {
             // make sure something is actually in our hands
             if (ItemInHand != null) {
                 // we do need this to check if the item is currently colliding with the agent, otherwise
@@ -4709,7 +4709,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         if (action.autoSimulation) {
                             StartCoroutine(checkIfObjectHasStoppedMoving(ItemInHand.GetComponent<SimObjPhysics>(), 0));
                         } else {
-                            StartCoroutine(checkDropObjectActionFast(ItemInHand.GetComponent<SimObjPhysics>()));
+                            StartCoroutine(checkDropHeldObjectActionFast(ItemInHand.GetComponent<SimObjPhysics>()));
                         }
                     } else {
                         actionFinished(true);
@@ -4727,9 +4727,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
         }
 
-        [ObsoleteAttribute(message: "This action is deprecated. Call DropObject instead.", error: false)]
+        [ObsoleteAttribute(message: "This action is deprecated. Call DropHeldObject instead.", error: false)]
         public void DropHandObject(ServerAction action) {
-            DropObject(action);
+            DropHeldObject(action);
         }
 
         // by default will throw in the forward direction relative to the Agent's Camera
@@ -4743,7 +4743,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
 
             GameObject go = ItemInHand;
-            DropObject(action);
+            DropHeldObject(action);
             // Force is not applied because action success from DropObject starts a coroutine that waits for the object to be stationary
             // to return lastActionSuccess == true that is not what we want for throwing an object, review why this was that way
             // if (this.lastActionSuccess) {

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4670,87 +4670,80 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             actionFinished(true);
         }
 
-        public void DropHeldObject(ServerAction action) {
+        public void DropHeldObject(bool forceAction = false, bool autoSimulation = true) {
             // make sure something is actually in our hands
-            if (ItemInHand != null) {
-                // we do need this to check if the item is currently colliding with the agent, otherwise
-                // dropping an object while it is inside the agent will cause it to shoot out weirdly
-                if (!action.forceAction && isHandObjectColliding(false)) {
-                    errorMessage = ItemInHand.transform.name + " can't be dropped. It must be clear of all other collision first, including the Agent";
-                    Debug.Log(errorMessage);
-                    actionFinished(false);
-                    return;
-                } else {
-                    Rigidbody rb = ItemInHand.GetComponent<Rigidbody>();
-                    rb.isKinematic = false;
-                    rb.constraints = RigidbodyConstraints.None;
-                    rb.useGravity = true;
-
-                    // change collision detection mode while falling so that obejcts don't phase through colliders.
-                    // this is reset to discrete on SimObjPhysics.cs's update 
-                    rb.collisionDetectionMode = CollisionDetectionMode.ContinuousSpeculative;
-
-                    GameObject topObject = GameObject.Find("Objects");
-                    if (topObject != null) {
-                        ItemInHand.transform.parent = topObject.transform;
-                    } else {
-                        ItemInHand.transform.parent = null;
-                    }
-
-                    DropContainedObjects(
-                        target: ItemInHand.GetComponent<SimObjPhysics>(),
-                        reparentContainedObjects: true,
-                        forceKinematic: false
-                    );
-
-                    // if physics simulation has been paused by the PausePhysicsAutoSim() action, don't do any coroutine checks
-                    if (!physicsSceneManager.physicsSimulationPaused) {
-                        // this is true by default
-                        if (action.autoSimulation) {
-                            StartCoroutine(checkIfObjectHasStoppedMoving(ItemInHand.GetComponent<SimObjPhysics>(), 0));
-                        } else {
-                            StartCoroutine(checkDropHeldObjectActionFast(ItemInHand.GetComponent<SimObjPhysics>()));
-                        }
-                    } else {
-                        actionFinished(true);
-                    }
-                    ItemInHand.GetComponent<SimObjPhysics>().isInAgentHand = false;
-                    ItemInHand = null;
-                    return;
-                }
-            } else {
-                errorMessage = "nothing in hand to drop!";
-                Debug.Log(errorMessage);
-                actionFinished(false);
-                return;
+            if (ItemInHand == null) {
+                throw new InvalidOperationException("Nothing is in the agent's hand to drop!");
             }
 
+            // we do need this to check if the item is currently colliding with the agent, otherwise
+            // dropping an object while it is inside the agent will cause it to shoot out weirdly
+            if (!forceAction && isHandObjectColliding(false)) {
+                throw new InvalidOperationException(
+                    $"{ItemInHand.transform.name} can't be dropped. " +
+                    "It must be clear of all other collision first, including the Agent."
+                );
+            }
+
+            Rigidbody rb = ItemInHand.GetComponent<Rigidbody>();
+            rb.isKinematic = false;
+            rb.constraints = RigidbodyConstraints.None;
+            rb.useGravity = true;
+
+            // change collision detection mode while falling so that obejcts don't phase through colliders.
+            // this is reset to discrete on SimObjPhysics.cs's update 
+            rb.collisionDetectionMode = CollisionDetectionMode.ContinuousSpeculative;
+
+            GameObject topObject = GameObject.Find("Objects");
+            if (topObject != null) {
+                ItemInHand.transform.parent = topObject.transform;
+            } else {
+                ItemInHand.transform.parent = null;
+            }
+
+            DropContainedObjects(
+                target: ItemInHand.GetComponent<SimObjPhysics>(),
+                reparentContainedObjects: true,
+                forceKinematic: false
+            );
+
+            // if physics simulation has been paused by the PausePhysicsAutoSim() action,
+            // don't do any coroutine checks
+            if (!physicsSceneManager.physicsSimulationPaused) {
+                // this is true by default
+                if (autoSimulation) {
+                    StartCoroutine(checkIfObjectHasStoppedMoving(ItemInHand.GetComponent<SimObjPhysics>(), 0));
+                } else {
+                    StartCoroutine(checkDropHeldObjectActionFast(ItemInHand.GetComponent<SimObjPhysics>()));
+                }
+            } else {
+                actionFinished(true);
+            }
+            ItemInHand.GetComponent<SimObjPhysics>().isInAgentHand = false;
+            ItemInHand = null;
         }
 
         [ObsoleteAttribute(message: "This action is deprecated. Call DropHeldObject instead.", error: false)]
-        public void DropHandObject(ServerAction action) {
-            DropHeldObject(action);
+        public void DropHandObject(bool forceAction = false, bool autoSimulation = true) {
+            DropHeldObject(forceAction: forceAction, autoSimulation: autoSimulation);
         }
 
         // by default will throw in the forward direction relative to the Agent's Camera
         // moveMagnitude, strength of throw, good values for an average throw are around 150-250
-        public void ThrowObject(ServerAction action) {
+        public void ThrowObject(float moveMagnitude, bool forceAction = false, bool autoSimulation = true) {
             if (ItemInHand == null) {
-                errorMessage = "Nothing in Hand to Throw!";
-                Debug.Log(errorMessage);
-                actionFinished(false);
-                return;
+                throw new InvalidOperationException("Nothing in Hand to Throw!");
             }
 
             GameObject go = ItemInHand;
-            DropHeldObject(action);
-            // Force is not applied because action success from DropObject starts a coroutine that waits for the object to be stationary
-            // to return lastActionSuccess == true that is not what we want for throwing an object, review why this was that way
-            // if (this.lastActionSuccess) {
-            Vector3 dir = m_Camera.transform.forward;
-            go.GetComponent<SimObjPhysics>().ApplyForce(dir, action.moveMagnitude);
-            //}
+            DropHeldObject(forceAction: forceAction, autoSimulation: autoSimulation);
 
+            // Force is not applied because action success from DropObject
+            // starts a coroutine that waits for the object to be stationary
+            // to return lastActionSuccess == true that is not what we want
+            // for throwing an object, review why this was that way
+            Vector3 dir = m_Camera.transform.forward;
+            go.GetComponent<SimObjPhysics>().ApplyForce(dir, moveMagnitude);
         }
 
         // Hide and Seek helper function, makes overlap box at x,z coordinates


### PR DESCRIPTION
Renames `DropHandObject` to `DropHeldObject`. In iTHOR, its unclear what the "hand" is.

Everything is backwards and sideways compatible. That is; users can still pass in `DropHandObject` to older and newer versions, and it will still work.