### PR TITLE
ai2thor-xorg - adding Interactive false to Screen section

### DIFF
--- a/scripts/ai2thor-xorg
+++ b/scripts/ai2thor-xorg
@@ -159,6 +159,7 @@ Section "Screen"
     Device         "Device{device_id}"
     DefaultDepth    24
     Option         "AllowEmptyInitialConfiguration" "True"
+    Option         "Interactive" "False"
     SubSection     "Display"
         Depth       24
         Virtual {width} {height}


### PR DESCRIPTION
Setting Interactive to "False" to prevent processes from getting killed.

https://download.nvidia.com/XFree86/Linux-x86_64/340.108/README/xconfigoptions.html