### PR TITLE
fix: disp_screen is an object

### DIFF
--- a/ai2thor/platform.py
+++ b/ai2thor/platform.py
@@ -123,7 +123,7 @@ class Linux64(BaseLinuxPlatform):
             if disp_screen.screen()["root_depth"] != 24:
                 errors.append(
                     "Display %s does not have a color depth of 24: %s"
-                    % (display_screen_str, disp_screen["root_depth"])
+                    % (display_screen_str, disp_screen.screen()["root_depth"])
                 )
         except (Xlib.error.DisplayNameError, Xlib.error.DisplayConnectionError) as e:
             errors.append(


### PR DESCRIPTION
This was generating an error:

```TypeError: 'Display' object is not subscriptable```

It was wrongly used. The line 123 (for example) shows the correct usage.