### PR TITLE
Fixed rogue trigger collider on ToiletPaper prefab

### DIFF
--- a/unity/Assets/Physics/SimObjsPhysics/Bathroom Objects/ToiletPaper/Prefabs/ToiletPaper.prefab
+++ b/unity/Assets/Physics/SimObjsPhysics/Bathroom Objects/ToiletPaper/Prefabs/ToiletPaper.prefab
@@ -447,8 +447,8 @@ MonoBehaviour:
   - {fileID: 4150381260731800}
   - {fileID: 4081742687852858}
   ReceptacleTriggerBoxes: []
-  isVisible: 0
-  isInteractable: 0
+  debugIsVisible: 0
+  debugIsInteractable: 0
   isInAgentHand: 0
   MyColliders:
   - {fileID: 136144517689340556}
@@ -473,6 +473,7 @@ MonoBehaviour:
   IsReceptacle: 0
   IsPickupable: 0
   IsMoveable: 0
+  isStatic: 0
   IsToggleable: 0
   IsOpenable: 0
   IsBreakable: 0
@@ -1150,9 +1151,9 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8338529351048980646}
-  m_LocalRotation: {x: -0, y: 1, z: -0.0000009835617, w: -0.00000019125079}
-  m_LocalPosition: {x: -1.1854918, y: 3.626348, z: 1.6049361}
-  m_LocalScale: {x: 6.73281, y: 6.73281, z: 6.73281}
+  m_LocalRotation: {x: 6.3948846e-13, y: -2.842171e-13, z: -0.7071068, w: 0.70710677}
+  m_LocalPosition: {x: 0.0000000171749, y: -0.000000017710041, z: -5.585442e-12}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 7931856335779462579}
   m_RootOrder: 1


### PR DESCRIPTION
Fixed outstanding trigger collider on sole ToiletPaper prefab, which was inflating the realtime-generated bounding box to absurd dimensions 