### PR TITLE
ThirdPartyCamera New Action and Bug Fixes

### DIFF
--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -508,7 +508,6 @@ public class AgentManager : MonoBehaviour {
 
         GameObject gameObject = GameObject.Instantiate(Resources.Load("ThirdPartyCameraTemplate")) as GameObject;
         gameObject.name = "ThirdPartyCamera" + thirdPartyCameras.Count;
-        //gameObject.AddComponent(typeof(Camera));
         Camera camera = gameObject.GetComponentInChildren<Camera>();
 
         // set up returned image

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -567,39 +567,6 @@ public class AgentManager : MonoBehaviour {
         );
     }
 
-    //same as `GetCoordinateFromRaycast` for the main agent camera, but used with any ThirdPartyCamera in scene
-    public void CoordinateFromRaycastThirdPartyCamera(float x, float y, int thirdPartyCameraId = 0) {
-        // count is out of bounds
-        if (thirdPartyCameraId >= thirdPartyCameras.Count || thirdPartyCameraId < 0) {
-            throw new ArgumentOutOfRangeException(
-                $"thirdPartyCameraId: {thirdPartyCameraId} (int: default=0) must in 0 <= thirdPartyCameraId < len(thirdPartyCameras)={thirdPartyCameras.Count}."
-            );
-        }
-
-        if (x < 0 || y < 0 || x > 1 || y > 1) {
-            throw new ArgumentOutOfRangeException($"x and y must be in [0:1] not (x={x}, y={y}).");
-        }
-
-        Camera thirdPartyCamera = thirdPartyCameras[thirdPartyCameraId];
-
-        Ray ray = thirdPartyCamera.ViewportPointToRay(new Vector3(x, 1 - y, 0));
-        RaycastHit hit;
-
-        if (Physics.Raycast(
-            ray: ray,
-            hitInfo: out hit,
-            maxDistance: Mathf.Infinity,
-            layerMask: LayerMask.GetMask("Default", "Agent", "SimObjVisible", "PlaceableSurface"),
-            queryTriggerInteraction: QueryTriggerInteraction.Ignore)) {
-            this.activeAgent().actionFinished(success: true, actionReturn: hit.point);
-
-        } else
-            this.activeAgent().actionFinished(success: true, actionReturn: null);
-
-
-
-    }
-
     // Here, we don't want some dimensions set. For instance, set x, but not y.
     public class OptionalVector3 {
         public float? x = null;

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -584,15 +584,20 @@ public class AgentManager : MonoBehaviour {
 
         Ray ray = thirdPartyCamera.ViewportPointToRay(new Vector3(x, 1 - y, 0));
         RaycastHit hit;
-        Physics.Raycast(
+
+        if (Physics.Raycast(
             ray: ray,
             hitInfo: out hit,
             maxDistance: Mathf.Infinity,
             layerMask: LayerMask.GetMask("Default", "Agent", "SimObjVisible", "PlaceableSurface"),
-            queryTriggerInteraction: QueryTriggerInteraction.Ignore
-        );
+            queryTriggerInteraction: QueryTriggerInteraction.Ignore)) {
+            this.activeAgent().actionFinished(success: true, actionReturn: hit.point);
 
-        this.activeAgent().actionFinished(success: true, actionReturn: hit.point);
+        } else
+            this.activeAgent().actionFinished(success: true, actionReturn: null);
+
+
+
     }
 
     // Here, we don't want some dimensions set. For instance, set x, but not y.

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -270,7 +270,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         action["snapToGrid"] = true;
                         // action.rotateStepDegrees = 45;
                         action["action"] = "Initialize";
-                        ActionDispatcher.Dispatch(AManager, new DynamicServerAction(action));
+                        CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);
                         // AgentManager am = PhysicsController.gameObject.FindObjectsOfType<AgentManager>()[0];
                         // Debug.Log("Physics scene manager = ...");
                         // Debug.Log(physicsSceneManager);
@@ -320,7 +320,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         action["action"] = "Initialize";
                         action["fieldOfView"] = 90;
                         action["gridSize"] = 0.25f;
-                        ActionDispatcher.Dispatch(AManager, new DynamicServerAction(action));
+                        CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);
                         break;
                     }
                 case "inita": {
@@ -363,7 +363,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         // action.massThreshold = 10f;
 
 
-                        ActionDispatcher.Dispatch(AManager, new DynamicServerAction(action));
+                        CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);
                         // AgentManager am = PhysicsController.gameObject.FindObjectsOfType<AgentManager>()[0];
                         // Debug.Log("Physics scene manager = ...");
                         // Debug.Log(physicsSceneManager);
@@ -1195,12 +1195,27 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     }
 
                 case "atpc": {
-                        AManager.AddThirdPartyCamera(
-                            position: Vector3.zero,
-                            rotation: Vector3.zero,
-                            orthographic: true,
-                            orthographicSize: 5
-                        );
+                        Dictionary<string, object> action = new Dictionary<string, object>();
+
+                        action["action"] = "AddThirdPartyCamera";
+                        action["position"] = Vector3.zero;
+                        action["rotation"] = Vector3.zero;
+                        action["orthographic"] = true;
+                        action["orthographicSize"] = 5;
+
+                        CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);
+                        break;
+                    }
+
+                case "cfrtpc": {
+                        Dictionary<string, object> action = new Dictionary<string, object>();
+
+                        action["action"] = "CoordinateFromRaycastThirdPartyCamera";
+                        action["x"] = 0.5f;
+                        action["y"] = 0.5f;
+                        action["thirdPartyCameraId"] = 0;
+
+                        CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);
                         break;
                     }
 
@@ -1794,45 +1809,36 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                 // move backward
                 case "mb": {
-                        ServerAction action = new ServerAction();
-                        action.action = "MoveBack";
+                        Dictionary<string, object> action = new Dictionary<string, object>();
+                        action["action"] = "MoveBack";
 
                         if (splitcommand.Length > 1) {
-                            action.moveMagnitude = float.Parse(splitcommand[1]);
-                        } else {
-                            action.moveMagnitude = 0.25f;
-                        }
-
+                            action["moveMagnitude"] = float.Parse(splitcommand[1]);
+                        } else { action["moveMagnitude"] = 0.25f; }
                         CurrentActiveController().ProcessControlCommand(action);
                         break;
                     }
 
                 // move left
                 case "ml": {
-                        ServerAction action = new ServerAction();
-                        action.action = "MoveLeft";
+                        Dictionary<string, object> action = new Dictionary<string, object>();
+                        action["action"] = "MoveLeft";
 
                         if (splitcommand.Length > 1) {
-                            action.moveMagnitude = float.Parse(splitcommand[1]);
-                        } else {
-                            action.moveMagnitude = 0.25f;
-                        }
-
+                            action["moveMagnitude"] = float.Parse(splitcommand[1]);
+                        } else { action["moveMagnitude"] = 0.25f; }
                         CurrentActiveController().ProcessControlCommand(action);
                         break;
                     }
 
                 // move right
                 case "mr": {
-                        ServerAction action = new ServerAction();
-                        action.action = "MoveRight";
+                        Dictionary<string, object> action = new Dictionary<string, object>();
+                        action["action"] = "MoveRight";
 
                         if (splitcommand.Length > 1) {
-                            action.moveMagnitude = float.Parse(splitcommand[1]);
-                        } else {
-                            action.moveMagnitude = 0.25f;
-                        }
-
+                            action["moveMagnitude"] = float.Parse(splitcommand[1]);
+                        } else { action["moveMagnitude"] = 0.25f; }
                         CurrentActiveController().ProcessControlCommand(action);
                         break;
                     }

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -1207,18 +1207,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         break;
                     }
 
-                case "cftpc": {
-                        Dictionary<string, object> action = new Dictionary<string, object>();
-
-                        action["action"] = "CoordinateFromRaycastThirdPartyCamera";
-                        action["x"] = 0f;
-                        action["y"] = 0f;
-                        action["thirdPartyCameraId"] = 0;
-
-                        CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);
-                        break;
-                    }
-
                 case "to": {
                         ServerAction action = new ServerAction();
                         action.action = "TeleportObject";

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -1207,12 +1207,12 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         break;
                     }
 
-                case "cfrtpc": {
+                case "cftpc": {
                         Dictionary<string, object> action = new Dictionary<string, object>();
 
                         action["action"] = "CoordinateFromRaycastThirdPartyCamera";
-                        action["x"] = 0.5f;
-                        action["y"] = 0.5f;
+                        action["x"] = 0f;
+                        action["y"] = 0f;
                         action["thirdPartyCameraId"] = 0;
 
                         CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -1195,13 +1195,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     }
 
                 case "atpc": {
-                        Dictionary<string, object> action = new Dictionary<string, object>();
-
-                        action["action"] = "AddThirdPartyCamera";
-                        action["position"] = Vector3.zero;
-                        action["rotation"] = Vector3.zero;
-                        action["orthographic"] = true;
-                        action["orthographicSize"] = 5;
+                        Dictionary<string, object> action = new Dictionary<string, object>() {
+                            ["action"] = "AddThirdPartyCamera",
+                            ["position"] = Vector3.zero,
+                            ["rotation"] = Vector3.zero,
+                            ["orthographic"] = true,
+                            ["orthographicSize"] = 5,
+                        };
 
                         CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);
                         break;

--- a/unity/Assets/UnitTests/TestBase.cs
+++ b/unity/Assets/UnitTests/TestBase.cs
@@ -15,6 +15,7 @@ namespace Tests {
         protected int sequenceId = 0;
         protected bool lastActionSuccess;
         protected string error;
+        protected object actionReturn;
 
         public IEnumerator step(Dictionary<string, object> action) {
             var agentManager = GameObject.FindObjectOfType<AgentManager>();
@@ -23,6 +24,7 @@ namespace Tests {
             yield return new WaitForEndOfFrame();
             var agent = agentManager.GetActiveAgent();
             lastActionSuccess = agent.lastActionSuccess;
+            actionReturn = agent.actionReturn;
             error = agent.errorMessage;
             sequenceId++;
         }

--- a/unity/Assets/UnitTests/TestThirdPartyCamera.cs
+++ b/unity/Assets/UnitTests/TestThirdPartyCamera.cs
@@ -72,6 +72,7 @@ namespace Tests {
 
             action.Clear();
 
+            //test raycast when hitting something in scene
             action["action"] = "CoordinateFromRaycastThirdPartyCamera";
             action["x"] = 0.5f;
             action["y"] = 0.5f;
@@ -87,10 +88,30 @@ namespace Tests {
             result = Mathf.Approximately(coord.y, 0.0f);
             Assert.AreEqual(result, true);
 
-            Debug.Log(coord.z);
             result = Mathf.Approximately(coord.z, 2.472f);
             Assert.AreEqual(result, true);
 
+            action.Clear();
+
+            //test raycast when nothing hit
+            action["action"] = "CoordinateFromRaycastThirdPartyCamera";
+            action["x"] = 0f;
+            action["y"] = 0f;
+            action["thirdPartyCameraId"] = 0;
+            yield return step(action);
+
+            result = false;
+
+            coord = (Vector3)actionReturn;
+
+            result = Mathf.Approximately(coord.x, 0.0f);
+            Assert.AreEqual(result, true);
+
+            result = Mathf.Approximately(coord.y, 0.0f);
+            Assert.AreEqual(result, true);
+
+            result = Mathf.Approximately(coord.z, 0.0f);
+            Assert.AreEqual(result, true);
         }
     }
 }

--- a/unity/Assets/UnitTests/TestThirdPartyCamera.cs
+++ b/unity/Assets/UnitTests/TestThirdPartyCamera.cs
@@ -100,18 +100,7 @@ namespace Tests {
             action["thirdPartyCameraId"] = 0;
             yield return step(action);
 
-            result = false;
-
-            coord = (Vector3)actionReturn;
-
-            result = Mathf.Approximately(coord.x, 0.0f);
-            Assert.AreEqual(result, true);
-
-            result = Mathf.Approximately(coord.y, 0.0f);
-            Assert.AreEqual(result, true);
-
-            result = Mathf.Approximately(coord.z, 0.0f);
-            Assert.AreEqual(result, true);
+            Assert.Null(actionReturn);
         }
     }
 }

--- a/unity/Assets/UnitTests/TestThirdPartyCamera.cs
+++ b/unity/Assets/UnitTests/TestThirdPartyCamera.cs
@@ -1,0 +1,96 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using System;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests {
+    public class TestThirdPartyCamera : TestBase {
+        [UnityTest]
+        public IEnumerator TestAddThirdPartyCamera() {
+            Dictionary<string, object> action = new Dictionary<string, object>();
+
+            action["action"] = "Initialize";
+            action["fieldOfView"] = 90f;
+            action["snapToGrid"] = true;
+            yield return step(action);
+
+            action.Clear();
+
+            action["action"] = "AddThirdPartyCamera";
+            action["position"] = Vector3.zero;
+            action["rotation"] = Vector3.zero;
+            action["orthographic"] = true;
+            action["orthographicSize"] = 5;
+            yield return step(action);
+
+            Assert.NotNull(GameObject.Find("ThirdPartyCamera0"));
+        }
+
+        [UnityTest]
+        public IEnumerator TestAddMultipleThirdPartyCamera() {
+            Dictionary<string, object> action = new Dictionary<string, object>();
+
+            action["action"] = "Initialize";
+            action["fieldOfView"] = 90f;
+            action["snapToGrid"] = true;
+            yield return step(action);
+
+            action.Clear();
+
+            action["action"] = "AddThirdPartyCamera";
+            action["position"] = Vector3.zero;
+            action["rotation"] = Vector3.zero;
+            action["orthographic"] = true;
+            action["orthographicSize"] = 5;
+            yield return step(action);
+            yield return step(action);
+
+            Assert.NotNull(GameObject.Find("ThirdPartyCamera0"));
+            Assert.NotNull(GameObject.Find("ThirdPartyCamera1"));
+
+        }
+
+        [UnityTest]
+        public IEnumerator TestCoordinateFromRaycastThirdPartyCamera() {
+            Dictionary<string, object> action = new Dictionary<string, object>();
+
+            action["action"] = "Initialize";
+            action["fieldOfView"] = 90f;
+            action["snapToGrid"] = true;
+            yield return step(action);
+
+            action.Clear();
+
+            action["action"] = "AddThirdPartyCamera";
+            action["position"] = Vector3.zero;
+            action["rotation"] = Vector3.zero;
+            action["orthographic"] = true;
+            action["orthographicSize"] = 5;
+            yield return step(action);
+
+            action.Clear();
+
+            action["action"] = "CoordinateFromRaycastThirdPartyCamera";
+            action["x"] = 0.5f;
+            action["y"] = 0.5f;
+            action["thirdPartyCameraId"] = 0;
+            yield return step(action);
+
+            bool result = false;
+            Vector3 coord = (Vector3)actionReturn;
+
+            result = Mathf.Approximately(coord.x, 0.0f);
+            Assert.AreEqual(result, true);
+
+            result = Mathf.Approximately(coord.y, 0.0f);
+            Assert.AreEqual(result, true);
+
+            Debug.Log(coord.z);
+            result = Mathf.Approximately(coord.z, 2.472f);
+            Assert.AreEqual(result, true);
+
+        }
+    }
+}

--- a/unity/Assets/UnitTests/TestThirdPartyCamera.cs
+++ b/unity/Assets/UnitTests/TestThirdPartyCamera.cs
@@ -52,55 +52,5 @@ namespace Tests {
 
         }
 
-        [UnityTest]
-        public IEnumerator TestCoordinateFromRaycastThirdPartyCamera() {
-            Dictionary<string, object> action = new Dictionary<string, object>();
-
-            action["action"] = "Initialize";
-            action["fieldOfView"] = 90f;
-            action["snapToGrid"] = true;
-            yield return step(action);
-
-            action.Clear();
-
-            action["action"] = "AddThirdPartyCamera";
-            action["position"] = Vector3.zero;
-            action["rotation"] = Vector3.zero;
-            action["orthographic"] = true;
-            action["orthographicSize"] = 5;
-            yield return step(action);
-
-            action.Clear();
-
-            //test raycast when hitting something in scene
-            action["action"] = "CoordinateFromRaycastThirdPartyCamera";
-            action["x"] = 0.5f;
-            action["y"] = 0.5f;
-            action["thirdPartyCameraId"] = 0;
-            yield return step(action);
-
-            bool result = false;
-            Vector3 coord = (Vector3)actionReturn;
-
-            result = Mathf.Approximately(coord.x, 0.0f);
-            Assert.AreEqual(result, true);
-
-            result = Mathf.Approximately(coord.y, 0.0f);
-            Assert.AreEqual(result, true);
-
-            result = Mathf.Approximately(coord.z, 2.472f);
-            Assert.AreEqual(result, true);
-
-            action.Clear();
-
-            //test raycast when nothing hit
-            action["action"] = "CoordinateFromRaycastThirdPartyCamera";
-            action["x"] = 0f;
-            action["y"] = 0f;
-            action["thirdPartyCameraId"] = 0;
-            yield return step(action);
-
-            Assert.Null(actionReturn);
-        }
     }
 }


### PR DESCRIPTION
~~- adds new action `CoordinateFromRaycastThirdPartyCamera` that allows getting coordinates of objects hit from a ThirdPartyCamera raycast (same as GetCoordinateFromRaycast for the main agent camera)~~

- updates some DebugInput field syntax to not use outdated `ActionDispatcher` syntax, instead use new `ProcessControlCommand` overload

- removes extra `AddComponent` call in `AddThirdPartyCamera` since camera prefabs now already have a camera component on them

~~- unit tests for ThirdPartyCamera instantiation as well as new CoordinateFromRaycastThirdPartyCamera~~

Edit: All functions related to `CoordinateFromRaycastThirdPartyCamera` are now isolated to the [`CoordinateFramRaycastTPC`](https://github.com/allenai/ai2thor/tree/CoordinateFromRaycastTPC) branch to make future updates to ThirdPartyCamera into a "ghost agent" cleaner.