### PR TITLE
Change Asset Metadata Type

### DIFF
--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -4361,10 +4361,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             var metadata = new Dictionary<string, Dictionary<string, object>>();
             foreach (GameObject p in assetDb.prefabs) {
-                if (p.GetComponent<SimObjPhysics>() == null) {
-                    continue;
-                }
-
                 var simObj = p.GetComponent<SimObjPhysics>();
                 var bb = simObj.AxisAlignedBoundingBox;
 

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -4359,22 +4359,31 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 return;
             }
 
-            var metadata = assetDb.prefabs.Where(p => p.GetComponent<SimObjPhysics>() != null).Select(
-                p => {
-                    var simObj = p.GetComponent<SimObjPhysics>();
-                    var bb = simObj.AxisAlignedBoundingBox;
-                    return new AssetMetadata() {
-                        id = simObj.gameObject.name,
-                        type = simObj.Type.ToString(),
-                        primaryProperty = simObj.PrimaryProperty.ToString(),
-                        secondaryProperties = simObj.SecondaryProperties.Select(s => s.ToString()).ToList(),
-                        boundingBox = new BoundingBox() {
-                            min = bb.center - bb.size / 2.0f,
-                            max = bb.center + bb.size / 2.0f
-                        }
-                    };
+            var metadata = new Dictionary<string, Dictionary<string, object>>();
+            foreach (GameObject p in assetDb.prefabs) {
+                if (p.GetComponent<SimObjPhysics>() == null) {
+                    continue;
                 }
-            ).ToList();
+
+                var simObj = p.GetComponent<SimObjPhysics>();
+                var bb = simObj.AxisAlignedBoundingBox;
+
+                // TODO: no objects should have duplicate names.
+                if (metadata.ContainsKey(simObj.gameObject.name)) {
+                    continue;
+                }
+
+                metadata.Add(simObj.gameObject.name, new Dictionary<string, object>() {
+                    ["objectType"] = simObj.Type.ToString(),
+                    ["primaryProperty"] = simObj.PrimaryProperty.ToString(),
+                    ["secondaryProperties"] = simObj.SecondaryProperties.Select(s => s.ToString()).ToList(),
+                    ["boundingBox"] = new BoundingBox() {
+                        min = bb.center - bb.size / 2.0f,
+                        max = bb.center + bb.size / 2.0f
+                    }
+                });
+            }
+
             actionFinished(true, metadata);
         }
 

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -4361,6 +4361,10 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             var metadata = new Dictionary<string, Dictionary<string, object>>();
             foreach (GameObject p in assetDb.prefabs) {
+                if (p.GetComponent<SimObjPhysics>() == null) {
+                    continue;
+                }
+
                 var simObj = p.GetComponent<SimObjPhysics>();
                 var bb = simObj.AxisAlignedBoundingBox;
 


### PR DESCRIPTION
Instead of returning a list of:
```python
[
    {
        "id": "Blinds",
        "type": "Blinds",
        "primaryProperty": "Static",
        "secondaryProperties": [],
        "boundingBox": {
            "min": {
                "x": -0.42500001192092896,
                "y": 2.0952999591827393,
                "z": -1.4369999170303345
            },
            "max": {
                "x": 0.6539999842643738,
                "y": 2.3373000621795654,
                "z": -1.4369999170303345
            }
        }
    },
    {
        "id": "Mirror",
        "type": "Mirror",
        "primaryProperty": "Static",
        "secondaryProperties": [],
        "boundingBox": {
            "min": {
                "x": -0.8920000791549683,
                "y": 1.069000005722046,
                "z": 0.5980000495910645
            },
            "max": {
                "x": -0.8450000286102295,
                "y": 1.7070000171661377,
                "z": 1.125
            }
        }
    },
    ...,
]
```
it returns a dict with ids as keys:
```python
{
    "Blinds": {
        "objectType": "Blinds",
        "primaryProperty": "Static",
        "secondaryProperties": [],
        "boundingBox": {
            "min": {
                "x": -0.42500001192092896,
                "y": 2.0952999591827393,
                "z": -1.4369999170303345
            },
            "max": {
                "x": 0.6539999842643738,
                "y": 2.3373000621795654,
                "z": -1.4369999170303345
            }
        }
    },
    "Mirror": {
        "objectType": "Mirror",
        "primaryProperty": "Static",
        "secondaryProperties": [],
        "boundingBox": {
            "min": {
                "x": -0.8920000791549683,
                "y": 1.069000005722046,
                "z": 0.5980000495910645
            },
            "max": {
                "x": -0.8450000286102295,
                "y": 1.7070000171661377,
                "z": 1.125
            }
        }
    },
    ...
}
```

Also renames `type` to `objectType` in the metadata, for consistency with the current naming and to avoid using `type` as it is a reserved word in Python.