### PR TITLE
adding floor mesh colliders

### DIFF
--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -3009,6 +3009,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             var spawnedObj = ProceduralTools.spawnObject(ProceduralTools.getAssetMap(), ho);
             actionFinished(true);
         }
+        
         //used to spawn in a new object at a given position, used with ProceduralTools.spawnObjectAtReceptacle
         //places an object on the surface directly below the `position` value, with slight offset
         public bool placeNewObjectAtPoint(SimObjPhysics t, Vector3 position) {

--- a/unity/Assets/Scripts/ProceduralTools.cs
+++ b/unity/Assets/Scripts/ProceduralTools.cs
@@ -1021,6 +1021,14 @@ namespace Thor.Procedural {
 
                 Debug.Log("After room " + room.id);
 
+                GameObject.Destroy(subFloorGO.GetComponent<Rigidbody>()); //these meshes dont need a rigidbody, only colliders
+
+                //set up mesh collider to allow raycasts against only the floor inside the room
+                subFloorGO.AddComponent<MeshCollider>();
+                var meshCollider = subFloorGO.GetComponent<MeshCollider>();
+                meshCollider.sharedMesh = mesh;
+                subFloorGO.layer = 12; //raycast to layer 12 so it doesn't interact with any other layer
+
                 subFloorGO.transform.parent = floorGameObject.transform;
             }
 
@@ -1197,7 +1205,12 @@ namespace Thor.Procedural {
                     }
                 }
 
-                if (!cornerCheck) {
+                bool floorCheck = true;
+                //raycast down from the object's position to see if it hits something on the NonInteractive layer (floor mesh collider)
+                if (!Physics.Raycast(toSpawn.transform.position, -Vector3.up, Mathf.Infinity, 1 << 12))
+                    floorCheck = false;
+
+                if (!cornerCheck || !floorCheck) {
                     success = false;
                 }
 
@@ -1244,7 +1257,6 @@ namespace Thor.Procedural {
                 spawned.transform.Rotate(toRot.x, toRot.y, toRot.z);
             }
 
-
             var toSpawn = spawned.GetComponent<SimObjPhysics>();
             Rigidbody rb = spawned.GetComponent<Rigidbody>();
             rb.isKinematic = true;
@@ -1273,8 +1285,12 @@ namespace Thor.Procedural {
                         }
                     }
 
-                    if (!cornerCheck) {
+                    bool floorCheck = true;
+                    //raycast down from the object's position to see if it hits something on the NonInteractive layer (floor mesh collider)
+                    if (!Physics.Raycast(toSpawn.transform.position, -Vector3.up, Mathf.Infinity, 1 << 12))
+                        floorCheck = false;
 
+                    if (!cornerCheck || !floorCheck) {
                         success = false;
                         continue;
                     }


### PR DESCRIPTION
-adding floor mesh colliders to all generated sub floors, set to lits own layer
-adds floorCheck raycast against floor layer to ensure spawned objects only appear over parts of floor object with a mesh renderer