### PR TITLE
Held object yaw rotation fix

### DIFF
--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -2049,7 +2049,7 @@ def test_rotate_hand(controller):
     h2 = controller.step(action="RotateHeldObject", yaw=90).metadata["hand"]
 
     assert_near(h1["position"], h2["position"])
-    assert h2["rotation"]["y"] - h1["rotation"]["y"] == 90
+    assert h2["rotation"]["y"] - h1["rotation"]["y"] == -90
     assert h2["rotation"]["x"] == h1["rotation"]["x"]
     assert h2["rotation"]["z"] == h1["rotation"]["z"]
 
@@ -2083,8 +2083,8 @@ def test_rotate_hand(controller):
     assert_near(h1["position"], h2["position"])
     assert_near(h1["rotation"], dict(x=0, y=180, z=0))
 
-    # Unity will normalize the rotation, so x=90, y=270, and z=270 becomes x=90, y=0, z=0
-    assert_near(h2["rotation"], dict(x=90, y=0, z=0))
+    # Unity will normalize the rotation
+    assert_near(h2["rotation"], dict(x=90, y=180, z=0))
 
     # local rotation test
     controller.reset()

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -461,7 +461,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 if (!manualInteract) {
                     DefaultAgentHand();
                 }
-                
+
                 actionFinished(true);
             } else {
                 errorMessage = $"a held item: {ItemInHand.transform.name} with something if agent rotates Left {degrees} degrees";
@@ -3065,7 +3065,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             // NOTE: -roll is used so that rotating an object rightward is positive
             AgentHand.transform.Rotate(
-                new Vector3(pitch, yaw, -roll), Space.World
+                new Vector3(pitch, -yaw, -roll), Space.World
             );
             transform.rotation = agentRot;
 
@@ -3080,7 +3080,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         // rotate the hand if there is an object in it
         public void RotateHandRelative(float x = 0, float y = 0, float z = 0) {
             // NOTE: -z is used for backwards compatibility.
-            RotateHeldObject(pitch: x, yaw: y, roll: -z);
+            RotateHeldObject(pitch: x, yaw: -y, roll: -z);
         }
 
         // action to return points from a grid that have an experiment receptacle below it


### PR DESCRIPTION
Starting from:
![image](https://user-images.githubusercontent.com/28768645/126406932-b673fe34-c3fe-49c8-b2cd-970c162e1bb0.png)

Fixes positive yaw to rotate clockwise:
![image](https://user-images.githubusercontent.com/28768645/126406969-7eaba535-fdbc-4db6-86e5-5ccd61f5429c.png)

Instead of counterclockwise (what is currently there):
![image](https://user-images.githubusercontent.com/28768645/126406995-21305235-b8d3-4665-8e89-22dc672e1a1b.png)

Missed this in #770, presumably because I might only using testing it with symmetric objects about the z axis.
