### PR TITLE
Support `RandomizeMaterials` and `RandomizeColors` with Image Synthesis on.

### DIFF
--- a/unity/Assets/Scripts/ImageSynthesis/ImageSynthesis.cs
+++ b/unity/Assets/Scripts/ImageSynthesis/ImageSynthesis.cs
@@ -318,7 +318,6 @@ public class ImageSynthesis : MonoBehaviour {
                 objTag = sop.ObjectID;
             }
 
-
             Color classColor = ColorEncoding.EncodeTagAsColor(classTag);
             Color objColor = ColorEncoding.EncodeTagAsColor(objTag);
 
@@ -331,22 +330,15 @@ public class ImageSynthesis : MonoBehaviour {
                 colorIds[objColor] = r.gameObject.name;
             }
 
-            //			if (r.material.name.ToLower().Contains ("lightray")) {
-            //				objColor.a = 0;
-            //				classColor.a = 0;
-            //				mpb.SetFloat ("_Opacity", 0);
-            //
-            //			} else {
-            //				objColor.a = 1;
-            //				classColor.a = 1;
-            //				mpb.SetFloat ("_Opacity", 1);
-            //			}
-            //
-            // updated per @danielg - replaces commented out code
-            // if (r.material.name.ToLower().Contains("lightray")) {
-            //     r.enabled = false;
-            //     continue;
-            // }
+            // Check to name sure name includes lightray for RandomizeMaterials to continue to work
+            // with image synthesis on.
+            if (
+                r.gameObject.name.ToLower().Contains("lightray")
+                && r.material.name.ToLower().Contains("lightray")
+            ) {
+                r.enabled = false;
+                continue;
+            }
 
             objColor.a = 1;
             classColor.a = 1;

--- a/unity/Assets/Scripts/ImageSynthesis/ImageSynthesis.cs
+++ b/unity/Assets/Scripts/ImageSynthesis/ImageSynthesis.cs
@@ -343,10 +343,10 @@ public class ImageSynthesis : MonoBehaviour {
             //			}
             //
             // updated per @danielg - replaces commented out code
-            if (r.material.name.ToLower().Contains("lightray")) {
-                r.enabled = false;
-                continue;
-            }
+            // if (r.material.name.ToLower().Contains("lightray")) {
+            //     r.enabled = false;
+            //     continue;
+            // }
 
             objColor.a = 1;
             classColor.a = 1;


### PR DESCRIPTION
For an explanation, read this interactive notebook which visually shows what is going on and what happens if one naively removes the disabling out of the light rays (i.e., they may appear in the segmentation frames):

https://colab.research.google.com/drive/16kzdy7DNc5dCPHBt5z0Qgm3FWvy6-4wk?usp=sharing

![image](https://user-images.githubusercontent.com/28768645/120867714-55564880-c547-11eb-86cc-c895772a6707.png)


The only way this may fail is if a light ray object (which only occurs in a few rooms, and also caused #754 ) does not actually have the name "LightRay". However, in the few scenes I've found that do have light rays, all of them are named `LightRay`, and there doesn't appear to be a better way to find them.

![image](https://user-images.githubusercontent.com/28768645/120867641-322b9900-c547-11eb-91af-446c2d85f447.png)
