### PR TITLE
Top-Down Image Frame Updates

### DIFF
--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -3218,7 +3218,10 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             if (structureObjs != null) {
                 foreach (StructureObject structure in structureObjs) {
-                    if (structure.WhatIsMyStructureObjectTag == StructureObjectTag.Ceiling) {
+                    if (
+                        structure.WhatIsMyStructureObjectTag == StructureObjectTag.Ceiling
+                        && structure.gameObject.name == "Ceiling"
+                    ) {
                         ceiling = structure;
                         break;
                     }

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -3184,9 +3184,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     sync.StopSyncingForASecond = false;
                 }
 
-                foreach (StructureObject so in structureObjsList) {
-                    UpdateDisplayGameObject(so.gameObject, true);
-                }
+                // foreach (StructureObject so in structureObjsList) {
+                //     UpdateDisplayGameObject(so.gameObject, true);
+                // }
             } else {
                 // stop culling the agent's body so it's visible from the top?
                 m_Camera.transform.GetComponent<FirstPersonCharacterCull>().StopCullingThingsForASecond = true;
@@ -3205,9 +3205,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 m_Camera.orthographic = (bool)cameraProps["orthographic"];
                 m_Camera.orthographicSize = (float)cameraProps["orthographicSize"];
 
-                foreach (StructureObject so in structureObjsList) {
-                    UpdateDisplayGameObject(so.gameObject, false);
-                }
+                // foreach (StructureObject so in structureObjsList) {
+                //     UpdateDisplayGameObject(so.gameObject, false);
+                // }
             }
             actionFinished(true);
         }
@@ -3217,6 +3217,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             StructureObject ceiling = null;
 
             if (structureObjs != null) {
+                StructureObject ceilingStruct = null;
                 foreach (StructureObject structure in structureObjs) {
                     if (
                         structure.WhatIsMyStructureObjectTag == StructureObjectTag.Ceiling
@@ -3224,7 +3225,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     ) {
                         ceiling = structure;
                         break;
+                    } else if (structure.WhatIsMyStructureObjectTag == StructureObjectTag.Ceiling) {
+                        ceilingStruct = structure;
                     }
+                }
+
+                if (ceiling == null) {
+                    ceiling = ceilingStruct;
                 }
             }
 

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -3253,6 +3253,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             float midX = (b.max.x + b.min.x) / 2f;
             float midZ = (b.max.z + b.min.z) / 2f;
 
+            // solves an edge case where the lowest point of the ceiling
+            // is actually below the floor :0
+            var sceneName = UnityEngine.SceneManagement.SceneManager.GetActiveScene().name;
+            if (sceneName == "FloorPlan309_physics") {
+                yValue = 2f;
+            }
+
             return new Dictionary<string, object>() {
                 ["position"] = new Vector3(midX, yValue, midZ),
                 ["rotation"] = new Vector3(90, 0, 0),

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -3241,7 +3241,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             float midZ = (b.max.z + b.min.z) / 2f;
 
             return new Dictionary<string, object>() {
-                ["position"] = new Vector3(midX, b.max.y + 5, midZ),
+                ["position"] = new Vector3(midX, b.max.y, midZ),
                 ["rotation"] = new Vector3(90, 0, 0),
                 ["orthographicSize"] = Math.Max((b.max.x - b.min.x) / 2f, (b.max.z - b.min.z) / 2f),
                 ["orthographic"] = true

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -3236,22 +3236,25 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
 
             Bounds b;
+            float yValue;
             if (ceiling != null) {
                 // There's a ceiling component in the room!
                 // Let's use it's bounds. (Likely iTHOR.)
                 b = ceiling.GetComponent<Renderer>().bounds;
+                yValue = b.min.y;
             } else {
                 // There's no component in the room!
                 // Let's use the bounds from every object. (Likely RoboTHOR.)
                 b = new Bounds();
                 b.min = agentManager.SceneBounds.min;
                 b.max = agentManager.SceneBounds.max;
+                yValue = b.max.y;
             }
             float midX = (b.max.x + b.min.x) / 2f;
             float midZ = (b.max.z + b.min.z) / 2f;
 
             return new Dictionary<string, object>() {
-                ["position"] = new Vector3(midX, b.min.y, midZ),
+                ["position"] = new Vector3(midX, yValue, midZ),
                 ["rotation"] = new Vector3(90, 0, 0),
                 ["orthographicSize"] = Math.Max((b.max.x - b.min.x) / 2f, (b.max.z - b.min.z) / 2f),
                 ["orthographic"] = true

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -3220,7 +3220,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 foreach (StructureObject structure in structureObjs) {
                     if (
                         structure.WhatIsMyStructureObjectTag == StructureObjectTag.Ceiling
-                        && structure.gameObject.name == "Ceiling"
+                        && structure.gameObject.name.ToLower().Contains("ceiling")
                     ) {
                         ceiling = structure;
                         break;

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -3184,9 +3184,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     sync.StopSyncingForASecond = false;
                 }
 
-                // foreach (StructureObject so in structureObjsList) {
-                //     UpdateDisplayGameObject(so.gameObject, true);
-                // }
+                foreach (StructureObject so in structureObjsList) {
+                    UpdateDisplayGameObject(so.gameObject, true);
+                }
             } else {
                 // stop culling the agent's body so it's visible from the top?
                 m_Camera.transform.GetComponent<FirstPersonCharacterCull>().StopCullingThingsForASecond = true;
@@ -3205,9 +3205,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 m_Camera.orthographic = (bool)cameraProps["orthographic"];
                 m_Camera.orthographicSize = (float)cameraProps["orthographicSize"];
 
-                // foreach (StructureObject so in structureObjsList) {
-                //     UpdateDisplayGameObject(so.gameObject, false);
-                // }
+                foreach (StructureObject so in structureObjsList) {
+                    UpdateDisplayGameObject(so.gameObject, false);
+                }
             }
             actionFinished(true);
         }

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -3244,7 +3244,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             float midZ = (b.max.z + b.min.z) / 2f;
 
             return new Dictionary<string, object>() {
-                ["position"] = new Vector3(midX, b.max.y, midZ),
+                ["position"] = new Vector3(midX, b.min.y, midZ),
                 ["rotation"] = new Vector3(90, 0, 0),
                 ["orthographicSize"] = Math.Max((b.max.x - b.min.x) / 2f, (b.max.z - b.min.z) / 2f),
                 ["orthographic"] = true

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -3160,7 +3160,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             List<StructureObject> structureObjsList = new List<StructureObject>();
             StructureObject[] structureObjs = FindObjectsOfType(typeof(StructureObject)) as StructureObject[];
-            StructureObject ceiling = null;
 
             foreach (StructureObject structure in structureObjs) {
                 switch (structure.WhatIsMyStructureObjectTag) {

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -3201,7 +3201,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 lastLocalCameraRotation = m_Camera.transform.localRotation;
 
                 var cameraProps = getMapViewCameraProperties();
-                m_Camera.transform.rotation = (Quaternion)cameraProps["rotation"];
+                m_Camera.transform.rotation = Quaternion.Euler((Vector3)cameraProps["rotation"]);
                 m_Camera.transform.position = (Vector3)cameraProps["position"];
                 m_Camera.orthographic = (bool)cameraProps["orthographic"];
                 m_Camera.orthographicSize = (float)cameraProps["orthographicSize"];
@@ -3241,7 +3241,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             return new Dictionary<string, object>() {
                 ["position"] = new Vector3(midX, b.max.y + 5, midZ),
-                ["rotation"] = Quaternion.Euler(90f, 0f, 0f),
+                ["rotation"] = new Vector3(90, 0, 0),
                 ["orthographicSize"] = Math.Max((b.max.x - b.min.x) / 2f, (b.max.z - b.min.z) / 2f),
                 ["orthographic"] = true
             };

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -3216,10 +3216,12 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             StructureObject[] structureObjs = FindObjectsOfType(typeof(StructureObject)) as StructureObject[];
             StructureObject ceiling = null;
 
-            foreach (StructureObject structure in structureObjs) {
-                if (structure.WhatIsMyStructureObjectTag == StructureObjectTag.Ceiling) {
-                    ceiling = structure;
-                    break;
+            if (structureObjs != null) {
+                foreach (StructureObject structure in structureObjs) {
+                    if (structure.WhatIsMyStructureObjectTag == StructureObjectTag.Ceiling) {
+                        ceiling = structure;
+                        break;
+                    }
                 }
             }
 

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -162,7 +162,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             SelectPlayerControl();
 
 #if !UNITY_EDITOR
-               HideHUD();
+            HideHUD();
 #endif
         }
 
@@ -2185,6 +2185,15 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         }
 
                         action.fillLiquid = "coffee";
+                        CurrentActiveController().ProcessControlCommand(action);
+                        break;
+                    }
+
+                // map view props
+                case "mvp": {
+                        var action = new Dictionary<string, object>() {
+                            ["action"] = "GetMapViewCameraProperties"
+                        };
                         CurrentActiveController().ProcessControlCommand(action);
                         break;
                     }


### PR DESCRIPTION
Now allows third party cameras to be used in place of ToggleMapView with

```python
from ai2thor.controller import Controller
event = controller.step(action="GetMapViewCameraProperties")
controller.step(
    action="AddThirdPartyCamera",
    **event.metadata["actionReturn"]
)
```
I don't think these should be merged into a single action, because, eventually, Third Party Cameras should be deprecated in favor of having the camera actually be an agent.

Resolves https://github.com/allenai/ai2thor/issues/812.
Fixes https://github.com/allenai/ai2thor/issues/445.
Deprecates `ToggleMapView`.