### PR TITLE
disp_screen indexing bug fix

### DIFF
--- a/ai2thor/platform.py
+++ b/ai2thor/platform.py
@@ -115,8 +115,8 @@ class Linux64(BaseLinuxPlatform):
                         display_screen_str,
                         width,
                         height,
-                        disp_screen["width_in_pixels"],
-                        disp_screen["height_in_pixels"],
+                        disp_screen.screen()["width_in_pixels"],
+                        disp_screen.screen()["height_in_pixels"],
                     )
                 )
 


### PR DESCRIPTION
Was getting the error:
```
---------------------------------------------------------------------------

TypeError                                 Traceback (most recent call last)

<ipython-input-2-18ecdd6422e8> in <module>()
----> 1 controller = Controller(makeAgentsVisible=False, width=1000, height=1000)

4 frames

/usr/local/lib/python3.7/dist-packages/ai2thor/platform.py in _validate_screen(cls, display_screen_str, width, height)
    116                         width,
    117                         height,
--> 118                         disp_screen["width_in_pixels"],
    119                         disp_screen["height_in_pixels"],
    120                     )

TypeError: 'Display' object is not subscriptable
```

Based on https://github.com/allenai/ai2thor/blob/main/ai2thor/platform.py#L109, it looks like one needs to call `.screen()` first.