### PR TITLE
minimal directionalPush bug fix

### DIFF
--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -1707,6 +1707,43 @@ def test_randomize_materials_clearOnReset(controller):
 
 
 @pytest.mark.parametrize("controller", fifo_wsgi)
+def test_directionalPush(controller):
+    positions = []
+    for angle in [0, 90, 180, 270, -1, -90]:
+        controller.reset(scene="FloorPlan28")
+        start = controller.step(
+            action="TeleportFull",
+            position=dict(x=-3.25, y=0.9, z=-1.25),
+            rotation=dict(x=0, y=0, z=0),
+            horizon=30,
+            standing=True,
+        )
+        # z increases
+        end = controller.step(
+            action="DirectionalPush",
+            pushAngle=angle,
+            objectId="Tomato|-03.13|+00.92|-00.39",
+            moveMagnitude=25,
+        )
+        start_obj = next(
+            obj for obj in start.metadata["objects"] if obj["objectType"] == "Tomato"
+        )
+        end_obj = next(
+            obj for obj in end.metadata["objects"] if obj["objectType"] == "Tomato"
+        )
+        positions.append((start_obj["position"], end_obj["position"]))
+
+    assert positions[0][1]["z"] - positions[0][0]["z"] > 0.2
+    assert positions[4][1]["z"] - positions[4][0]["z"] > 0.2
+
+    assert positions[1][1]["x"] - positions[1][0]["x"] > 0.2
+    assert positions[2][1]["z"] - positions[2][0]["z"] < -0.2
+
+    assert positions[3][1]["x"] - positions[3][0]["x"] < -0.2
+    assert positions[5][1]["x"] - positions[5][0]["x"] < -0.2
+
+
+@pytest.mark.parametrize("controller", fifo_wsgi)
 def test_randomize_materials_params(controller):
     controller.reset(scene="FloorPlan15")
     meta = controller.step(

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1,4 +1,4 @@
-// Copyright Allen Institute for Artificial Intelligence 2017
+﻿// Copyright Allen Institute for Artificial Intelligence 2017
 
 using System;
 using System.Collections;
@@ -1896,13 +1896,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 return;
             }
 
-            // the direction vecctor to push the target object defined by action.PushAngle 
-            // degrees clockwise from the agent's forward, the PushAngle must be less than 360
-            if (action.pushAngle <= 0 || action.pushAngle >= 360) {
-                errorMessage = "please give a PushAngle between 0 and 360.";
-                Debug.Log(errorMessage);
-                actionFinished(false);
-                return;
+            // The direction vector to push the target object defined by action.pushAngle
+            // degrees clockwise from the agent's forward.
+            action.pushAngle %= 360;
+
+            // converts negative rotations to be positive
+            if (action.pushAngle < 360) {
+                action.pushAngle += 360;
             }
 
             SimObjPhysics target = null;


### PR DESCRIPTION
Minimal bug fix to `directionalPush` to support 0 degrees as an angle. It also adds support for negative angles and angles >= 360 to match the `degrees` functionality present in rotate actions.