### PR TITLE
Remove TextmeshPro

### DIFF
--- a/unity/Packages/manifest.json
+++ b/unity/Packages/manifest.json
@@ -18,7 +18,6 @@
     "com.unity.multiplayer-hlapi": "1.0.8",
     "com.unity.postprocessing": "2.3.0",
     "com.unity.test-framework": "1.1.24",
-    "com.unity.textmeshpro": "2.0.1",
     "com.unity.timeline": "1.2.6",
     "com.unity.ugui": "1.0.0",
     "jillejr.newtonsoft.json-for-unity": "12.0.301",

--- a/unity/Packages/packages-lock.json
+++ b/unity/Packages/packages-lock.json
@@ -76,15 +76,6 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.textmeshpro": {
-      "version": "2.0.1",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.ugui": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
     "com.unity.timeline": {
       "version": "1.2.6",
       "depth": 0,


### PR DESCRIPTION
Removing TextMeshPro package. Package is unused.

For completeness, the motivation behind the PR is to try and get all the package requirements between the CloudRendering build (Unity 2021.2 Alpha) and our current build to be the same so we don't have to maintain a separate branch for the CloudRendering code.