### PR TITLE
Rename `ObjectTemperature` to `temperature`

### DIFF
--- a/ai2thor/tests/data/arm-metadata-schema.json
+++ b/ai2thor/tests/data/arm-metadata-schema.json
@@ -224,7 +224,7 @@
           "isCooked": {
             "type": "boolean"
           },
-          "ObjectTemperature": {
+          "temperature": {
             "type": "string"
           },
           "isHeatSource": {
@@ -377,7 +377,7 @@
           }
         },
         "required": [
-          "ObjectTemperature",
+          "temperature",
           "axisAlignedBoundingBox",
           "breakable",
           "canBeUsedUp",

--- a/ai2thor/tests/data/metadata-schema.json
+++ b/ai2thor/tests/data/metadata-schema.json
@@ -88,7 +88,7 @@
           "isCooked": {
             "type": "boolean"
           },
-          "ObjectTemperature": {
+          "temperature": {
             "type": "string"
           },
           "isHeatSource": {
@@ -241,7 +241,7 @@
           }
         },
         "required": [
-          "ObjectTemperature",
+          "temperature",
           "axisAlignedBoundingBox",
           "breakable",
           "canBeUsedUp",

--- a/doc/static/ReleaseNotes/ReleaseNotes_2.0.md
+++ b/doc/static/ReleaseNotes/ReleaseNotes_2.0.md
@@ -59,7 +59,7 @@ New metadata values have been added to represent new state changes:
 - **canFillWithLiquid**
 - **isFilledWithLiquid**
 - **dirtyable**
-- **isDirty**
+- \*\*temperature
 - **cookable**
 - **isCooked**
 - **sliceable**

--- a/doc/static/ReleaseNotes/ReleaseNotes_2.0.md
+++ b/doc/static/ReleaseNotes/ReleaseNotes_2.0.md
@@ -59,14 +59,14 @@ New metadata values have been added to represent new state changes:
 - **canFillWithLiquid**
 - **isFilledWithLiquid**
 - **dirtyable**
-- \*\*temperature
+- **isDirty**
 - **cookable**
 - **isCooked**
 - **sliceable**
 - **isSliced**
 - **canBeUsedUp**
 - **isUsedUp**
-- **objectTemperature**
+- **temperature**
 - **isHeatSource**
 - **isColdSource**
 - **salientMaterials**

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1387,7 +1387,7 @@ public class ObjectMetadata {
                          //
                          // temperature placeholder values, might get more specific later with degrees but for now just track these three states
     public enum Temperature { RoomTemp, Hot, Cold };
-    public string ObjectTemperature;// return current abstracted temperature of object as a string (RoomTemp, Hot, Cold)
+    public string temperature;// return current abstracted temperature of object as a string (RoomTemp, Hot, Cold)
                                     //
     public bool isHeatSource;// can change other object temp to hot
     public bool isColdSource;// can change other object temp to cool

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1355,69 +1355,121 @@ public class ObjectMetadata {
     public string name;
     public Vector3 position;
     public Vector3 rotation;
+
     // public float cameraHorizon; moved to AgentMetadata, objects don't have a camerahorizon
     public bool visible;
-    public bool obstructed; // if true, object is obstructed by something and actions cannot be performed on it. This means an object behind glass will be obstructed=True and visible=True
+
+    // If true, object is obstructed by something and actions cannot be performed on it.
+    // This means an object behind glass will be obstructed=True and visible=True
+    public bool obstructed;
+
+    // is this object a receptacle?
     public bool receptacle;
-    ///
-    // note: some objects are not themselves toggleable, because they must be toggled on/off via another sim object (stove knob -> stove burner)
-    public bool toggleable;// is this object able to be toggled on/off directly?
 
-    // note some objects can still return the istoggle value even if they cannot directly be toggled on off (stove burner -> stove knob)
-    public bool isToggled;// is this object currently on or off? true is on
-    ///
+    // note: some objects are not themselves toggleable, because they must be toggled
+    // on/off via another sim object (stove knob -> stove burner)
+    // is this object able to be toggled on/off directly?
+    public bool toggleable;
+
+    // note some objects can still return the istoggle value even if they cannot directly
+    // be toggled on off (stove burner -> stove knob)
+    // is this object currently on or off? true is on
+    public bool isToggled;
+
+    // can this object be broken?
     public bool breakable;
-    public bool isBroken;// is this object broken?
-    ///
-    public bool canFillWithLiquid;// objects filled with liquids
-    public bool isFilledWithLiquid;// is this object filled with some liquid? - similar to 'depletable' but this is for liquids
-    public string fillLiquid; // coffee, wine, water
-    ///
-    public bool dirtyable;// can toggle object state dirty/clean
-    public bool isDirty;// is this object in a dirty or clean state?
-    ///
-    public bool canBeUsedUp;// for objects that can be emptied or depleted (toilet paper, paper towels, tissue box etc) - specifically not for liquids
+
+    // is this object broken?
+    public bool isBroken;
+
+    // objects filled with liquids
+    public bool canFillWithLiquid;
+
+    // is this object filled with some liquid? - similar to 'depletable' but this is for liquids
+    public bool isFilledWithLiquid;
+
+    // coffee, wine, water
+    public string fillLiquid;
+
+    // can toggle object state dirty/clean
+    public bool dirtyable;
+
+    // is this object in a dirty or clean state?
+    public bool isDirty;
+
+    // for objects that can be emptied or depleted (toilet paper, paper towels, tissue box etc)
+    // - specifically not for liquids.
+    public bool canBeUsedUp;
+
+    // is this object currently used up?
     public bool isUsedUp;
-    ///
-    public bool cookable;// can this object be turned to a cooked state? object should not be able to toggle back to uncooked state with contextual interactions, only a direct action
-    public bool isCooked;// is it cooked right now? - context sensitive objects might set this automatically like Toaster/Microwave/ Pots/Pans if isHeated = true
-                         // ///
-                         // public bool abletocook;// can this object be heated up by a "fire" tagged source? -  use this for Pots/Pans
-                         // public bool isabletocook;// object is in contact with a "fire" tagged source (stove burner), if this is heated any object cookable object touching it will be switched to cooked - again use for Pots/Pans
-                         //
-                         // temperature placeholder values, might get more specific later with degrees but for now just track these three states
-    public enum Temperature { RoomTemp, Hot, Cold };
-    public string temperature;// return current abstracted temperature of object as a string (RoomTemp, Hot, Cold)
-                                    //
-    public bool isHeatSource;// can change other object temp to hot
-    public bool isColdSource;// can change other object temp to cool
-                             //
-    public bool sliceable;// can this be sliced in some way?
-    public bool isSliced;// currently sliced?
-    ///
+
+    // can this object be turned to a cooked state? object should not be able to toggle
+    // back to uncooked state with contextual interactions, only a direct action
+    public bool cookable;
+
+    // is it cooked right now? - context sensitive objects might set this
+    // automatically like Toaster/Microwave/Pots/Pans if isHeated = true
+    // temperature placeholder values, might get more specific later
+    // with degrees but for now just track these three states
+    public bool isCooked;
+
+    // return current abstracted temperature of object as a string (RoomTemp, Hot, Cold)
+    public string temperature;
+
+    // can change other object temp to hot
+    public bool isHeatSource;
+
+    // can change other object temp to cool
+    public bool isColdSource;
+
+    // can this be sliced in some way?
+    public bool sliceable;
+
+    // currently sliced?
+    public bool isSliced;
+
+    // can this object be opened?
     public bool openable;
+
+    // is this object currently opened?
     public bool isOpen;
-    public float openness; // if the object is openable, what is the current openness? It's a normalized percentage from [0:1]
-    ///
+
+    // if the object is openable, what is the current openness? It's a normalized value from [0:1]
+    public float openness;
+
+    // can this object be picked up?
     public bool pickupable;
-    public bool isPickedUp;// if the pickupable object is actively being held by the agent
-    public bool moveable;// if the object is moveable, able to be pushed/affected by physics but is too big to pick up
 
-    public float mass;// mass is only for moveable and pickupable objects
+    // if the pickupable object is actively being held by the agent
+    public bool isPickedUp;
 
-    // salient materials are only for pickupable and moveable objects, for now static only objects do not report material back since we have to assign them manually
-    public enum ObjectSalientMaterial { Metal, Wood, Plastic, Glass, Ceramic, Stone, Fabric, Rubber, Food, Paper, Wax, Soap, Sponge, Organic, Leather } // salient materials that make up an object (ie: cell phone - metal, glass)
+    // if the object is moveable, able to be pushed/affected by physics but is too big to pick up
+    public bool moveable;
 
-    public string[] salientMaterials; // salient materials that this object is made of as strings (see enum above). This is only for objects that are Pickupable or Moveable
-    ///
+    // mass is only for moveable and pickupable objects
+    public float mass;
+
+    // Salient materials that this object is made of as strings (see enum above).
+    // This is only for objects that are Pickupable or Moveable
+    public string[] salientMaterials;
+
     public string[] receptacleObjectIds;
-    public float distance;// dintance fromm object's transform to agent transform
-    public String objectType;
+
+    // distance from object's transform to agent transform
+    public float distance;
+
+    // what type of object is this?
+    public string objectType;
+
+    // uuid of the object
     public string objectId;
-    // public string parentReceptacle;
+
     public string[] parentReceptacles;
-    // public float currentTime;
-    public bool isMoving;// true if this game object currently has a non-zero velocity
+
+    // true if this game object currently has a non-zero velocity
+    public bool isMoving;
+
     public AxisAlignedBoundingBox axisAlignedBoundingBox;
     public ObjectOrientedBoundingBox objectOrientedBoundingBox;
 
@@ -1964,21 +2016,43 @@ public enum VisibilityScheme {
     Distance
 }
 
+public enum Temperature {
+    RoomTemp,
+    Hot,
+    Cold
+};
 
+// Salient materials are only for pickupable and moveable objects,
+// for now static only objects do not report material back since we have to assign them manually
+// They are the materials that make up an object (ie: cell phone - metal, glass).
+public enum SalientObjectMaterial {
+    Metal,
+    Wood,
+    Plastic,
+    Glass,
+    Ceramic,
+    Stone,
+    Fabric,
+    Rubber,
+    Food,
+    Paper,
+    Wax,
+    Soap,
+    Sponge,
+    Organic,
+    Leather
+};
 
 [Serializable]
 public class ControllerInitialization {
     public Dictionary<string, TypedVariable> variableInitializations;
 }
 
-
 [Serializable]
 public class TypedVariable {
     public string type;
     public object value;
 }
-
-
 
 public class ShouldSerializeContractResolver : DefaultContractResolver {
     public static readonly ShouldSerializeContractResolver Instance = new ShouldSerializeContractResolver();

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1645,7 +1645,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
 
             // object temperature to string
-            objMeta.ObjectTemperature = simObj.CurrentObjTemp.ToString();
+            objMeta.temperature = simObj.CurrentObjTemp.ToString();
 
             objMeta.pickupable = simObj.IsPickupable;
             objMeta.isPickedUp = simObj.isPickedUp;// returns true for if this object is currently being held by the agent

--- a/unity/Assets/Scripts/ColdZone.cs
+++ b/unity/Assets/Scripts/ColdZone.cs
@@ -17,7 +17,7 @@ public class ColdZone : MonoBehaviour {
         // if any simobjphys are touching this zone, set their temperature values to Cold
         if (other.GetComponentInParent<SimObjPhysics>()) {
             SimObjPhysics sop = other.GetComponentInParent<SimObjPhysics>();
-            sop.CurrentTemperature = ObjectMetadata.Temperature.Cold;
+            sop.CurrentTemperature = Temperature.Cold;
 
             if (sop.HowManySecondsUntilRoomTemp != sop.GetTimerResetValue()) {
                 sop.HowManySecondsUntilRoomTemp = sop.GetTimerResetValue();

--- a/unity/Assets/Scripts/DroneFPSAgentController.cs
+++ b/unity/Assets/Scripts/DroneFPSAgentController.cs
@@ -230,7 +230,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
 
             // object temperature to string
-            objMeta.ObjectTemperature = simObj.CurrentObjTemp.ToString();
+            objMeta.temperature = simObj.CurrentObjTemp.ToString();
 
             objMeta.pickupable = simObj.PrimaryProperty == SimObjPrimaryProperty.CanPickup;// can this object be picked up?
             objMeta.isPickedUp = simObj.isPickedUp;// returns true for if this object is currently being held by the agent

--- a/unity/Assets/Scripts/Fill.cs
+++ b/unity/Assets/Scripts/Fill.cs
@@ -87,7 +87,7 @@ public class Fill : MonoBehaviour {
         if (whichLiquid == "coffee") {
             // coffee is hot!
             SimObjPhysics sop = gameObject.GetComponent<SimObjPhysics>();
-            sop.CurrentTemperature = ObjectMetadata.Temperature.Hot;
+            sop.CurrentTemperature = Temperature.Hot;
             if (sop.HowManySecondsUntilRoomTemp != sop.GetTimerResetValue()) {
                 sop.HowManySecondsUntilRoomTemp = sop.GetTimerResetValue();
             }

--- a/unity/Assets/Scripts/HeatZone.cs
+++ b/unity/Assets/Scripts/HeatZone.cs
@@ -21,7 +21,7 @@ public class HeatZone : MonoBehaviour {
         if (other.GetComponentInParent<SimObjPhysics>()) {
             // Set temperature of object to HOT
             SimObjPhysics sop = other.GetComponentInParent<SimObjPhysics>();
-            sop.CurrentTemperature = ObjectMetadata.Temperature.Hot;
+            sop.CurrentTemperature = Temperature.Hot;
 
             if (sop.HowManySecondsUntilRoomTemp != sop.GetTimerResetValue()) {
                 sop.HowManySecondsUntilRoomTemp = sop.GetTimerResetValue();

--- a/unity/Assets/Scripts/SimObjPhysics.cs
+++ b/unity/Assets/Scripts/SimObjPhysics.cs
@@ -65,7 +65,7 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
     private float RBoriginalAngularDrag;
 
     [Header("Salient Materials")] // if this object is moveable or pickupable, set these up
-    public ObjectMetadata.ObjectSalientMaterial[] salientMaterials;
+    public SalientObjectMaterial[] salientMaterials;
 
     private PhysicsMaterialValues[] OriginalPhysicsMaterialValuesForAllMyColliders = null;
 
@@ -75,7 +75,7 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
     public List<ReceptacleSpawnPoint> MySpawnPoints = new List<ReceptacleSpawnPoint>();
 
     // keep track of this object's current temperature (abstracted to three states, RoomTemp/Hot/Cold)
-    public ObjectMetadata.Temperature CurrentTemperature = ObjectMetadata.Temperature.RoomTemp;
+    public Temperature CurrentTemperature = Temperature.RoomTemp;
 
     // value for how long it should take this object to get back to room temperature from hot/cold
     public float HowManySecondsUntilRoomTemp = 10f;
@@ -568,7 +568,7 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
     /// end placeholder stuff
 
     // return temperature enum here
-    public ObjectMetadata.Temperature CurrentObjTemp {
+    public Temperature CurrentObjTemp {
         get {
             return CurrentTemperature;
         }
@@ -913,10 +913,10 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
         if (sceneManager.AllowDecayTemperature)// only do this if the scene is initialized to use Temperature decay over time
         {
             // if this object is either hot or col, begin a timer that counts until the object becomes room temperature again
-            if (CurrentTemperature != ObjectMetadata.Temperature.RoomTemp && StartRoomTempTimer == true) {
+            if (CurrentTemperature != Temperature.RoomTemp && StartRoomTempTimer == true) {
                 HowManySecondsUntilRoomTemp -= Time.deltaTime;
                 if (HowManySecondsUntilRoomTemp < 0) {
-                    CurrentTemperature = ObjectMetadata.Temperature.RoomTemp;
+                    CurrentTemperature = Temperature.RoomTemp;
                     HowManySecondsUntilRoomTemp = TimerResetValue;
                 }
             }


### PR DESCRIPTION
### Overview

This is a backwards breaking change (in line with https://github.com/allenai/ai2thor/pull/824) in the object metadata that renames the `ObjectTemperature` key to `temperature`.

### Motivation

The capitalization of the `ObjectTemperature` metadata key is inconsistent with all the other metadata keys (i.e., should be `camelCase`).

### Old references

- ObjectTemperature was referenced a few times in the documentation (see: https://github.com/allenai/ai2thor.allenai.org/search?q=ObjectTemperature). However, these were mostly in the description of temperature decay descriptions.
- However, on the [2.0 release note](https://github.com/allenai/ai2thor/blob/main/doc/static/ReleaseNotes/ReleaseNotes_2.0.md#state-changes-added-to-object-metadata), it was actually incorrectly documented, saying that the key was `objectTemperature` instead of `ObjectTemperature`.
- As far as I can tell, it has never been used.