### PR TITLE
Allowing for rotating the wrist & elbow in a relative fashion.

### DIFF
--- a/unity/Assets/Scripts/ArmAgentController.cs
+++ b/unity/Assets/Scripts/ArmAgentController.cs
@@ -385,6 +385,60 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             );
         }
 
+        /*
+        Rotates the elbow (in a relative fashion) by some given
+        number of degrees. Easiest to see how this works by
+        using the editor debugging and shift+alt+(q/e).
+
+        Currently not a completely finished action. New logic is needed
+        to prevent self-collisions. In particular we need to
+        account for the hierarchy of rigidbodies of each arm joint and
+        determine how to detect collision between a given arm joint and other arm joints.
+        */
+        public void RotateElbowRelative(
+            float degrees,
+            float speed = 10f,
+            float? fixedDeltaTime = null,
+            bool returnToStart = true,
+            bool disableRendering = true
+        ) {
+            IK_Robot_Arm_Controller arm = getArm();
+            Quaternion target = new Quaternion();
+
+            arm.rotateElbowRelative(
+                controller: this,
+                degrees: degrees,
+                degreesPerSecond: speed,
+                disableRendering: disableRendering,
+                fixedDeltaTime: fixedDeltaTime.GetValueOrDefault(Time.fixedDeltaTime),
+                returnToStartPositionIfFailed: returnToStart
+            );
+        }
+
+        /*
+        Same as RotateElbowRelative but rotates the elbow to a given angle directly.
+        */
+        public void RotateElbow(
+            float degrees,
+            float speed = 10f,
+            float? fixedDeltaTime = null,
+            bool returnToStart = true,
+            bool disableRendering = true
+        ) {
+            IK_Robot_Arm_Controller arm = getArm();
+            Quaternion target = new Quaternion();
+
+            arm.rotateElbow(
+                controller: this,
+                degrees: degrees,
+                degreesPerSecond: speed,
+                disableRendering: disableRendering,
+                fixedDeltaTime: fixedDeltaTime.GetValueOrDefault(Time.fixedDeltaTime),
+                returnToStartPositionIfFailed: returnToStart
+            );
+        }
+
+
         // constrain arm's y position based on the agent's current capsule collider center and extents
         // valid Y height from action.y is [0, 1.0] to represent the relative min and max heights of the
         // arm constrained by the agent's capsule

--- a/unity/Assets/Scripts/ArmAgentController.cs
+++ b/unity/Assets/Scripts/ArmAgentController.cs
@@ -355,27 +355,26 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
         // currently not finished action. New logic needs to account for the
         // hierarchy of rigidbodies of each arm joint and how to detect collision
-        // between a given arm joint an other arm joints.
-        public void RotateMidLevelHand(ServerAction action) {
+        // between a given arm joint and other arm joints.
+        public void RotateWristRelative(
+            float pitch = 0f,
+            float yaw = 0f,
+            float roll = 0f,
+            float speed = 10f,
+            float? fixedDeltaTime = null,
+            bool returnToStart = true,
+            bool disableRendering = true
+        ) {
             IK_Robot_Arm_Controller arm = getArm();
             Quaternion target = new Quaternion();
 
-            // rotate around axis aliged x, y, z with magnitude based on vector3
-            if (action.degrees == 0) {
-                // use euler angles
-                target = Quaternion.Euler(action.rotation);
-            } else {
-                // rotate action.degrees about axis
-                target = Quaternion.AngleAxis(action.degrees, action.rotation);
-            }
-
-            arm.rotateHand(
+            arm.rotateWrist(
                 controller: this,
-                targetQuat: target,
-                degreesPerSecond: action.speed,
-                disableRendering: action.disableRendering,
-                fixedDeltaTime: action.fixedDeltaTime.GetValueOrDefault(Time.fixedDeltaTime),
-                returnToStartPositionIfFailed: action.returnToStart
+                rotation: Quaternion.Euler(pitch, yaw, -roll),
+                degreesPerSecond: speed,
+                disableRendering: disableRendering,
+                fixedDeltaTime: fixedDeltaTime.GetValueOrDefault(Time.fixedDeltaTime),
+                returnToStartPositionIfFailed: returnToStart
             );
         }
 

--- a/unity/Assets/Scripts/ArmAgentController.cs
+++ b/unity/Assets/Scripts/ArmAgentController.cs
@@ -373,7 +373,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             bool disableRendering = true
         ) {
             IK_Robot_Arm_Controller arm = getArm();
-            Quaternion target = new Quaternion();
 
             arm.rotateWrist(
                 controller: this,
@@ -403,7 +402,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             bool disableRendering = true
         ) {
             IK_Robot_Arm_Controller arm = getArm();
-            Quaternion target = new Quaternion();
 
             arm.rotateElbowRelative(
                 controller: this,
@@ -426,7 +424,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             bool disableRendering = true
         ) {
             IK_Robot_Arm_Controller arm = getArm();
-            Quaternion target = new Quaternion();
 
             arm.rotateElbow(
                 controller: this,

--- a/unity/Assets/Scripts/ArmAgentController.cs
+++ b/unity/Assets/Scripts/ArmAgentController.cs
@@ -353,9 +353,16 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
         }
 
-        // currently not finished action. New logic needs to account for the
-        // hierarchy of rigidbodies of each arm joint and how to detect collision
-        // between a given arm joint and other arm joints.
+        /*
+        Rotates the wrist (in a relative fashion) given some input
+        pitch, yaw, and roll offsets. Easiest to see how this works by
+        using the editor debugging and shift+alt+(arrow keys or s/w).
+
+        Currently not a completely finished action. New logic is needed
+        to prevent self-collisions. In particular we need to
+        account for the hierarchy of rigidbodies of each arm joint and
+        determine how to detect collision between a given arm joint and other arm joints.
+        */
         public void RotateWristRelative(
             float pitch = 0f,
             float yaw = 0f,

--- a/unity/Assets/Scripts/DebugDiscreteAgentController.cs
+++ b/unity/Assets/Scripts/DebugDiscreteAgentController.cs
@@ -192,7 +192,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         }
                     } else if (armRotateMode) {
                         var actionName = "RotateWristRelative";
-                        var localPos = new Vector3(0, 0, 0);
                         float rotateMag = 30f;
                         float pitch = 0f;
                         float yaw = 0f;

--- a/unity/Assets/Scripts/DebugDiscreteAgentController.cs
+++ b/unity/Assets/Scripts/DebugDiscreteAgentController.cs
@@ -197,6 +197,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         float pitch = 0f;
                         float yaw = 0f;
                         float roll = 0f;
+                        float degrees = 0f;
 
                         if (Input.GetKeyDown(KeyCode.W)) {
                             roll += rotateMag;
@@ -210,6 +211,16 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                             yaw -= rotateMag;
                         } else if (Input.GetKeyDown(KeyCode.RightArrow)) {
                             yaw += rotateMag;
+                        } else if (Input.GetKeyDown(KeyCode.E)) {
+                            actionName = "RotateElbowRelative";
+                            degrees += rotateMag;
+                        } else if (Input.GetKeyDown(KeyCode.Q)) {
+                            // Why Q/E rather than A/D? Because apparently
+                            // shift+alt+A is a Unity shortcut and Unity
+                            // doesn't provide the ability to disable shortcuts in
+                            // play mode despite this being a feature request since 2013.
+                            actionName = "RotateElbowRelative";
+                            degrees -= rotateMag;
                         } else {
                             actionName = "";
                         }
@@ -217,9 +228,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         if (actionName != "") {
                             Dictionary<string, object> action = new Dictionary<string, object>();
                             action["action"] = actionName;
-                            action["pitch"] = pitch;
-                            action["yaw"] = yaw;
-                            action["roll"] = roll;
+                            if (actionName == "RotateWristRelative") {
+                                action["pitch"] = pitch;
+                                action["yaw"] = yaw;
+                                action["roll"] = roll;
+                            } else if (actionName == "RotateElbowRelative") {
+                                action["degrees"] = degrees;
+                            }
                             this.CurrentActiveController().ProcessControlCommand(action);
                         }
                     }

--- a/unity/Assets/Scripts/DebugDiscreteAgentController.cs
+++ b/unity/Assets/Scripts/DebugDiscreteAgentController.cs
@@ -103,8 +103,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 }
 
                 if (!inputField.isFocused) {
-                    bool armMode = Input.GetKey(KeyCode.LeftShift);
-                    if (!armMode) {
+                    bool shiftHeld = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
+                    bool altHeld = Input.GetKey(KeyCode.LeftAlt) || Input.GetKey(KeyCode.RightAlt);
+                    bool noModifier = (!shiftHeld) && (!altHeld);
+                    bool armMoveMode = shiftHeld && !altHeld;
+                    bool armRotateMode = shiftHeld && altHeld;
+
+                    if (noModifier) {
                         float WalkMagnitude = 0.25f;
 
                         Dictionary<string, object> action = new Dictionary<string, object>();
@@ -150,7 +155,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                             this.CurrentActiveController().ProcessControlCommand(action);
                         }
 
-                    } else {
+                    } else if (armMoveMode) {
                         var actionName = "MoveArmRelative";
                         var localPos = new Vector3(0, 0, 0);
                         float ArmMoveMagnitude = 0.05f;
@@ -183,6 +188,38 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                                 //action["fixedDeltaTime"] = fixedDeltaTime;
                                 //action["speed"] = 0.1;
                             }
+                            this.CurrentActiveController().ProcessControlCommand(action);
+                        }
+                    } else if (armRotateMode) {
+                        var actionName = "RotateWristRelative";
+                        var localPos = new Vector3(0, 0, 0);
+                        float rotateMag = 30f;
+                        float pitch = 0f;
+                        float yaw = 0f;
+                        float roll = 0f;
+
+                        if (Input.GetKeyDown(KeyCode.W)) {
+                            roll += rotateMag;
+                        } else if (Input.GetKeyDown(KeyCode.S)) {
+                            roll -= rotateMag;
+                        } else if (Input.GetKeyDown(KeyCode.UpArrow)) {
+                            pitch += rotateMag;
+                        } else if (Input.GetKeyDown(KeyCode.DownArrow)) {
+                            pitch -= rotateMag;
+                        } else if (Input.GetKeyDown(KeyCode.LeftArrow)) {
+                            yaw -= rotateMag;
+                        } else if (Input.GetKeyDown(KeyCode.RightArrow)) {
+                            yaw += rotateMag;
+                        } else {
+                            actionName = "";
+                        }
+
+                        if (actionName != "") {
+                            Dictionary<string, object> action = new Dictionary<string, object>();
+                            action["action"] = actionName;
+                            action["pitch"] = pitch;
+                            action["yaw"] = yaw;
+                            action["roll"] = roll;
                             this.CurrentActiveController().ProcessControlCommand(action);
                         }
                     }

--- a/unity/Assets/Scripts/IK_Robot_Arm_Controller.cs
+++ b/unity/Assets/Scripts/IK_Robot_Arm_Controller.cs
@@ -430,6 +430,56 @@ public class IK_Robot_Arm_Controller : MonoBehaviour {
         }
     }
 
+    public void rotateElbowRelative(
+        PhysicsRemoteFPSAgentController controller,
+        float degrees,
+        float degreesPerSecond,
+        bool disableRendering = false,
+        float fixedDeltaTime = 0.02f,
+        bool returnToStartPositionIfFailed = false
+    ) {
+        collisionListener.Reset();
+        GameObject poleManipulator = GameObject.Find("IK_pole_manipulator");
+        Quaternion rotation = Quaternion.Euler(0f, 0f, degrees);
+        IEnumerator rotate = ContinuousMovement.rotate(
+            controller,
+            collisionListener,
+            poleManipulator.transform,
+            poleManipulator.transform.rotation * rotation,
+            disableRendering ? fixedDeltaTime : Time.fixedDeltaTime,
+            degreesPerSecond,
+            returnToStartPositionIfFailed
+        );
+
+        if (disableRendering) {
+            controller.unrollSimulatePhysics(
+                rotate,
+                fixedDeltaTime
+            );
+        } else {
+            StartCoroutine(rotate);
+        }
+    }
+
+    public void rotateElbow(
+        PhysicsRemoteFPSAgentController controller,
+        float degrees,
+        float degreesPerSecond,
+        bool disableRendering = false,
+        float fixedDeltaTime = 0.02f,
+        bool returnToStartPositionIfFailed = false
+    ) {
+        GameObject poleManipulator = GameObject.Find("IK_pole_manipulator");
+        rotateElbowRelative(
+            controller: controller,
+            degrees: (degrees - poleManipulator.transform.eulerAngles.z),
+            degreesPerSecond: degreesPerSecond,
+            disableRendering: disableRendering,
+            fixedDeltaTime: fixedDeltaTime,
+            returnToStartPositionIfFailed: returnToStartPositionIfFailed
+        );
+    }
+
     public List<string> WhatObjectsAreInsideMagnetSphereAsObjectID() {
         return magnetSphereComp.CurrentlyContainedSimObjectsByID();
     }

--- a/unity/Assets/Scripts/IK_Robot_Arm_Controller.cs
+++ b/unity/Assets/Scripts/IK_Robot_Arm_Controller.cs
@@ -401,9 +401,9 @@ public class IK_Robot_Arm_Controller : MonoBehaviour {
         }
     }
 
-    public void rotateHand(
+    public void rotateWrist(
         PhysicsRemoteFPSAgentController controller,
-        Quaternion targetQuat,
+        Quaternion rotation,
         float degreesPerSecond,
         bool disableRendering = false,
         float fixedDeltaTime = 0.02f,
@@ -414,7 +414,7 @@ public class IK_Robot_Arm_Controller : MonoBehaviour {
             controller,
             collisionListener,
             armTarget.transform,
-            armTarget.transform.rotation * targetQuat,
+            armTarget.transform.rotation * rotation,
             disableRendering ? fixedDeltaTime : Time.fixedDeltaTime,
             degreesPerSecond,
             returnToStartPositionIfFailed

--- a/unity/Assets/Scripts/IK_Robot_Arm_Controller.cs
+++ b/unity/Assets/Scripts/IK_Robot_Arm_Controller.cs
@@ -245,7 +245,8 @@ public class IK_Robot_Arm_Controller : MonoBehaviour {
         bool restrictTargetPosition = false,
         bool disableRendering = false
     ) {
-        Vector3 offsetWorldPos = Vector3.zero;
+
+        Vector3 offsetWorldPos;
         switch (coordinateSpace) {
             case "world":
                 // world space, can be used to move directly toward positions
@@ -291,9 +292,7 @@ public class IK_Robot_Arm_Controller : MonoBehaviour {
         IK_Robot_Arm_Controller arm = this;
 
         // Move arm based on hand space or arm origin space
-        // Vector3 targetWorldPos = handCameraSpace ? handCameraTransform.TransformPoint(target) : arm.transform.TransformPoint(target);
-        Vector3 targetWorldPos = Vector3.zero;
-
+        Vector3 targetWorldPos;
         switch (coordinateSpace) {
             case "world":
                 // world space, can be used to move directly toward positions

--- a/unity/Assets/Scripts/PhysicsSceneManager.cs
+++ b/unity/Assets/Scripts/PhysicsSceneManager.cs
@@ -825,11 +825,13 @@ public class PhysicsSceneManager : MonoBehaviour {
 
     // manually advance the physics timestep 
     public void AdvancePhysicsStep(
-            float timeStep = 0.02f,
-            float? simSeconds = null,
-            bool allowAutoSimulation = false
-        ) {
-
+        float timeStep = 0.02f,
+        float? simSeconds = null,
+        bool allowAutoSimulation = false
+    ) {
+        if (timeStep <= 0f && simSeconds.GetValueOrDefault(0f) > 0f) {
+            throw new InvalidOperationException($"timestep must be > 0");
+        }
         bool oldPhysicsAutoSim = Physics.autoSimulation;
         Physics.autoSimulation = false;
 


### PR DESCRIPTION
This should only be merged after #803. Note that I've targeted this merge at the `arm-collision-test` branch so that it's easier to see the differences, it should actually be merged to main after approval.

This PR:

* Replaces the `RotateMidLevelHand` method with a `RotateWristRelative` action. As it sounds, this allows for rotating the arm's wrist given an input pitch, yaw, and roll. I've hooked up this action into the debug editor, try it out by using `shift+alt+(arrow keys and w/s)` (I think it's fairly intuitive).
* Adds `RotateElbow` and `RotateElbowRelative` commands to allow for rotating the arm's elbow. Try this with `shift+alt+(q/e)`
* Enables a special "teleportation" case in arm movement/rotation: when taking an arm action with `speed` set to `float.PositiveInfinity` and `fixedDeltaTime` is set to `0`, the action completes instantly ignoring physics. This is similar to the `Teleport` function we have for agent moment.

Note that I haven't tried to fix any existing self-collision issues, I don't think these are too problematic in general.