### PR TITLE
Object Bounds Fix

### DIFF
--- a/unity/Assets/Physics/SimObjsPhysics/Common Objects/DiningTable/Prefabs/Dining_Table_Master_Prefabs/Dining_Table_23_Master.prefab
+++ b/unity/Assets/Physics/SimObjsPhysics/Common Objects/DiningTable/Prefabs/Dining_Table_Master_Prefabs/Dining_Table_23_Master.prefab
@@ -263,7 +263,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  uniqueID: DiningTable|+05.00|+05.00|+05.00
+  objectID: 
   Type: 26
   PrimaryProperty: 2
   SecondaryProperties: 07000000
@@ -311,8 +311,8 @@ MonoBehaviour:
   - {fileID: 496423436821638486}
   ReceptacleTriggerBoxes:
   - {fileID: 497522507131202931}
-  isVisible: 0
-  isInteractable: 0
+  debugIsVisible: 0
+  debugIsInteractable: 0
   isInAgentHand: 0
   MyColliders:
   - {fileID: 496423436035978729}
@@ -328,11 +328,29 @@ MonoBehaviour:
   HFrbdrag: 0.4
   HFrbangulardrag: 0.15
   salientMaterials: 0100000002000000
+  MySpawnPoints: []
   CurrentTemperature: 0
   HowManySecondsUntilRoomTemp: 10
   inMotion: 0
+  numSimObjHit: 0
+  numFloorHit: 0
+  numStructureHit: 0
   lastVelocity: 0
+  IsReceptacle: 0
+  IsPickupable: 0
+  IsMoveable: 0
+  isStatic: 0
+  IsToggleable: 0
+  IsOpenable: 0
+  IsBreakable: 0
+  IsFillable: 0
+  IsDirtyable: 0
+  IsCookable: 0
+  IsSliceable: 0
+  canChangeTempToHot: 0
+  canChangeTempToCold: 0
   ContainedObjectReferences: []
+  CurrentlyContains: []
 --- !u!54 &496423435562221877
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -1847,6 +1865,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1859,6 +1878,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -2236,6 +2256,22 @@ PrefabInstance:
       value: 64
       objectReference: {fileID: 0}
     - target: {fileID: 4251536333782420, guid: 6877aba5a696347dbb6c01f851f2da28, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4251536333782420, guid: 6877aba5a696347dbb6c01f851f2da28, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.9124999
+      objectReference: {fileID: 0}
+    - target: {fileID: 4251536333782420, guid: 6877aba5a696347dbb6c01f851f2da28, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.05624972
+      objectReference: {fileID: 0}
+    - target: {fileID: 4251536333782420, guid: 6877aba5a696347dbb6c01f851f2da28, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.8437496
+      objectReference: {fileID: 0}
+    - target: {fileID: 4251536333782420, guid: 6877aba5a696347dbb6c01f851f2da28, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0.001
       objectReference: {fileID: 0}
@@ -2246,6 +2282,10 @@ PrefabInstance:
     - target: {fileID: 4251536333782420, guid: 6877aba5a696347dbb6c01f851f2da28, type: 3}
       propertyPath: m_LocalPosition.z
       value: -0.002
+      objectReference: {fileID: 0}
+    - target: {fileID: 4251536333782420, guid: 6877aba5a696347dbb6c01f851f2da28, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70710695
       objectReference: {fileID: 0}
     - target: {fileID: 4251536333782420, guid: 6877aba5a696347dbb6c01f851f2da28, type: 3}
       propertyPath: m_LocalRotation.x
@@ -2260,14 +2300,6 @@ PrefabInstance:
       value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4251536333782420, guid: 6877aba5a696347dbb6c01f851f2da28, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.70710695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4251536333782420, guid: 6877aba5a696347dbb6c01f851f2da28, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4251536333782420, guid: 6877aba5a696347dbb6c01f851f2da28, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
@@ -2278,18 +2310,6 @@ PrefabInstance:
     - target: {fileID: 4251536333782420, guid: 6877aba5a696347dbb6c01f851f2da28, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4251536333782420, guid: 6877aba5a696347dbb6c01f851f2da28, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 0.9124999
-      objectReference: {fileID: 0}
-    - target: {fileID: 4251536333782420, guid: 6877aba5a696347dbb6c01f851f2da28, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.05624972
-      objectReference: {fileID: 0}
-    - target: {fileID: 4251536333782420, guid: 6877aba5a696347dbb6c01f851f2da28, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1.8437496
       objectReference: {fileID: 0}
     - target: {fileID: 114448760657764924, guid: 6877aba5a696347dbb6c01f851f2da28,
         type: 3}
@@ -2317,86 +2337,16 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 496423435562221879}
     m_Modifications:
-    - target: {fileID: 3374243347131093467, guid: 75c10ae80375fdd4799c195f6ca961d1,
+    - target: {fileID: 247342059982857045, guid: 75c10ae80375fdd4799c195f6ca961d1,
         type: 3}
-      propertyPath: m_Name
-      value: Shelf_Open (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300014, guid: 6adf3a48769eb2147b3367d2919c905b, type: 3}
+    - target: {fileID: 1474647849720935382, guid: 75c10ae80375fdd4799c195f6ca961d1,
         type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.15
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2733517437033681095, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.007
-      objectReference: {fileID: 0}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300014, guid: 6adf3a48769eb2147b3367d2919c905b, type: 3}
     - target: {fileID: 2733517437033681095, guid: 75c10ae80375fdd4799c195f6ca961d1,
         type: 3}
       propertyPath: m_LocalScale.x
@@ -2407,60 +2357,10 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 1.2462
       objectReference: {fileID: 0}
-    - target: {fileID: 3227712252492213481, guid: 75c10ae80375fdd4799c195f6ca961d1,
+    - target: {fileID: 2733517437033681095, guid: 75c10ae80375fdd4799c195f6ca961d1,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: -0.007
-      objectReference: {fileID: 0}
-    - target: {fileID: 3227712252492213481, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.6911381
-      objectReference: {fileID: 0}
-    - target: {fileID: 3227712252492213481, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1.2462
-      objectReference: {fileID: 0}
-    - target: {fileID: 4816071333051077481, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.022
-      objectReference: {fileID: 0}
-    - target: {fileID: 4816071333051077481, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.7122775
-      objectReference: {fileID: 0}
-    - target: {fileID: 4816071333051077481, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.7992379
-      objectReference: {fileID: 0}
-    - target: {fileID: 5067813496655688011, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5067813496655688011, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5077122227750319582, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.003
-      objectReference: {fileID: 0}
-    - target: {fileID: 5077122227750319582, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.7334166
-      objectReference: {fileID: 0}
-    - target: {fileID: 5077122227750319582, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 0.8152874
       objectReference: {fileID: 0}
     - target: {fileID: 3064152604819875213, guid: 75c10ae80375fdd4799c195f6ca961d1,
         type: 3}
@@ -2647,16 +2547,141 @@ PrefabInstance:
       propertyPath: ReceptacleTriggerBoxes.Array.data[0]
       value: 
       objectReference: {fileID: 6241126358691856812}
-    - target: {fileID: 247342059982857045, guid: 75c10ae80375fdd4799c195f6ca961d1,
+    - target: {fileID: 3227712252492213481, guid: 75c10ae80375fdd4799c195f6ca961d1,
         type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300014, guid: 6adf3a48769eb2147b3367d2919c905b, type: 3}
-    - target: {fileID: 1474647849720935382, guid: 75c10ae80375fdd4799c195f6ca961d1,
+      propertyPath: m_LocalScale.x
+      value: 1.6911381
+      objectReference: {fileID: 0}
+    - target: {fileID: 3227712252492213481, guid: 75c10ae80375fdd4799c195f6ca961d1,
         type: 3}
-      propertyPath: m_Mesh
+      propertyPath: m_LocalScale.z
+      value: 1.2462
+      objectReference: {fileID: 0}
+    - target: {fileID: 3227712252492213481, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.007
+      objectReference: {fileID: 0}
+    - target: {fileID: 3374243347131093467, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_Name
+      value: Shelf_Open (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4816071333051077481, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.7122775
+      objectReference: {fileID: 0}
+    - target: {fileID: 4816071333051077481, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.7992379
+      objectReference: {fileID: 0}
+    - target: {fileID: 4816071333051077481, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.022
+      objectReference: {fileID: 0}
+    - target: {fileID: 5067813496655688011, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5067813496655688011, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5077122227750319582, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.7334166
+      objectReference: {fileID: 0}
+    - target: {fileID: 5077122227750319582, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.8152874
+      objectReference: {fileID: 0}
+    - target: {fileID: 5077122227750319582, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 5089162487321946526, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: myParent
       value: 
-      objectReference: {fileID: 4300014, guid: 6adf3a48769eb2147b3367d2919c905b, type: 3}
+      objectReference: {fileID: 496423435562221874}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 75c10ae80375fdd4799c195f6ca961d1, type: 3}
 --- !u!4 &6385144915399565509 stripped
@@ -2894,130 +2919,25 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 496423435562221879}
     m_Modifications:
-    - target: {fileID: 3374243347131093467, guid: 75c10ae80375fdd4799c195f6ca961d1,
+    - target: {fileID: 247342059982857045, guid: 75c10ae80375fdd4799c195f6ca961d1,
         type: 3}
-      propertyPath: m_Name
-      value: Shelf_Open
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300012, guid: 6adf3a48769eb2147b3367d2919c905b, type: 3}
+    - target: {fileID: 1474647849720935382, guid: 75c10ae80375fdd4799c195f6ca961d1,
         type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.5233
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2733517437033681095, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.007
-      objectReference: {fileID: 0}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300012, guid: 6adf3a48769eb2147b3367d2919c905b, type: 3}
     - target: {fileID: 2733517437033681095, guid: 75c10ae80375fdd4799c195f6ca961d1,
         type: 3}
       propertyPath: m_LocalScale.x
       value: 1.5550696
       objectReference: {fileID: 0}
-    - target: {fileID: 3227712252492213481, guid: 75c10ae80375fdd4799c195f6ca961d1,
+    - target: {fileID: 2733517437033681095, guid: 75c10ae80375fdd4799c195f6ca961d1,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: -0.007
-      objectReference: {fileID: 0}
-    - target: {fileID: 3227712252492213481, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.5550696
-      objectReference: {fileID: 0}
-    - target: {fileID: 4816071333051077481, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.022
-      objectReference: {fileID: 0}
-    - target: {fileID: 4816071333051077481, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.5745081
-      objectReference: {fileID: 0}
-    - target: {fileID: 5067813496655688011, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5067813496655688011, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5077122227750319582, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.003
-      objectReference: {fileID: 0}
-    - target: {fileID: 5077122227750319582, guid: 75c10ae80375fdd4799c195f6ca961d1,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.5939463
       objectReference: {fileID: 0}
     - target: {fileID: 3064152604819875213, guid: 75c10ae80375fdd4799c195f6ca961d1,
         type: 3}
@@ -3204,16 +3124,126 @@ PrefabInstance:
       propertyPath: ReceptacleTriggerBoxes.Array.data[0]
       value: 
       objectReference: {fileID: 1804133093794853772}
-    - target: {fileID: 247342059982857045, guid: 75c10ae80375fdd4799c195f6ca961d1,
+    - target: {fileID: 3227712252492213481, guid: 75c10ae80375fdd4799c195f6ca961d1,
         type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300012, guid: 6adf3a48769eb2147b3367d2919c905b, type: 3}
-    - target: {fileID: 1474647849720935382, guid: 75c10ae80375fdd4799c195f6ca961d1,
+      propertyPath: m_LocalScale.x
+      value: 1.5550696
+      objectReference: {fileID: 0}
+    - target: {fileID: 3227712252492213481, guid: 75c10ae80375fdd4799c195f6ca961d1,
         type: 3}
-      propertyPath: m_Mesh
+      propertyPath: m_LocalPosition.x
+      value: -0.007
+      objectReference: {fileID: 0}
+    - target: {fileID: 3374243347131093467, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_Name
+      value: Shelf_Open
+      objectReference: {fileID: 0}
+    - target: {fileID: 4816071333051077481, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5745081
+      objectReference: {fileID: 0}
+    - target: {fileID: 4816071333051077481, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.022
+      objectReference: {fileID: 0}
+    - target: {fileID: 5067813496655688011, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5067813496655688011, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5077122227750319582, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5939463
+      objectReference: {fileID: 0}
+    - target: {fileID: 5077122227750319582, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 5089162487321946526, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: myParent
       value: 
-      objectReference: {fileID: 4300012, guid: 6adf3a48769eb2147b3367d2919c905b, type: 3}
+      objectReference: {fileID: 496423435562221874}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5233
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6828744035350689265, guid: 75c10ae80375fdd4799c195f6ca961d1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 75c10ae80375fdd4799c195f6ca961d1, type: 3}
 --- !u!1 &1804133093794853772 stripped

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -3147,7 +3147,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 Physics.autoSimulation = autoSim;
             }
             physicsSceneManager.ResetObjectIdToSimObjPhysics();
-            //physicsSceneManager.MakeBreakableAndSleep();
             actionFinished(success);
         }
 

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -3147,7 +3147,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 Physics.autoSimulation = autoSim;
             }
             physicsSceneManager.ResetObjectIdToSimObjPhysics();
-            physicsSceneManager.MakeBreakableAndSleep();
+            //physicsSceneManager.MakeBreakableAndSleep();
             actionFinished(success);
         }
 

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -3147,7 +3147,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 Physics.autoSimulation = autoSim;
             }
             physicsSceneManager.ResetObjectIdToSimObjPhysics();
-
+            physicsSceneManager.MakeBreakableAndSleep();
             actionFinished(success);
         }
 

--- a/unity/Assets/Scripts/Break.cs
+++ b/unity/Assets/Scripts/Break.cs
@@ -69,6 +69,19 @@ public class Break : MonoBehaviour {
             // Disable this game object and spawn in the broken pieces
             Rigidbody rb = gameObject.GetComponent<Rigidbody>();
 
+            //befor disabling things, if this object is a receptacle, unparent all objects contained
+            if (gameObject.GetComponent<SimObjPhysics>().IsReceptacle) {
+                GameObject objs = GameObject.Find("Objects");
+                foreach (GameObject go in gameObject.GetComponent<SimObjPhysics>().ContainedGameObjects()) {
+                    print($"{go.name}");
+                    go.transform.SetParent(objs.transform);
+                    Rigidbody childrb = go.GetComponent<Rigidbody>();
+                    rb.useGravity = true;
+                    rb.constraints = RigidbodyConstraints.None;
+                    rb.collisionDetectionMode = CollisionDetectionMode.ContinuousSpeculative;
+                }
+            }
+
             // turn off everything except the top object
             foreach (Transform t in gameObject.transform) {
                 t.gameObject.SetActive(false);

--- a/unity/Assets/Scripts/Break.cs
+++ b/unity/Assets/Scripts/Break.cs
@@ -75,9 +75,10 @@ public class Break : MonoBehaviour {
                 foreach (GameObject go in gameObject.GetComponent<SimObjPhysics>().ContainedGameObjects()) {
                     go.transform.SetParent(objs.transform);
                     Rigidbody childrb = go.GetComponent<Rigidbody>();
-                    rb.useGravity = true;
-                    rb.constraints = RigidbodyConstraints.None;
-                    rb.collisionDetectionMode = CollisionDetectionMode.ContinuousSpeculative;
+                    childrb.isKinematic = false;
+                    childrb.useGravity = true;
+                    childrb.constraints = RigidbodyConstraints.None;
+                    childrb.collisionDetectionMode = CollisionDetectionMode.ContinuousSpeculative;
                 }
             }
 

--- a/unity/Assets/Scripts/Break.cs
+++ b/unity/Assets/Scripts/Break.cs
@@ -69,7 +69,7 @@ public class Break : MonoBehaviour {
             // Disable this game object and spawn in the broken pieces
             Rigidbody rb = gameObject.GetComponent<Rigidbody>();
 
-            //befor disabling things, if this object is a receptacle, unparent all objects contained
+            //before disabling things, if this object is a receptacle, unparent all objects contained
             if (gameObject.GetComponent<SimObjPhysics>().IsReceptacle) {
                 GameObject objs = GameObject.Find("Objects");
                 foreach (GameObject go in gameObject.GetComponent<SimObjPhysics>().ContainedGameObjects()) {

--- a/unity/Assets/Scripts/Break.cs
+++ b/unity/Assets/Scripts/Break.cs
@@ -73,7 +73,6 @@ public class Break : MonoBehaviour {
             if (gameObject.GetComponent<SimObjPhysics>().IsReceptacle) {
                 GameObject objs = GameObject.Find("Objects");
                 foreach (GameObject go in gameObject.GetComponent<SimObjPhysics>().ContainedGameObjects()) {
-                    print($"{go.name}");
                     go.transform.SetParent(objs.transform);
                     Rigidbody childrb = go.GetComponent<Rigidbody>();
                     rb.useGravity = true;

--- a/unity/Assets/Scripts/InstantiatePrefabTest.cs
+++ b/unity/Assets/Scripts/InstantiatePrefabTest.cs
@@ -271,6 +271,35 @@ public class InstantiatePrefabTest : MonoBehaviour {
         // get the bounding box of the sim object we are trying to place
         BoxCollider oabb = sop.BoundingBox.GetComponent<BoxCollider>();
 
+        Vector3 oabb_original_center = new Vector3();
+        Vector3 oabb_original_size = new Vector3();
+
+        //store current bounds dimensions: center, size
+        oabb_original_center = oabb.center;
+        oabb_original_size = oabb.size;
+
+        if (sop.IsReceptacle) {
+            //make sure to enable BoundingBox boxcollider component otherwise BOUNDS IS ZERO
+            oabb.enabled = true;
+            Bounds b = oabb.bounds;
+
+            foreach (GameObject c in sop.ContainedGameObjects()) {
+
+                //grow the oabb to encapuslate any contained object colliders so check spawn area can account for more space occupied
+                BoxCollider cBB = c.GetComponent<SimObjPhysics>().BoundingBox.GetComponent<BoxCollider>();
+                cBB.enabled = true;
+                b.Encapsulate(cBB.bounds);
+                cBB.enabled = false;
+            }
+
+            oabb.center = b.center;
+            oabb.size = b.size;
+
+            //reset this to disabled, will enable later in once rotations start to be checked
+            oabb.enabled = false;
+
+        }
+
         // zero out rotation and velocity/angular velocity, then match the target receptacle's rotation
         sop.transform.rotation = rsp.ReceptacleBox.transform.rotation;
         Rigidbody sopRB = sop.GetComponent<Rigidbody>();
@@ -363,6 +392,10 @@ public class InstantiatePrefabTest : MonoBehaviour {
                 // translate position of the target sim object to the rsp.Point and offset in local y up
                 sop.transform.position = rsp.Point + rsp.ReceptacleBox.transform.up * (quat.distance + yoffset);// rsp.Point + sop.transform.up * DistanceFromBottomOfBoxToTransform;
                 sop.transform.rotation = quat.rotation;
+
+                //also reset the object's BoundingBox values at this point
+                oabb.center = oabb_original_center;
+                oabb.size = oabb_original_size;
 
                 // now to do a check to make sure the sim object is contained within the Receptacle box, and doesn't have
                 // bits of it hanging out
@@ -480,8 +513,9 @@ public class InstantiatePrefabTest : MonoBehaviour {
             }
         }
 
-        // reset rotation if no valid spawns found
-        // oh now we couldn't spawn it, all the spawn areas were not clear
+        // reset rotation, position, and bounding box original center and size if not able to be placed
+        oabb.center = oabb_original_center;
+        oabb.size = oabb_original_size;
         sop.transform.rotation = originalRot;
         sop.transform.position = originalPos;
         return false;

--- a/unity/Assets/Scripts/InstantiatePrefabTest.cs
+++ b/unity/Assets/Scripts/InstantiatePrefabTest.cs
@@ -486,6 +486,11 @@ public class InstantiatePrefabTest : MonoBehaviour {
                 // set true if we want objects to be stationary when placed. (if placed on uneven surface, object remains stationary)
                 // if false, once placed the object will resolve with physics (if placed on uneven surface object might slide or roll)
                 if (PlaceStationary == true) {
+                    // if the target receptacle is a pickupable receptacle, set it to kinematic true as will sence we are placing stationary
+                    if (rsp.ParentSimObjPhys.PrimaryProperty == SimObjPrimaryProperty.CanPickup) {
+                        rsp.ParentSimObjPhys.GetComponent<Rigidbody>().isKinematic = true;
+                    }
+
                     // make object being placed kinematic true
                     sop.GetComponent<Rigidbody>().collisionDetectionMode = CollisionDetectionMode.Discrete;
                     sop.GetComponent<Rigidbody>().isKinematic = true;
@@ -499,12 +504,6 @@ public class InstantiatePrefabTest : MonoBehaviour {
                         PhysicsRemoteFPSAgentController agent = GameObject.Find("FPSController").GetComponent<PhysicsRemoteFPSAgentController>();
                         agent.DropContainedObjectsStationary(sop); // use stationary version so that colliders are turned back on, but kinematics remain true
                     }
-
-                    // if the target receptacle is a pickupable receptacle, set it to kinematic true as will sence we are placing stationary
-                    if (rsp.ParentSimObjPhys.PrimaryProperty == SimObjPrimaryProperty.CanPickup) {
-                        rsp.ParentSimObjPhys.GetComponent<Rigidbody>().isKinematic = true;
-                    }
-
                 }
 
                 // place stationary false, let physics drop everything too

--- a/unity/Assets/Scripts/InstantiatePrefabTest.cs
+++ b/unity/Assets/Scripts/InstantiatePrefabTest.cs
@@ -177,6 +177,10 @@ public class InstantiatePrefabTest : MonoBehaviour {
         // try a number of spawnpoints in this specific receptacle up to the maxPlacementAttempts
         int tries = 0;
         foreach (ReceptacleSpawnPoint p in goodRsps) {
+            if(sop.Type == SimObjType.Plate)
+            {
+                print($"trying to place {sop.name} in {p.ParentSimObjPhys}");
+            }
             if (PlaceObject(sop, p, PlaceStationary, degreeIncrement, AlwaysPlaceUpright)) {
                 return true;
             }
@@ -283,6 +287,11 @@ public class InstantiatePrefabTest : MonoBehaviour {
             oabb.enabled = true;
             Bounds b = oabb.bounds;
 
+            if(sop.Type == SimObjType.Plate)
+            {
+                print($"number of contained objs by {sop.name} is {sop.ContainedGameObjects().Count}");
+            }
+
             foreach (GameObject c in sop.ContainedGameObjects()) {
 
                 //grow the oabb to encapuslate any contained object colliders so check spawn area can account for more space occupied
@@ -333,7 +342,7 @@ public class InstantiatePrefabTest : MonoBehaviour {
 
                 Vector3 Offset = oabb.ClosestPoint(oabb.transform.TransformPoint(oabb.center) + -rsp.ReceptacleBox.transform.up * 10); // was using rsp.point
                 BoxBottom = new Plane(rsp.ReceptacleBox.transform.up, Offset);
-                DistanceFromBoxBottomTosop = BoxBottom.GetDistanceToPoint(sop.transform.position);
+                DistanceFromBoxBottomTosop = Math.Abs(BoxBottom.GetDistanceToPoint(sop.transform.position));
 
                 ToCheck.Add(new RotationAndDistanceValues(DistanceFromBoxBottomTosop, sop.transform.rotation));
             }
@@ -388,10 +397,21 @@ public class InstantiatePrefabTest : MonoBehaviour {
         foreach (RotationAndDistanceValues quat in ToCheck) {
             // if spawn area is clear, spawn it and return true that we spawned it
             if (CheckSpawnArea(sop, rsp.Point + rsp.ParentSimObjPhys.transform.up * (quat.distance + yoffset), quat.rotation, false)) {
-
+                
+                if(sop.Type == SimObjType.Plate)
+                {
+                    print($"placing {sop.name} at rsp point {rsp.Point}");
+                    print($"whta the hell is being added to rsp.Point: {rsp.ReceptacleBox.transform.up * (quat.distance + yoffset)}");
+                    print($"i'm sorry what is the quat.distancE?: {quat.distance}");
+                }
                 // translate position of the target sim object to the rsp.Point and offset in local y up
                 sop.transform.position = rsp.Point + rsp.ReceptacleBox.transform.up * (quat.distance + yoffset);// rsp.Point + sop.transform.up * DistanceFromBottomOfBoxToTransform;
                 sop.transform.rotation = quat.rotation;
+
+                if(sop.Type == SimObjType.Plate)
+                {
+                    print($"{sop.name} position set to {sop.transform.position}");
+                }
 
                 //also reset the object's BoundingBox values at this point
                 oabb.center = oabb_original_center;

--- a/unity/Assets/Scripts/InstantiatePrefabTest.cs
+++ b/unity/Assets/Scripts/InstantiatePrefabTest.cs
@@ -364,6 +364,11 @@ public class InstantiatePrefabTest : MonoBehaviour {
                 sop.transform.position = rsp.Point + rsp.ReceptacleBox.transform.up * (quat.distance + yoffset);// rsp.Point + sop.transform.up * DistanceFromBottomOfBoxToTransform;
                 sop.transform.rotation = quat.rotation;
 
+                //ensure transforms are synced
+                if (!Physics.autoSyncTransforms) {
+                    Physics.SyncTransforms();
+                }
+
                 // now to do a check to make sure the sim object is contained within the Receptacle box, and doesn't have
                 // bits of it hanging out
 
@@ -432,8 +437,8 @@ public class InstantiatePrefabTest : MonoBehaviour {
 
                 // set true if we want objects to be stationary when placed. (if placed on uneven surface, object remains stationary)
                 // if false, once placed the object will resolve with physics (if placed on uneven surface object might slide or roll)
-                if (PlaceStationary == true) {
-                    // if the target receptacle is a pickupable receptacle, set it to kinematic true as will sence we are placing stationary
+                if (PlaceStationary) {
+                    // if the target receptacle is a pickupable receptacle, set it to kinematic true as will since we are placing stationary
                     if (rsp.ParentSimObjPhys.PrimaryProperty == SimObjPrimaryProperty.CanPickup || rsp.ParentSimObjPhys.PrimaryProperty == SimObjPrimaryProperty.Moveable) {
                         rsp.ParentSimObjPhys.GetComponent<Rigidbody>().isKinematic = true;
                     }

--- a/unity/Assets/Scripts/InstantiatePrefabTest.cs
+++ b/unity/Assets/Scripts/InstantiatePrefabTest.cs
@@ -487,7 +487,7 @@ public class InstantiatePrefabTest : MonoBehaviour {
                 // if false, once placed the object will resolve with physics (if placed on uneven surface object might slide or roll)
                 if (PlaceStationary == true) {
                     // if the target receptacle is a pickupable receptacle, set it to kinematic true as will sence we are placing stationary
-                    if (rsp.ParentSimObjPhys.PrimaryProperty == SimObjPrimaryProperty.CanPickup) {
+                    if (rsp.ParentSimObjPhys.PrimaryProperty == SimObjPrimaryProperty.CanPickup || rsp.ParentSimObjPhys.PrimaryProperty == SimObjPrimaryProperty.Moveable) {
                         rsp.ParentSimObjPhys.GetComponent<Rigidbody>().isKinematic = true;
                     }
 

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -3963,7 +3963,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             foreach (SimObjPhysics sop in simObjs) {
                 if (sop.Type.ToString() == objectType) {
                     if (sop.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanBreak)) {
-                        sop.GetComponent<Break>().Unbreakable = true;
+                        //look both in this object and children so things like Windows don't FREAK OUT
+                        sop.GetComponentInChildren<Break>().Unbreakable = true;
                     }
                 }
             }
@@ -3974,7 +3975,17 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             SimObjPhysics[] simObjs = GameObject.FindObjectsOfType(typeof(SimObjPhysics)) as SimObjPhysics[];
             foreach (SimObjPhysics sop in simObjs) {
                 if (sop.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanBreak)) {
-                    sop.GetComponent<Break>().Unbreakable = true;
+                    sop.GetComponentInChildren<Break>().Unbreakable = true;
+                }
+            }
+            actionFinished(true);
+        }
+
+        public void MakeAllObjectsBreakable() {
+            SimObjPhysics[] simObjs = GameObject.FindObjectsOfType(typeof(SimObjPhysics)) as SimObjPhysics[];
+            foreach (SimObjPhysics sop in simObjs) {
+                if (sop.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanBreak)) {
+                    sop.GetComponentInChildren<Break>().Unbreakable = false;
                 }
             }
             actionFinished(true);

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -3970,6 +3970,16 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             actionFinished(true);
         }
 
+        public void MakeAllObjectsUnbreakable() {
+            SimObjPhysics[] simObjs = GameObject.FindObjectsOfType(typeof(SimObjPhysics)) as SimObjPhysics[];
+            foreach (SimObjPhysics sop in simObjs) {
+                if (sop.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanBreak)) {
+                    sop.GetComponent<Break>().Unbreakable = true;
+                }
+            }
+            actionFinished(true);
+        }
+
         public void SetObjectPoses(ServerAction action) {
             // make sure objectPoses and also the Object Pose elements inside are initialized correctly
             if (action.objectPoses == null || action.objectPoses[0] == null) {

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4708,7 +4708,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             bool forceKinematic
         ) {
             if (target.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.Receptacle)) {
-                // print("dropping contained objects");
                 GameObject topObject = null;
 
                 foreach (SimObjPhysics sop in target.ContainedObjectReferences) {

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -3975,24 +3975,20 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
         public void MakeAllObjectsUnbreakable() {
-            SimObjPhysics[] simObjs = GameObject.FindObjectsOfType(typeof(SimObjPhysics)) as SimObjPhysics[];
-            if(simObjs != null) {
-                foreach (SimObjPhysics sop in simObjs) {
-                    if (sop.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanBreak)) {
-                        sop.GetComponentInChildren<Break>().Unbreakable = true;
-                    }
-                }
-            }
+            UpdateBreakabilityOfAllObjects(true);
 
-            actionFinished(true);
         }
 
         public void MakeAllObjectsBreakable() {
+            UpdateBreakabilityOfAllObjects(false);
+        }
+
+        private void UpdateBreakabilityOfAllObjects(bool isUnbreakable) {
             SimObjPhysics[] simObjs = GameObject.FindObjectsOfType(typeof(SimObjPhysics)) as SimObjPhysics[];
             if(simObjs != null) {
                 foreach (SimObjPhysics sop in simObjs) {
                     if (sop.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanBreak)) {
-                        sop.GetComponentInChildren<Break>().Unbreakable = false;
+                        sop.GetComponentInChildren<Break>().Unbreakable = isUnbreakable;
                     }
                 }
             }

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -3960,32 +3960,40 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
 
             SimObjPhysics[] simObjs = GameObject.FindObjectsOfType(typeof(SimObjPhysics)) as SimObjPhysics[];
-            foreach (SimObjPhysics sop in simObjs) {
-                if (sop.Type.ToString() == objectType) {
-                    if (sop.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanBreak)) {
-                        //look both in this object and children so things like Windows don't FREAK OUT
-                        sop.GetComponentInChildren<Break>().Unbreakable = true;
+            if(simObjs != null) {
+                foreach (SimObjPhysics sop in simObjs) {
+                    if (sop.Type.ToString() == objectType) {
+                        if (sop.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanBreak)) {
+                            //look both in this object and children so things like Windows don't FREAK OUT
+                            sop.GetComponentInChildren<Break>().Unbreakable = true;
+                        }
                     }
                 }
             }
+
             actionFinished(true);
         }
 
         public void MakeAllObjectsUnbreakable() {
             SimObjPhysics[] simObjs = GameObject.FindObjectsOfType(typeof(SimObjPhysics)) as SimObjPhysics[];
-            foreach (SimObjPhysics sop in simObjs) {
-                if (sop.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanBreak)) {
-                    sop.GetComponentInChildren<Break>().Unbreakable = true;
+            if(simObjs != null) {
+                foreach (SimObjPhysics sop in simObjs) {
+                    if (sop.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanBreak)) {
+                        sop.GetComponentInChildren<Break>().Unbreakable = true;
+                    }
                 }
             }
+
             actionFinished(true);
         }
 
         public void MakeAllObjectsBreakable() {
             SimObjPhysics[] simObjs = GameObject.FindObjectsOfType(typeof(SimObjPhysics)) as SimObjPhysics[];
-            foreach (SimObjPhysics sop in simObjs) {
-                if (sop.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanBreak)) {
-                    sop.GetComponentInChildren<Break>().Unbreakable = false;
+            if(simObjs != null) {
+                foreach (SimObjPhysics sop in simObjs) {
+                    if (sop.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanBreak)) {
+                        sop.GetComponentInChildren<Break>().Unbreakable = false;
+                    }
                 }
             }
             actionFinished(true);

--- a/unity/Assets/Scripts/PhysicsSceneManager.cs
+++ b/unity/Assets/Scripts/PhysicsSceneManager.cs
@@ -124,7 +124,7 @@ public class PhysicsSceneManager : MonoBehaviour {
                         rb.angularDrag += 0.01f;
 
 #if UNITY_EDITOR
-                        print(rb.transform.name + " is still in motion!");
+                        //print(rb.transform.name + " is still in motion!");
 #endif
                     } else {
                         // the velocities are small enough, assume object has come to rest and force this one to sleep
@@ -557,6 +557,10 @@ public class PhysicsSceneManager : MonoBehaviour {
             InstantiatePrefabTest spawner = gameObject.GetComponent<InstantiatePrefabTest>();
             foreach (GameObject gameObjToPlaceInReceptacle in gameObjsToPlaceInReceptacles) {
                 SimObjPhysics sopToPlaceInReceptacle = gameObjToPlaceInReceptacle.GetComponent<SimObjPhysics>();
+
+                if (staticPlacement) {
+                    sopToPlaceInReceptacle.GetComponent<Rigidbody>().isKinematic = true;
+                }
 
                 if (excludedSimObjects.Contains(sopToPlaceInReceptacle)) {
                     HowManyCouldntSpawn--;

--- a/unity/Assets/Scripts/PhysicsSceneManager.cs
+++ b/unity/Assets/Scripts/PhysicsSceneManager.cs
@@ -173,16 +173,6 @@ public class PhysicsSceneManager : MonoBehaviour {
         }
     }
 
-    // public void MakeBreakableAndSleep() {
-    //     foreach (SimObjPhysics sop in GameObject.FindObjectsOfType<SimObjPhysics>()) {
-    //         if(sop.IsBreakable) {
-    //             sop.GetComponent<Rigidbody>().Sleep();
-    //             sop.GetComponentInChildren<Break>().Unbreakable = false;
-    //         }
-
-    //     }
-    // }
-
     public void MakeAllObjectsMoveable() {
         foreach (SimObjPhysics sop in GameObject.FindObjectsOfType<SimObjPhysics>()) {
             // check if the sopType is something that can be hung
@@ -585,8 +575,8 @@ public class PhysicsSceneManager : MonoBehaviour {
                 foreach (SimObjPhysics receptacleSop in IterShuffleSimObjPhysicsDictList(objTypeToReceptacles, rng)) {
                     List<ReceptacleSpawnPoint> targetReceptacleSpawnPoints;
 
-                    if(receptacleSop.ContainedGameObjects().Count > 0) {
-                        //this object already has something in it, skip over it since we currently can't account for detecting bounds of a receptacle + any contained objects
+                    if(receptacleSop.ContainedGameObjects().Count > 0 && receptacleSop.IsPickupable) {
+                        //this pickupable object already has something in it, skip over it since we currently can't account for detecting bounds of a receptacle + any contained objects
                         continue;
                     }
 

--- a/unity/Assets/Scripts/PhysicsSceneManager.cs
+++ b/unity/Assets/Scripts/PhysicsSceneManager.cs
@@ -173,15 +173,15 @@ public class PhysicsSceneManager : MonoBehaviour {
         }
     }
 
-    public void MakeBreakableAndSleep() {
-        foreach (SimObjPhysics sop in GameObject.FindObjectsOfType<SimObjPhysics>()) {
-            if(sop.IsBreakable) {
-                sop.GetComponent<Rigidbody>().Sleep();
-                sop.GetComponentInChildren<Break>().Unbreakable = false;
-            }
+    // public void MakeBreakableAndSleep() {
+    //     foreach (SimObjPhysics sop in GameObject.FindObjectsOfType<SimObjPhysics>()) {
+    //         if(sop.IsBreakable) {
+    //             sop.GetComponent<Rigidbody>().Sleep();
+    //             sop.GetComponentInChildren<Break>().Unbreakable = false;
+    //         }
 
-        }
-    }
+    //     }
+    // }
 
     public void MakeAllObjectsMoveable() {
         foreach (SimObjPhysics sop in GameObject.FindObjectsOfType<SimObjPhysics>()) {
@@ -572,9 +572,9 @@ public class PhysicsSceneManager : MonoBehaviour {
                     sopToPlaceInReceptacle.GetComponent<Rigidbody>().isKinematic = true;
                 }
 
-                if(sopToPlaceInReceptacle.IsBreakable) {
-                    sopToPlaceInReceptacle.GetComponent<Break>().Unbreakable = true;
-                }
+                // if(sopToPlaceInReceptacle.IsBreakable) {
+                //     sopToPlaceInReceptacle.GetComponent<Break>().Unbreakable = true;
+                // }
 
                 if (excludedSimObjects.Contains(sopToPlaceInReceptacle)) {
                     HowManyCouldntSpawn--;

--- a/unity/Assets/Scripts/PhysicsSceneManager.cs
+++ b/unity/Assets/Scripts/PhysicsSceneManager.cs
@@ -571,6 +571,11 @@ public class PhysicsSceneManager : MonoBehaviour {
                 foreach (SimObjPhysics receptacleSop in IterShuffleSimObjPhysicsDictList(objTypeToReceptacles, rng)) {
                     List<ReceptacleSpawnPoint> targetReceptacleSpawnPoints;
 
+                    if(receptacleSop.ContainedGameObjects().Count > 0) {
+                        //this object already has something in it, skip over it since we currently can't account for detecting bounds of a receptacle + any contained objects
+                        continue;
+                    }
+
                     // check if the target Receptacle is an ObjectSpecificReceptacle
                     // if so, if this game object is compatible with the ObjectSpecific restrictions, place it!
                     // this is specifically for things like spawning a mug inside a coffee maker

--- a/unity/Assets/Scripts/PhysicsSceneManager.cs
+++ b/unity/Assets/Scripts/PhysicsSceneManager.cs
@@ -173,6 +173,16 @@ public class PhysicsSceneManager : MonoBehaviour {
         }
     }
 
+    public void MakeBreakableAndSleep() {
+        foreach (SimObjPhysics sop in GameObject.FindObjectsOfType<SimObjPhysics>()) {
+            if(sop.IsBreakable) {
+                sop.GetComponent<Rigidbody>().Sleep();
+                sop.GetComponentInChildren<Break>().Unbreakable = false;
+            }
+
+        }
+    }
+
     public void MakeAllObjectsMoveable() {
         foreach (SimObjPhysics sop in GameObject.FindObjectsOfType<SimObjPhysics>()) {
             // check if the sopType is something that can be hung
@@ -560,6 +570,10 @@ public class PhysicsSceneManager : MonoBehaviour {
 
                 if (staticPlacement) {
                     sopToPlaceInReceptacle.GetComponent<Rigidbody>().isKinematic = true;
+                }
+
+                if(sopToPlaceInReceptacle.IsBreakable) {
+                    sopToPlaceInReceptacle.GetComponent<Break>().Unbreakable = true;
                 }
 
                 if (excludedSimObjects.Contains(sopToPlaceInReceptacle)) {

--- a/unity/Assets/Scripts/SimObjPhysics.cs
+++ b/unity/Assets/Scripts/SimObjPhysics.cs
@@ -321,6 +321,7 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
             }
 
             // Update SimObject's BoundingBox collider to match new bounds
+            this.BoundingBox.transform.localPosition = Vector3.zero;
             this.BoundingBox.transform.rotation = Quaternion.identity;
             this.BoundingBox.GetComponent<BoxCollider>().center = newBB.center;
             this.BoundingBox.GetComponent<BoxCollider>().size = newBB.extents * 2.0f;

--- a/unity/Assets/UnitTests/TestPutObject.cs
+++ b/unity/Assets/UnitTests/TestPutObject.cs
@@ -49,11 +49,13 @@ namespace Tests {
 
             GameObject creditCard = GameObject.Find("CreditCard_acee2f3e");
 
+            Debug.Log(creditCard.transform.position.x);
+
             bool result = false;
             result = Mathf.Approximately(creditCard.transform.position.x, -0.1972949f);
             Assert.AreEqual(result, true);
 
-            result = Mathf.Approximately(creditCard.transform.position.y, 1.105045f);
+            result = Mathf.Approximately(creditCard.transform.position.y, 1.106945f);
             Assert.AreEqual(result, true);
 
             result = Mathf.Approximately(creditCard.transform.position.z, 0.7573217f);
@@ -105,7 +107,7 @@ namespace Tests {
             result = Mathf.Approximately(creditCard.transform.position.x, -0.4736856f);
             Assert.AreEqual(result, true);
 
-            result = Mathf.Approximately(creditCard.transform.position.y, 1.105045f);
+            result = Mathf.Approximately(creditCard.transform.position.y, 1.106945f);
             Assert.AreEqual(result, true);
 
             result = Mathf.Approximately(creditCard.transform.position.z, 0.7573217f);

--- a/unity/Assets/UnitTests/TestPutObject.cs
+++ b/unity/Assets/UnitTests/TestPutObject.cs
@@ -49,8 +49,6 @@ namespace Tests {
 
             GameObject creditCard = GameObject.Find("CreditCard_acee2f3e");
 
-            Debug.Log(creditCard.transform.position.x);
-
             bool result = false;
             result = Mathf.Approximately(creditCard.transform.position.x, -0.1972949f);
             Assert.AreEqual(result, true);


### PR DESCRIPTION
- adds a line to ensure the child game object used for `BoundingBox` for all sim objects correctly has its local position zeroed out. 

- forces any objects that are about to break to drop an child objects contained by them. This fixes issues of some objects disappearing on `InitialRandomSpawn` when certain receptacles break. Previously, if something like an Apple was placed inside a breakable plate via `InitialRandomSpawn` with `placeStationary = True` it would not be "dropped" by the receptacle and was deactivated a the plate breaks.

- adds new `MakeAllObjectsUnbreakable` and `MakeAllObjectsBreakable` actions to be used with `InitialRandomSpawn`

- adds a check to not reposition receptacles that have had another object spawn inside of them during the `InitialRandomSpawn` process. The current logic only checks if the new position of a receptacle has enough free space for the receptacle only, not any objects also "contained" by the receptacle. One cause of objects breaking were sequences like: 

```
Saltshaker spawns inside Plate,

Plate (+ Saltshaker) spawns inside Microwave since Plate had enough room to fit in microwave, 

Saltshaker causes plate to be shoved down into the bottom of the microwave since the saltshaker is now clipping with the top of the microwave, 

plate breaks (which also previously deleted the Saltshaker since it wasn't decoupled from the plate)
```

- The above change means fewer objects will be shuffled around, which is a major (albeit temporary) change in the random spawn logic. This will be fixed with the full `InitialRandomSpawn` rework to come.

The new way to ensure no objects break on `InitialRandomSpawn` is to do something like the following following scene initialization:

```python
    event = controller.step(  
        action="MakeAllObjectsUnbreakable"
    )

    event = controller.step(
        action="InitialRandomSpawn",
        randomSeed=seed,
        forceVisible=False,
        numPlacementAttempts=5,
        placeStationary=True
    )

    event = controller.step(  
    action="MakeAllObjectsBreakable"
    )
```

Note that these actions before and after `InitialRandomSpawn` can't currently be integrated into `InitialRandomSpawn` itself. I tried automatically calling these but some sort of physics resolution external to `InitialRandomSpawn` is causing issues. I believe in order to integrate this automatically, it will require a rewrite of the entire `InitialRandomSpawn` sequence which is being done in a future update anyway.

Additionally [here is a colab demonstrating the fix](https://colab.research.google.com/drive/1nJCa5lym3f7mcMzcq7VWC01MsUHlKdVe?usp=sharing).
These changes fix issues in regards to #818 