### PR TITLE
Fixing arm bugs, adding new action allowing for rotating an object held by the arm, and adding anti-aliasing option to 3rd party cameras.

### DIFF
--- a/unity/Assets/Editor/PhysicsSettler.cs
+++ b/unity/Assets/Editor/PhysicsSettler.cs
@@ -107,7 +107,7 @@ class PhysicsSettler {
                 Physics.autoSimulation = cachedAutoSimulation;
                 active = false;
             } else {
-                Physics.Simulate(0.01f);
+                PhysicsSceneManager.PhysicsSimulateTHOR(0.01f);
             }
         }
     }

--- a/unity/Assets/Resources/ThirdPartyCameraTemplate.prefab
+++ b/unity/Assets/Resources/ThirdPartyCameraTemplate.prefab
@@ -1,0 +1,150 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7692911009727723218
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 811531799282885830}
+  - component: {fileID: 5990649868303501632}
+  - component: {fileID: 3402215512074657615}
+  - component: {fileID: 5576228602605313083}
+  m_Layer: 0
+  m_Name: ThirdPartyCameraTemplate
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &811531799282885830
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7692911009727723218}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &5990649868303501632
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7692911009727723218}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &3402215512074657615
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7692911009727723218}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 948f4100a11a5c24981795d21301da5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  volumeTrigger: {fileID: 811531799282885830}
+  volumeLayer:
+    serializedVersion: 2
+    m_Bits: 0
+  stopNaNPropagation: 1
+  finalBlitToCameraTarget: 0
+  antialiasingMode: 0
+  temporalAntialiasing:
+    jitterSpread: 0.75
+    sharpness: 0.25
+    stationaryBlending: 0.95
+    motionBlending: 0.85
+  subpixelMorphologicalAntialiasing:
+    quality: 2
+  fastApproximateAntialiasing:
+    fastMode: 0
+    keepAlpha: 0
+  fog:
+    enabled: 1
+    excludeSkybox: 1
+  debugLayer:
+    lightMeter:
+      width: 512
+      height: 256
+      showCurves: 1
+    histogram:
+      width: 512
+      height: 256
+      channel: 3
+    waveform:
+      exposure: 0.12
+      height: 256
+    vectorscope:
+      size: 256
+      exposure: 0.12
+    overlaySettings:
+      linearDepth: 0
+      motionColorIntensity: 4
+      motionGridSize: 64
+      colorBlindnessType: 0
+      colorBlindnessStrength: 1
+  m_Resources: {fileID: 11400000, guid: d82512f9c8e5d4a4d938b575d47f88d4, type: 2}
+  m_ShowToolkit: 0
+  m_ShowCustomSorter: 0
+  breakBeforeColorGrading: 0
+  m_BeforeTransparentBundles: []
+  m_BeforeStackBundles: []
+  m_AfterStackBundles: []
+--- !u!114 &5576228602605313083
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7692911009727723218}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd09293d18a1af44d95b8ed5c5418f95, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/unity/Assets/Resources/ThirdPartyCameraTemplate.prefab.meta
+++ b/unity/Assets/Resources/ThirdPartyCameraTemplate.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a434aa0f3e7304e5dafa25ce6e55cf49
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -522,7 +522,6 @@ public class AgentManager : MonoBehaviour {
         if (antiAliasing == "none") {
             postProcessLayer.enabled = false;
         } else {
-            Debug.Log("Happens");
             postProcessLayer.enabled = true;
             switch (antiAliasing) {
                 case "fxaa":

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -17,6 +17,9 @@ using System.Reflection;
 using System.Text;
 using UnityEngine.Networking;
 using System.Linq;
+using UnityEngine.Rendering.PostProcessing;
+using UnityStandardAssets.ImageEffects;
+
 
 public class AgentManager : MonoBehaviour {
     public List<BaseFPSAgentController> agents = new List<BaseFPSAgentController>();
@@ -497,12 +500,14 @@ public class AgentManager : MonoBehaviour {
         bool orthographic = false,
         float? orthographicSize = null,
         float? nearClippingPlane = null,
-        float? farClippingPlane = null
+        float? farClippingPlane = null,
+        string antiAliasing = "none"
     ) {
         // adds error if fieldOfView is out of bounds
         assertFovInBounds(fov: fieldOfView);
 
-        GameObject gameObject = new GameObject("ThirdPartyCamera" + thirdPartyCameras.Count);
+        GameObject gameObject = GameObject.Instantiate(Resources.Load("ThirdPartyCameraTemplate")) as GameObject;
+        gameObject.name = "ThirdPartyCamera" + thirdPartyCameras.Count;
         gameObject.AddComponent(typeof(Camera));
         Camera camera = gameObject.GetComponentInChildren<Camera>();
 
@@ -510,6 +515,28 @@ public class AgentManager : MonoBehaviour {
         camera.cullingMask = ~(1 << 11);
         if (renderDepthImage || renderSemanticSegmentation || renderInstanceSegmentation || renderNormalsImage || renderFlowImage) {
             gameObject.AddComponent(typeof(ImageSynthesis));
+        }
+
+        antiAliasing = antiAliasing.ToLower();
+        PostProcessLayer postProcessLayer = gameObject.GetComponentInChildren<PostProcessLayer>();
+        if (antiAliasing == "none") {
+            postProcessLayer.enabled = false;
+        } else {
+            Debug.Log("Happens");
+            postProcessLayer.enabled = true;
+            switch (antiAliasing) {
+                case "fxaa":
+                    postProcessLayer.antialiasingMode = PostProcessLayer.Antialiasing.FastApproximateAntialiasing;
+                    break;
+                case "smaa":
+                    postProcessLayer.antialiasingMode = PostProcessLayer.Antialiasing.SubpixelMorphologicalAntialiasing;
+                    break;
+                case "taa":
+                    postProcessLayer.antialiasingMode = PostProcessLayer.Antialiasing.TemporalAntialiasing;
+                    break;
+                default:
+                    break;
+            }
         }
 
         thirdPartyCameras.Add(camera);

--- a/unity/Assets/Scripts/ArmAgentController.cs
+++ b/unity/Assets/Scripts/ArmAgentController.cs
@@ -83,6 +83,81 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             );
         }
 
+        /*
+        Let's say you wanted the agent to be able to rotate the object it's
+        holding so that it could get multiple views of the object. You
+        could do this by using the RotateWristRelative action but the downside
+        of using that function is that object will be translated as the
+        wrist rotates. This RotateWristAroundHeldObject action gets around this
+        problem by allowing you to specify how much you'd like the object to
+        rotate by and then figuring out how to translate/rotate the wrist so
+        that the object rotates while staying fixed in space.
+
+        Note that the object may stil be translated if the specified rotation
+        of the object is not feasible given the arm's DOF and length/joint
+        constraints.
+        */
+        public void RotateWristAroundHeldObject(
+            float pitch = 0f,
+            float yaw = 0f,
+            float roll = 0f,
+            float speed = 10f,
+            float? fixedDeltaTime = null,
+            bool returnToStart = true,
+            bool disableRendering = true
+        ) {
+            IK_Robot_Arm_Controller arm = getArm();
+
+            if (arm.heldObjects.Count == 1) {
+                SimObjPhysics sop = arm.heldObjects.Keys.ToArray()[0];
+                RotateWristAroundPoint(
+                    point: sop.gameObject.transform.position,
+                    pitch: pitch,
+                    yaw: yaw,
+                    roll: roll,
+                    speed: speed,
+                    fixedDeltaTime: fixedDeltaTime,
+                    returnToStart: returnToStart,
+                    disableRendering: disableRendering
+                );
+            } else {
+                actionFinished(
+                    success: false,
+                    errorMessage: $"Cannot RotateWristAroundHeldObject when holding" +
+                        $" != 1 objects, currently holding {arm.heldObjects.Count} objects."
+                );
+            }
+
+        }
+
+        /*
+        Rotates and translates the wrist so that its position
+        stays fixed relative some given point as that point
+        rotates some given amount.
+        */
+        public void RotateWristAroundPoint(
+            Vector3 point,
+            float pitch = 0f,
+            float yaw = 0f,
+            float roll = 0f,
+            float speed = 10f,
+            float? fixedDeltaTime = null,
+            bool returnToStart = true,
+            bool disableRendering = true
+        ) {
+            IK_Robot_Arm_Controller arm = getArm();
+
+            arm.rotateWristAroundPoint(
+                controller: this,
+                rotatePoint: point,
+                rotation: Quaternion.Euler(pitch, yaw, -roll),
+                degreesPerSecond: speed,
+                disableRendering: disableRendering,
+                fixedDeltaTime: fixedDeltaTime.GetValueOrDefault(Time.fixedDeltaTime),
+                returnToStartPositionIfFailed: returnToStart
+            );
+        }
+
         // perhaps this should fail if no object is picked up?
         // currently action success happens as long as the arm is
         // enabled because it is a successful "attempt" to pickup something

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -40,6 +40,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         [SerializeField] protected Vector3 lastLocalCameraPosition;
         [SerializeField] protected Quaternion lastLocalCameraRotation;
         public float autoResetTimeScale = 1.0f;
+        protected uint lastActionInitialPhysicsSimulateCount;
 
         protected float gridVisualizeY = 0.005f; // used to visualize reachable position grid, offset from floor
         protected HashSet<int> initiallyDisabledRenderers = new HashSet<int>();
@@ -292,6 +293,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         protected virtual void actionFinished(bool success, AgentState newState, object actionReturn = null) {
             if (!this.IsProcessing) {
                 Debug.LogError("ActionFinished called with agentState not in processing ");
+            }
+
+            if (
+                (!Physics.autoSyncTransforms)
+                && lastActionInitialPhysicsSimulateCount == PhysicsSceneManager.PhysicsSimulateCallCount
+            ) {
+                Physics.SyncTransforms();
             }
 
             lastActionSuccess = success;
@@ -1813,7 +1821,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         // Once all those invocations have been converted to Dictionary<string, object>
         // this can be removed
         public void ProcessControlCommand(ServerAction serverAction) {
-
+            lastActionInitialPhysicsSimulateCount = PhysicsSceneManager.PhysicsSimulateCallCount;
             errorMessage = "";
             errorCode = ServerActionErrorCode.Undefined;
             collisionsInAction = new List<string>();
@@ -1856,6 +1864,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
         public void ProcessControlCommand(DynamicServerAction controlCommand, object target) {
+            lastActionInitialPhysicsSimulateCount = PhysicsSceneManager.PhysicsSimulateCallCount;
             errorMessage = "";
             errorCode = ServerActionErrorCode.Undefined;
             collisionsInAction = new List<string>();
@@ -3133,7 +3142,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 bool autoSim = Physics.autoSimulation;
                 Physics.autoSimulation = false;
                 for (int i = 0; i < 100; i++) {
-                    Physics.Simulate(0.02f);
+                    PhysicsSceneManager.PhysicsSimulateTHOR(0.02f);
                 }
                 Physics.autoSimulation = autoSim;
             }

--- a/unity/Assets/Scripts/ContinuousMovement.cs
+++ b/unity/Assets/Scripts/ContinuousMovement.cs
@@ -158,8 +158,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             tmpObjects.Add(fulcrum);
             tmpObjects.Add(wristProxy);
 
-            Quaternion updateTransformStartRotation = updateTransform.rotation;
-
             Func<Quaternion, Quaternion, Quaternion> directionFunc = (target, current) => target;
             Func<Quaternion, Quaternion, float> distanceFunc = (target, current) => Quaternion.Angle(current, target);
 

--- a/unity/Assets/Scripts/ContinuousMovement.cs
+++ b/unity/Assets/Scripts/ContinuousMovement.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 using UnityStandardAssets.Characters.FirstPerson;
 using System;
 
-
 namespace UnityStandardAssets.Characters.FirstPerson {
     public class ContinuousMovement {
         public static int unrollSimulatePhysics(IEnumerator enumerator, float fixedDeltaTime) {
@@ -42,19 +41,20 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
 
             return updateTransformPropertyFixedUpdate(
-                controller,
-                collisionListener,
-                moveTransform,
-                targetRotation,
-                getRotFunc,
-                setRotFunc,
-                nextRotFunc,
+                controller: controller,
+                collisionListener: collisionListener,
+                moveTransform: moveTransform,
+                target: targetRotation,
+                getProp: getRotFunc,
+                setProp: setRotFunc,
+                nextProp: nextRotFunc,
                 // Direction function for quaternion should just output target quaternion, since RotateTowards is used for addToProp
-                (target, current) => target,
+                getDirection: (target, current) => target,
                 // Distance Metric
-                (target, current) => Quaternion.Angle(current, target),
-                fixedDeltaTime,
-                returnToStartPropIfFailed
+                distanceMetric: (target, current) => Quaternion.Angle(current, target),
+                fixedDeltaTime: fixedDeltaTime,
+                returnToStartPropIfFailed: returnToStartPropIfFailed,
+                epsilon: 1e-3
             );
         }
 
@@ -72,17 +72,18 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             Func<Func<Transform, Vector3>, Action<Transform, Vector3>, Func<Transform, Vector3, Vector3>, IEnumerator> moveClosure =
                 (get, set, next) => updateTransformPropertyFixedUpdate(
-                    controller,
-                    collisionListener,
-                    moveTransform,
-                    targetPosition,
-                    get,
-                    set,
-                    next,
-                    (target, current) => (target - current).normalized,
-                    (target, current) => Vector3.SqrMagnitude(target - current),
-                    fixedDeltaTime,
-                    returnToStartPropIfFailed
+                    controller: controller,
+                    collisionListener: collisionListener,
+                    moveTransform: moveTransform,
+                    target: targetPosition,
+                    getProp: get,
+                    setProp: set,
+                    nextProp: next,
+                    getDirection: (target, current) => (target - current).normalized,
+                    distanceMetric: (target, current) => Vector3.SqrMagnitude(target - current),
+                    fixedDeltaTime: fixedDeltaTime,
+                    returnToStartPropIfFailed: returnToStartPropIfFailed,
+                    epsilon: 1e-6 // Since the distance metric uses SqrMagnitude this amounts to a distance of 1 millimeter
             );
 
             Func<Transform, Vector3> getPosFunc;
@@ -109,6 +110,93 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             );
         }
 
+        protected static IEnumerator finallyDestroyGameObjects(
+            List<GameObject> gameObjectsToDestroy,
+            IEnumerator steps
+        ) {
+            while (steps.MoveNext()) {
+                yield return steps.Current;
+            }
+
+            foreach (GameObject go in gameObjectsToDestroy) {
+                GameObject.Destroy(go);
+            }
+        }
+
+        public static IEnumerator rotateAroundPoint(
+            PhysicsRemoteFPSAgentController controller,
+            CollisionListener collisionListener,
+            Transform updateTransform,
+            Vector3 rotatePoint,
+            Quaternion targetRotation,
+            float fixedDeltaTime,
+            float degreesPerSecond,
+            bool returnToStartPropIfFailed = false
+        ) {
+            bool teleport = (degreesPerSecond == float.PositiveInfinity) && fixedDeltaTime == 0f;
+
+            // To figure out how to translate/rotate the undateTransform
+            // we just create two proxy game object that represent the
+            // transforms of objects sitting at the updateTransform
+            // position (fulcrum) and the rotatePoint (wristProxy). The
+            // wristProxy transform is a child of the fulcrum transform.
+            // As we rotate the fulcrum transform we thus figure out how the
+            // updateTransform should be updated by looking at how the
+            // wristProxy transform has changed.
+
+            GameObject fulcrum = new GameObject();
+            fulcrum.transform.position = rotatePoint;
+            fulcrum.transform.rotation = updateTransform.rotation;
+            targetRotation = fulcrum.transform.rotation * targetRotation;
+
+            GameObject wristProxy = new GameObject();
+            wristProxy.transform.parent = fulcrum.transform;
+            wristProxy.transform.position = updateTransform.position;
+            wristProxy.transform.rotation = updateTransform.rotation;
+
+            List<GameObject> tmpObjects = new List<GameObject>();
+            tmpObjects.Add(fulcrum);
+            tmpObjects.Add(wristProxy);
+
+            Quaternion updateTransformStartRotation = updateTransform.rotation;
+
+            Func<Quaternion, Quaternion, Quaternion> directionFunc = (target, current) => target;
+            Func<Quaternion, Quaternion, float> distanceFunc = (target, current) => Quaternion.Angle(current, target);
+
+            Func<Transform, Quaternion> getRotFunc = (t) => t.rotation;
+            Action<Transform, Quaternion> setRotFunc = (t, newRotation) => {
+                 t.rotation = newRotation;
+                 updateTransform.position = wristProxy.transform.position;
+                 updateTransform.rotation = newRotation;
+            };
+            Func<Transform, Quaternion, Quaternion> nextRotFunc = (t, target) => {
+                return Quaternion.RotateTowards(t.rotation, target, fixedDeltaTime * degreesPerSecond);
+            };
+
+            if (teleport) {
+                nextRotFunc = (t, direction) => targetRotation;
+            }
+
+            return finallyDestroyGameObjects(
+                gameObjectsToDestroy: tmpObjects,
+                steps: updateTransformPropertyFixedUpdate(
+                    controller: controller,
+                    collisionListener: collisionListener,
+                    moveTransform: fulcrum.transform,
+                    target: targetRotation,
+                    getProp: getRotFunc,
+                    setProp: setRotFunc,
+                    nextProp: nextRotFunc,
+                    getDirection: directionFunc,
+                    distanceMetric: distanceFunc,
+                    fixedDeltaTime: fixedDeltaTime,
+                    returnToStartPropIfFailed: returnToStartPropIfFailed,
+                    epsilon: 1e-3
+                )
+            );
+
+        }
+
         public static IEnumerator updateTransformPropertyFixedUpdate<T>(
             PhysicsRemoteFPSAgentController controller,
             CollisionListener collisionListener,
@@ -117,13 +205,12 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             Func<Transform, T> getProp,
             Action<Transform, T> setProp,
             Func<Transform, T, T> nextProp,
-
             // We could remove this one, but it is a speedup to not compute direction for position update calls at every addToProp call and just outside while
             Func<T, T, T> getDirection,
             Func<T, T, float> distanceMetric,
             float fixedDeltaTime,
             bool returnToStartPropIfFailed,
-            double epsilon = 1e-3
+            double epsilon
         ) {
             T originalProperty = getProp(moveTransform);
             var previousProperty = originalProperty;
@@ -165,7 +252,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     if (fixedDeltaTime == 0f) {
                         Physics.SyncTransforms();
                     } else {
-                        Physics.Simulate(fixedDeltaTime);
+                        PhysicsSceneManager.PhysicsSimulateTHOR(fixedDeltaTime);
                     }
                 }
 
@@ -193,7 +280,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 if (fixedDeltaTime == 0f) {
                     Physics.SyncTransforms();
                 } else {
-                    Physics.Simulate(fixedDeltaTime);
+                    PhysicsSceneManager.PhysicsSimulateTHOR(fixedDeltaTime);
                 }
             }
         }

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -59,7 +59,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 arm.transform.localPosition += direction * 1.0f * Time.fixedDeltaTime;
 
                 if (!Physics.autoSimulation) {
-                    Physics.Simulate(Time.fixedDeltaTime);
+                    PhysicsSceneManager.PhysicsSimulateTHOR(Time.fixedDeltaTime);
                 }
 
                 yield return new WaitForEndOfFrame();
@@ -101,7 +101,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 dumpPosition(wristCol);
 
                 if (!Physics.autoSimulation) {
-                    Physics.Simulate(Time.fixedDeltaTime);
+                    PhysicsSceneManager.PhysicsSimulateTHOR(Time.fixedDeltaTime);
                 }
                 // animator.Update(Time.fixedDeltaTime);
 

--- a/unity/Assets/Scripts/IK_Robot_Arm_Controller.cs
+++ b/unity/Assets/Scripts/IK_Robot_Arm_Controller.cs
@@ -760,7 +760,7 @@ public class IK_Robot_Arm_Controller : MonoBehaviour {
         }
 
         meta.heldObjects = heldObjectIDs;
-        meta.handSphereCenter = magnetSphere.transform.position;
+        meta.handSphereCenter = magnetSphere.transform.TransformPoint(magnetSphere.center);
         meta.handSphereRadius = magnetSphere.radius;
         meta.pickupableObjects = WhatObjectsAreInsideMagnetSphereAsObjectID();
         return meta;

--- a/unity/Assets/Scripts/IK_Robot_Arm_Controller.cs
+++ b/unity/Assets/Scripts/IK_Robot_Arm_Controller.cs
@@ -228,11 +228,14 @@ public class IK_Robot_Arm_Controller : MonoBehaviour {
         return targetShoulderSpace.z >= 0.0f && targetShoulderSpace.magnitude <= extendedArmLength;
     }
 
-    protected IEnumerator resetArmTargetPositionAsLastStep(IEnumerator steps) {
+    protected IEnumerator resetArmTargetPositionRotationAsLastStep(IEnumerator steps) {
         while (steps.MoveNext()) {
             yield return steps.Current;
         }
-        armTarget.position = handCameraTransform.transform.position;
+        Vector3 pos = handCameraTransform.transform.position;
+        Quaternion rot = handCameraTransform.transform.rotation;
+        armTarget.position = pos;
+        armTarget.rotation = rot;
     }
 
 
@@ -336,7 +339,7 @@ public class IK_Robot_Arm_Controller : MonoBehaviour {
             );
         }
 
-        IEnumerator moveCall = resetArmTargetPositionAsLastStep(
+        IEnumerator moveCall = resetArmTargetPositionRotationAsLastStep(
             ContinuousMovement.move(
                 controller,
                 collisionListener,
@@ -384,15 +387,17 @@ public class IK_Robot_Arm_Controller : MonoBehaviour {
 
         Vector3 target = new Vector3(this.transform.localPosition.x, targetY, 0);
 
-        IEnumerator moveCall = ContinuousMovement.move(
-            controller: controller,
-            collisionListener: collisionListener,
-            moveTransform: this.transform,
-            targetPosition: target,
-            fixedDeltaTime: disableRendering ? fixedDeltaTime : Time.fixedDeltaTime,
-            unitsPerSecond: unitsPerSecond,
-            returnToStartPropIfFailed: returnToStartPositionIfFailed,
-            localPosition: true
+        IEnumerator moveCall = resetArmTargetPositionRotationAsLastStep(
+                ContinuousMovement.move(
+                controller: controller,
+                collisionListener: collisionListener,
+                moveTransform: this.transform,
+                targetPosition: target,
+                fixedDeltaTime: disableRendering ? fixedDeltaTime : Time.fixedDeltaTime,
+                unitsPerSecond: unitsPerSecond,
+                returnToStartPropIfFailed: returnToStartPositionIfFailed,
+                localPosition: true
+            )
         );
 
         if (disableRendering) {
@@ -405,6 +410,39 @@ public class IK_Robot_Arm_Controller : MonoBehaviour {
         }
     }
 
+    public void rotateWristAroundPoint(
+        PhysicsRemoteFPSAgentController controller,
+        Vector3 rotatePoint,
+        Quaternion rotation,
+        float degreesPerSecond,
+        bool disableRendering = false,
+        float fixedDeltaTime = 0.02f,
+        bool returnToStartPositionIfFailed = false
+    ) {
+        collisionListener.Reset();
+        IEnumerator rotate = resetArmTargetPositionRotationAsLastStep(
+            ContinuousMovement.rotateAroundPoint(
+                controller: controller,
+                collisionListener: collisionListener,
+                updateTransform: armTarget.transform,
+                rotatePoint: rotatePoint,
+                targetRotation: rotation,
+                fixedDeltaTime: disableRendering ? fixedDeltaTime : Time.fixedDeltaTime,
+                degreesPerSecond: degreesPerSecond,
+                returnToStartPropIfFailed: returnToStartPositionIfFailed
+            )
+        );
+
+        if (disableRendering) {
+            controller.unrollSimulatePhysics(
+                rotate,
+                fixedDeltaTime
+            );
+        } else {
+            StartCoroutine(rotate);
+        }
+    }
+
     public void rotateWrist(
         PhysicsRemoteFPSAgentController controller,
         Quaternion rotation,
@@ -414,14 +452,16 @@ public class IK_Robot_Arm_Controller : MonoBehaviour {
         bool returnToStartPositionIfFailed = false
     ) {
         collisionListener.Reset();
-        IEnumerator rotate = ContinuousMovement.rotate(
-            controller,
-            collisionListener,
-            armTarget.transform,
-            armTarget.transform.rotation * rotation,
-            disableRendering ? fixedDeltaTime : Time.fixedDeltaTime,
-            degreesPerSecond,
-            returnToStartPositionIfFailed
+        IEnumerator rotate = resetArmTargetPositionRotationAsLastStep(
+            ContinuousMovement.rotate(
+                controller,
+                collisionListener,
+                armTarget.transform,
+                armTarget.transform.rotation * rotation,
+                disableRendering ? fixedDeltaTime : Time.fixedDeltaTime,
+                degreesPerSecond,
+                returnToStartPositionIfFailed
+            )
         );
 
         if (disableRendering) {
@@ -445,14 +485,16 @@ public class IK_Robot_Arm_Controller : MonoBehaviour {
         collisionListener.Reset();
         GameObject poleManipulator = GameObject.Find("IK_pole_manipulator");
         Quaternion rotation = Quaternion.Euler(0f, 0f, degrees);
-        IEnumerator rotate = ContinuousMovement.rotate(
-            controller,
-            collisionListener,
-            poleManipulator.transform,
-            poleManipulator.transform.rotation * rotation,
-            disableRendering ? fixedDeltaTime : Time.fixedDeltaTime,
-            degreesPerSecond,
-            returnToStartPositionIfFailed
+        IEnumerator rotate = resetArmTargetPositionRotationAsLastStep(
+            ContinuousMovement.rotate(
+                controller,
+                collisionListener,
+                poleManipulator.transform,
+                poleManipulator.transform.rotation * rotation,
+                disableRendering ? fixedDeltaTime : Time.fixedDeltaTime,
+                degreesPerSecond,
+                returnToStartPositionIfFailed
+            )
         );
 
         if (disableRendering) {
@@ -718,7 +760,7 @@ public class IK_Robot_Arm_Controller : MonoBehaviour {
         }
 
         meta.heldObjects = heldObjectIDs;
-        meta.handSphereCenter = transform.TransformPoint(magnetSphere.center);
+        meta.handSphereCenter = magnetSphere.transform.position;
         meta.handSphereRadius = magnetSphere.radius;
         meta.pickupableObjects = WhatObjectsAreInsideMagnetSphereAsObjectID();
         return meta;

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1683,8 +1683,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             try {
                 // default high level hand when teleporting
                 DefaultAgentHand();
-                ToggleArmColliders(arm: Arm, value: forceAction);
-                base.teleportFull(position: position, rotation: rotation, horizon: horizon, forceAction: forceAction);
+                base.teleportFull(
+                    position: position,
+                    rotation: rotation,
+                    horizon: horizon,
+                    forceAction: forceAction
+                );
+
                 if (standing) {
                     stand();
                 } else {
@@ -1702,11 +1707,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         );
                     }
                     base.assertTeleportedNearGround(targetPosition: position);
-
-                    ToggleArmColliders(arm: Arm, value: false);
                 }
             } catch (InvalidOperationException e) {
-                ToggleArmColliders(arm: Arm, value: false);
                 if (wasStanding) {
                     stand();
                 } else {

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1487,7 +1487,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             while (agentMovePQ.Count > 0 || !objectMoved) {
                 if (agentMovePQ.Count == 0) {
                     success = moveObjectWithTeleport(objectToMove, objectToMove.transform.position + d, snapToGrid);
-                    Physics.Simulate(0.04f);
+                    PhysicsSceneManager.PhysicsSimulateTHOR(0.04f);
                     break;
                 } else {
                     PhysicsRemoteFPSAgentController nextAgent = (PhysicsRemoteFPSAgentController)agentMovePQ.First;
@@ -1496,13 +1496,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     if (!objectMoved && agentPriority < objectPriority) {
                         // Debug.Log("Object");
                         success = moveObjectWithTeleport(objectToMove, objectToMove.transform.position + d, snapToGrid);
-                        Physics.Simulate(0.04f);
+                        PhysicsSceneManager.PhysicsSimulateTHOR(0.04f);
                         objectMoved = true;
                     } else {
                         // Debug.Log(nextAgent);
                         agentMovePQ.Dequeue();
                         success = nextAgent.moveInDirection(d, "", -1, false, false, agentsAndObjColliders);
-                        Physics.Simulate(0.04f);
+                        PhysicsSceneManager.PhysicsSimulateTHOR(0.04f);
                     }
                 }
                 if (!success) {
@@ -2448,7 +2448,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 }
                 rb.angularVelocity = rb.angularVelocity * 0.96f;
 
-                Physics.Simulate(0.04f);
+                PhysicsSceneManager.PhysicsSimulateTHOR(0.04f);
 #if UNITY_EDITOR
                 yield return null;
 #endif
@@ -2528,12 +2528,12 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             // SetUpRotationBoxChecks();
             IsHandDefault = false;
 
-            Physics.Simulate(0.1f);
+            PhysicsSceneManager.PhysicsSimulateTHOR(0.1f);
             bool handObjectIsColliding = isHandObjectColliding(true);
             if (count != 0) {
                 for (int j = 0; handObjectIsColliding && j < 5; j++) {
                     AgentHand.transform.position = AgentHand.transform.position + 0.01f * aveCollisionsNormal;
-                    Physics.Simulate(0.1f);
+                    PhysicsSceneManager.PhysicsSimulateTHOR(0.1f);
                     handObjectIsColliding = isHandObjectColliding(true);
                 }
             }
@@ -4780,7 +4780,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 yield return null;
 
                 for (int i = 0; i < 100; i++) {
-                    Physics.Simulate(0.04f);
+                    PhysicsSceneManager.PhysicsSimulateTHOR(0.04f);
 #if UNITY_EDITOR
                     yield return null;
 #endif

--- a/unity/Assets/Scripts/PhysicsSceneManager.cs
+++ b/unity/Assets/Scripts/PhysicsSceneManager.cs
@@ -41,6 +41,7 @@ public class PhysicsSceneManager : MonoBehaviour {
     public bool isSceneAtRest; // if any object in the scene has a non zero velocity, set to false
     public List<Rigidbody> rbsInScene = null; // list of all active rigidbodies in the scene
     public int AdvancePhysicsStepCount;
+    public static uint PhysicsSimulateCallCount;
 
     private void OnEnable() {
         // clear this on start so that the CheckForDuplicates function doesn't check pre-existing lists
@@ -63,7 +64,13 @@ public class PhysicsSceneManager : MonoBehaviour {
     }
     // Use this for initialization
     void Start() {
+        PhysicsSceneManager.PhysicsSimulateCallCount = 0;
         GatherAllRBsInScene();
+    }
+
+    public static void PhysicsSimulateTHOR(float deltaTime) {
+        Physics.Simulate(deltaTime);
+        PhysicsSceneManager.PhysicsSimulateCallCount++;
     }
 
     private void GatherAllRBsInScene() {


### PR DESCRIPTION
## Bugs fixed:

* The `handSphereCenter` returned by the metadata was not in world space coordinates.
* Some actions used by the arm do not advance physics (e.g. `PlaceObjectAtLocation`). This means that **objects may be moved by an action without their transforms being synchronized**; I noticed this problem when the bounding box returned for an object failed to update after using `PlaceObjectAtLocation`. To fix this, I now wrap the `Physics.Simulate` function so that we record whether or not physics has been simulated and, if not, I synchronize the transforms before computing metadata.
* The arm would fail to move if moved less than ~0.03 meters. This was fixed by changing `epsilon` from `1e-3` to  `1e-6`, the arm will now only fail to move if moved less than 1cm.

## New features

Added an anti-aliasing option for 3rd party cameras.

## New actions:

* `RotateWristAroundPoint` - This action allows for rotating an object held by the arm without changing the x,y,z position of the object. See attached video.

https://user-images.githubusercontent.com/628838/124312665-8ca71d80-db24-11eb-83f3-a4df21d7301c.mov

