### PR TITLE
Add fillLiquid to metadata

### DIFF
--- a/ai2thor/tests/data/arm-metadata-schema.json
+++ b/ai2thor/tests/data/arm-metadata-schema.json
@@ -204,7 +204,7 @@
             "type": "boolean"
           },
           "fillLiquid": {
-            "type": "string"
+            "type": "object"
           },
           "dirtyable": {
             "type": "boolean"

--- a/ai2thor/tests/data/arm-metadata-schema.json
+++ b/ai2thor/tests/data/arm-metadata-schema.json
@@ -204,7 +204,7 @@
             "type": "boolean"
           },
           "fillLiquid": {
-            "type": "object"
+            "type": "null"
           },
           "dirtyable": {
             "type": "boolean"

--- a/ai2thor/tests/data/arm-metadata-schema.json
+++ b/ai2thor/tests/data/arm-metadata-schema.json
@@ -203,6 +203,9 @@
           "isFilledWithLiquid": {
             "type": "boolean"
           },
+          "fillLiquid": {
+            "type": "string"
+          },
           "dirtyable": {
             "type": "boolean"
           },
@@ -388,6 +391,7 @@
           "isCooked",
           "isDirty",
           "isFilledWithLiquid",
+          "fillLiquid",
           "isMoving",
           "isOpen",
           "isPickedUp",

--- a/ai2thor/tests/data/metadata-schema.json
+++ b/ai2thor/tests/data/metadata-schema.json
@@ -75,6 +75,9 @@
                     "isFilledWithLiquid": {
                         "type": "boolean"
                     },
+                    "fillLiquid": {
+                        "type": "string"
+                    },
                     "dirtyable": {
                         "type": "boolean"
                     },
@@ -274,6 +277,7 @@
                     "isCooked",
                     "isDirty",
                     "isFilledWithLiquid",
+                    "fillLiquid",
                     "isMoving",
                     "isOpen",
                     "isPickedUp",

--- a/ai2thor/tests/data/metadata-schema.json
+++ b/ai2thor/tests/data/metadata-schema.json
@@ -76,7 +76,7 @@
                         "type": "boolean"
                     },
                     "fillLiquid": {
-                        "type": "string"
+                        "type": "object"
                     },
                     "dirtyable": {
                         "type": "boolean"

--- a/ai2thor/tests/data/metadata-schema.json
+++ b/ai2thor/tests/data/metadata-schema.json
@@ -76,7 +76,7 @@
                         "type": "boolean"
                     },
                     "fillLiquid": {
-                        "type": "object"
+                        "type": "null"
                     },
                     "dirtyable": {
                         "type": "boolean"

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1315,6 +1315,7 @@ public class ObjectMetadata {
     ///
     public bool canFillWithLiquid;// objects filled with liquids
     public bool isFilledWithLiquid;// is this object filled with some liquid? - similar to 'depletable' but this is for liquids
+    public string fillLiquid; // coffee, wine, water
     ///
     public bool dirtyable;// can toggle object state dirty/clean
     public bool isDirty;// is this object in a dirty or clean state?

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1562,6 +1562,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             objMeta.canFillWithLiquid = simObj.IsFillable;
             if (objMeta.canFillWithLiquid) {
                 objMeta.isFilledWithLiquid = simObj.IsFilled;
+                objMeta.fillLiquid = simObj.FillLiquid;
             }
 
             objMeta.dirtyable = simObj.IsDirtyable;

--- a/unity/Assets/Scripts/DroneFPSAgentController.cs
+++ b/unity/Assets/Scripts/DroneFPSAgentController.cs
@@ -153,6 +153,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             objMeta.canFillWithLiquid = simObj.IsFillable;
             if (objMeta.canFillWithLiquid) {
                 objMeta.isFilledWithLiquid = simObj.IsFilled;
+                objMeta.fillLiquid = simObj.FillLiquid;
             }
 
             objMeta.dirtyable = simObj.IsDirtyable;

--- a/unity/Assets/Scripts/Fill.cs
+++ b/unity/Assets/Scripts/Fill.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using System;
+using Random = UnityEngine.Random;
 
 public class Fill : MonoBehaviour {
     [SerializeField]
@@ -11,7 +13,6 @@ public class Fill : MonoBehaviour {
 
     [SerializeField]
     protected GameObject WineObject = null;
-
 
     [SerializeField]
     protected bool isFilled = false; // false - empty, true - currently filled with
@@ -38,7 +39,6 @@ public class Fill : MonoBehaviour {
         Liquids.Add("water", WaterObject);
         Liquids.Add("coffee", CoffeeObject);
         Liquids.Add("wine", WineObject);
-
     }
 
     // Update is called once per frame
@@ -50,127 +50,64 @@ public class Fill : MonoBehaviour {
                 EmptyObject();
             }
         }
-
-        // // debug stuff
-        // if(Input.GetKeyDown(KeyCode.G))
-        // {
-        //     FillObject("water");
-        // }
     }
 
     // fill the object with a random liquid
     public void FillObjectRandomLiquid() {
         int whichone = Random.Range(1, 3);
-        if (whichone == 1) {
-            FillObject("water");
-        }
-
-        if (whichone == 2) {
-            FillObject("wine");
-        }
-
-        if (whichone == 3) {
-            FillObject("coffee");
+        switch (whichone) {
+            case 1:
+                FillObject("water");
+                break;
+            case 2:
+                FillObject("wine");
+                break;
+            case 3:
+                FillObject("coffee");
+                break;
         }
     }
 
-    public bool FillObject(string whichLiquid) {
-        if (Liquids.ContainsKey(whichLiquid)) {
-            // check if this object has whichLiquid setup as fillable: If the object has a null reference this object
-            // is not setup for that liquid
-            if (Liquids[whichLiquid] == null) {
-                return false;
-            }
-
-            Liquids[whichLiquid].transform.gameObject.SetActive(true);
-
-            // coffee is hot so change the object's temperature if whichLiquid was coffee
-            if (whichLiquid == "coffee") {
-                // coffee is hot!
-                SimObjPhysics sop = gameObject.GetComponent<SimObjPhysics>();
-                sop.CurrentTemperature = ObjectMetadata.Temperature.Hot;
-                if (sop.HowManySecondsUntilRoomTemp != sop.GetTimerResetValue()) {
-                    sop.HowManySecondsUntilRoomTemp = sop.GetTimerResetValue();
-                }
-
-                sop.SetStartRoomTempTimer(false);
-            }
-
-            isFilled = true;
-            currentlyFilledWith = whichLiquid;
-            return true;
+    public void FillObject(string whichLiquid) {
+        if (!Liquids.ContainsKey(whichLiquid)) {
+            throw new ArgumentException("Unknown liquid: " + whichLiquid);
         }
 
-        // whichLiquid is not in the dictionary
-        else {
-            return false;
+        // check if this object has whichLiquid setup as fillable: If the object has a null reference this object
+        // is not setup for that liquid
+        if (Liquids[whichLiquid] == null) {
+            throw new ArgumentException(
+                $"The liquid {whichLiquid} is not setup for this object."
+            );
         }
 
+        Liquids[whichLiquid].transform.gameObject.SetActive(true);
 
-        // if the dict doesn't contain this key pair uuuuuh
+        // coffee is hot so change the object's temperature if whichLiquid was coffee
+        if (whichLiquid == "coffee") {
+            // coffee is hot!
+            SimObjPhysics sop = gameObject.GetComponent<SimObjPhysics>();
+            sop.CurrentTemperature = ObjectMetadata.Temperature.Hot;
+            if (sop.HowManySecondsUntilRoomTemp != sop.GetTimerResetValue()) {
+                sop.HowManySecondsUntilRoomTemp = sop.GetTimerResetValue();
+            }
+            sop.SetStartRoomTempTimer(false);
+        }
 
-        // if(whichLiquid == "water")
-        // {
-        //     if(WaterObject != null)
-        //     WaterObject.transform.gameObject.SetActive(true);
-
-        //     isFilled = true;
-        //     currentlyFilledWith = "water";
-        // }
-
-        // else if(whichLiquid == "coffee")
-        // {
-        //     if(CoffeeObject != null)
-        //     CoffeeObject.transform.gameObject.SetActive(true);
-
-        //     // coffee is hot!
-        //     SimObjPhysics sop = gameObject.GetComponent<SimObjPhysics>();
-        //     sop.CurrentTemperature = ObjectMetadata.Temperature.Hot;
-        //     if(sop.HowManySecondsUntilRoomTemp != sop.GetTimerResetValue())
-        //     sop.HowManySecondsUntilRoomTemp = sop.GetTimerResetValue();
-        //     sop.SetStartRoomTempTimer(false);
-
-
-        //     isFilled = true;
-        //     currentlyFilledWith = "coffee";
-        // }
-
-        // else if(whichLiquid == "wine")
-        // {
-        //     if(WineObject != null)
-        //     CoffeeObject.transform.gameObject.SetActive(true);
-
-        //     isFilled = true;
-        //     currentlyFilledWith = "wine";
-        // }
+        isFilled = true;
+        currentlyFilledWith = whichLiquid;
     }
 
     public void EmptyObject() {
         // for each thing in Liquids, if it exists set it to false and then set bools appropriately
-
         foreach (KeyValuePair<string, GameObject> gogogo in Liquids) {
             // if the value field is not null and has a reference to a liquid object 
             if (gogogo.Value != null) {
                 gogogo.Value.SetActive(false);
             }
         }
-        // Liquids[currentlyFilledWith].transform.gameObject.SetActive(false);
         currentlyFilledWith = null;
         isFilled = false;
-
-        // if(currentlyFilledWith == "water")
-        // {
-        //     WaterObject.transform.gameObject.SetActive(false);
-        //     currentlyFilledWith = null;
-        //     isFilled= false;
-        // }
-
-        // else if(currentlyFilledWith == "coffee")
-        // {
-        //     CoffeeObject.transform.gameObject.SetActive(false);
-        //     currentlyFilledWith = null;
-        //     isFilled= false;
-        // }
     }
 
     public void OnTriggerStay(Collider other) {

--- a/unity/Assets/Scripts/Fill.cs
+++ b/unity/Assets/Scripts/Fill.cs
@@ -24,6 +24,10 @@ public class Fill : MonoBehaviour {
         return isFilled;
     }
 
+    public string FilledLiquid() {
+        return currentlyFilledWith;
+    }
+
     void Start() {
 #if UNITY_EDITOR
         if (!gameObject.GetComponent<SimObjPhysics>().DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanBeFilled)) {

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -8540,49 +8540,35 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
 
             if (action.fillLiquid == null) {
-                errorMessage = "Missing Liquid string for FillObject action";
+                errorMessage = "";
                 actionFinished(false);
+                throw new InvalidOperationException("Missing Liquid string for FillObject action");
             }
 
             // ignore casing
             action.fillLiquid = action.fillLiquid.ToLower();
 
-            if (target) {
-                if (target.GetComponent<SimObjPhysics>().DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanBeFilled)) {
-                    Fill fil = target.GetComponent<Fill>();
-
-                    // if the passed in liquid string is not valid
-                    if (!fil.Liquids.ContainsKey(action.fillLiquid)) {
-                        errorMessage = action.fillLiquid + " is not a valid Liquid Type";
-                        actionFinished(false);
-                        return;
-                    }
-
-                    // make sure object is empty
-                    if (!fil.IsFilled()) {
-                        if (fil.FillObject(action.fillLiquid)) {
-                            actionFinished(true);
-                            return;
-                        } else {
-                            actionFinished(false);
-                            errorMessage = target.transform.name + " cannot be filled with " + action.fillLiquid;
-                            return;
-                        }
-
-                    } else {
-                        errorMessage = target.transform.name + " is already Filled!";
-                        actionFinished(false);
-                        return;
-                    }
-                } else {
-                    errorMessage = target.transform.name + " does not have CanBeFilled property!";
-                    actionFinished(false);
-                    return;
-                }
-            } else {
-                errorMessage = "object not found: " + action.objectId;
-                actionFinished(false);
+            if (!target) {
+                throw new ArgumentException("object not found: " + action.objectId);
             }
+
+            if (!target.GetComponent<SimObjPhysics>().DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanBeFilled)) {
+                throw new ArgumentException(target.transform.name + " does not have CanBeFilled property!");
+            }
+
+            Fill fil = target.GetComponent<Fill>();
+
+            // if the passed in liquid string is not valid
+            if (!fil.Liquids.ContainsKey(action.fillLiquid)) {
+                throw new ArgumentException(action.fillLiquid + " is not a valid Liquid Type");
+            }
+
+            if (fil.IsFilled()) {
+                throw new InvalidOperationException(target.transform.name + " is already Filled!");
+            }
+
+            fil.FillObject(action.fillLiquid);
+            actionFinished(true);
         }
 
         public void EmptyLiquidFromObject(ServerAction action) {

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -8540,8 +8540,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
 
             if (action.fillLiquid == null) {
-                errorMessage = "";
-                actionFinished(false);
                 throw new InvalidOperationException("Missing Liquid string for FillObject action");
             }
 

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1,4 +1,4 @@
-// Copyright Allen Institute for Artificial Intelligence 2017
+﻿// Copyright Allen Institute for Artificial Intelligence 2017
 
 using System;
 using System.Collections;
@@ -8543,6 +8543,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 errorMessage = "Missing Liquid string for FillObject action";
                 actionFinished(false);
             }
+
+            // ignore casing
+            action.fillLiquid = action.fillLiquid.ToLower();
 
             if (target) {
                 if (target.GetComponent<SimObjPhysics>().DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanBeFilled)) {

--- a/unity/Assets/Scripts/SimObjPhysics.cs
+++ b/unity/Assets/Scripts/SimObjPhysics.cs
@@ -506,6 +506,13 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
         }
     }
 
+    public string FillLiquid {
+        get {
+            Fill f = this.GetComponent<Fill>();
+            return f == null ? null : f.FilledLiquid();
+        }
+    }
+
     public bool IsDirty {
         get {
             Dirty deedsdonedirtcheap = this.GetComponent<Dirty>();


### PR DESCRIPTION
For [Fill Object with Liquid](https://ai2thor.allenai.org/ithor/documentation/object-state-changes/#fill-object-with-liquid):

* Adds `fillLiquid` to metadata .
* Bug fixes the action to make sure each failed path terminates immediately (i.e., with `throw new Exception()`)