### PR TITLE
Add platform as Controller() constructor param

### DIFF
--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -1138,9 +1138,10 @@ class Controller(object):
             platform_system(), self.width, self.height, self.x_display, self.headless
         )
 
-        candidate_platforms = ai2thor.platform.select_platforms(request)
 
-        if platform is not None:
+        if platform is None:
+            candidate_platforms = ai2thor.platform.select_platforms(request)
+        else:
             candidate_platforms = [platform]
 
         builds = self.find_platform_builds(candidate_platforms, request, commits, releases_dir, local_build)

--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -21,7 +21,8 @@ import subprocess
 import shutil
 import re
 import os
-import platform
+from platform import system  as platform_system
+from platform import architecture  as platform_architecture
 import uuid
 from functools import lru_cache
 
@@ -391,6 +392,7 @@ class Controller(object):
         include_private_scenes=False,
         server_class=None,
         gpu_device=None,
+        platform=None,
         **unity_initialization_parameters,
     ):
         self.receptacle_nearest_pivot_points = {}
@@ -456,11 +458,11 @@ class Controller(object):
                 )
             )
 
-        if server_class is None and platform.system() == "Windows":
+        if server_class is None and platform_system() == "Windows":
             self.server_class = ai2thor.wsgi_server.WsgiServer
         elif (
             isinstance(server_class, ai2thor.fifo_server.FifoServer)
-            and platform.system() == "Windows"
+            and platform_system() == "Windows"
         ):
             raise ValueError("server_class=FifoServer cannot be used on Windows.")
         elif server_class is None:
@@ -482,7 +484,7 @@ class Controller(object):
         elif local_executable_path:
             self._build = ai2thor.build.ExternalBuild(local_executable_path)
         else:
-            self._build = self.find_build(local_build, commit_id, branch)
+            self._build = self.find_build(local_build, commit_id, branch, platform)
 
         self._build.download()
 
@@ -1112,9 +1114,9 @@ class Controller(object):
 
         return commits
 
-    def find_build(self, local_build, commit_id, branch):
+    def find_build(self, local_build, commit_id, branch, platform):
         releases_dir = self.releases_dir
-        if platform.architecture()[0] != "64bit":
+        if platform_architecture()[0] != "64bit":
             raise Exception("Only 64bit currently supported")
         if branch:
             commits = self._branch_commits(branch)
@@ -1133,19 +1135,26 @@ class Controller(object):
             ] + commits  # we add the commits to the list to allow the ci_build to succeed
 
         request = ai2thor.platform.Request(
-            platform.system(), self.width, self.height, self.x_display, self.headless
+            platform_system(), self.width, self.height, self.x_display, self.headless
         )
-        builds = self.find_platform_builds(request, commits, releases_dir, local_build)
+
+        candidate_platforms = ai2thor.platform.select_platforms(request)
+
+        if platform is not None:
+            candidate_platforms = [platform]
+
+        builds = self.find_platform_builds(candidate_platforms, request, commits, releases_dir, local_build)
         if not builds:
+            platforms_message = ",".join(map(lambda p: p.name(), candidate_platforms))
             if commit_id:
                 raise ValueError(
-                    "Invalid commit_id: %s - no build exists for arch=%s"
-                    % (commit_id, platform.system())
+                    "Invalid commit_id: %s - no build exists for arch=%s platforms=%s"
+                    % (commit_id, platform_system(), platforms_message)
                 )
             else:
                 raise Exception(
-                    "No build exists for arch=%s and commits: %s"
-                    % (platform.system(), ", ".join(map(lambda x: x[:8], commits)))
+                    "No build exists for arch=%s platforms=%s and commits: %s"
+                    % (platform_system(), platforms_message, ", ".join(map(lambda x: x[:8], commits)))
                 )
 
         # select the first build + platform that succeeds
@@ -1175,8 +1184,7 @@ class Controller(object):
             error_messages.append(message)
         raise Exception("\n".join(error_messages))
 
-    def find_platform_builds(self, request, commits, releases_dir, local_build):
-        candidate_platforms = ai2thor.platform.select_platforms(request)
+    def find_platform_builds(self, candidate_platforms, request, commits, releases_dir, local_build):
         builds = []
         for plat in candidate_platforms:
             for commit_id in commits:

--- a/ai2thor/platform.py
+++ b/ai2thor/platform.py
@@ -198,7 +198,7 @@ class OSXIntel64(BasePlatform):
 
 
 class CloudRendering(BaseLinuxPlatform):
-    enabled = False
+    enabled = True
 
     @classmethod
     def dependency_instructions(cls, request):

--- a/ai2thor/platform.py
+++ b/ai2thor/platform.py
@@ -222,7 +222,7 @@ class WebGL(BasePlatform):
 
 def select_platforms(request):
     candidates = []
-    system_platform_map = dict(Linux=(CloudRendering, Linux64), Darwin=(OSXIntel64,))
+    system_platform_map = dict(Linux=(Linux64, CloudRendering), Darwin=(OSXIntel64,))
     for p in system_platform_map.get(request.system, ()):
         if not p.enabled:
             continue

--- a/ai2thor/tests/test_controller.py
+++ b/ai2thor/tests/test_controller.py
@@ -34,7 +34,7 @@ def fake_cr_exists(self):
 def fake_not_exists(self):
     return False
 
-def fake_find_platform_builds(self, request, commits, releases_dir, local_build):
+def fake_find_platform_builds(self, canditate_platorms, request, commits, releases_dir, local_build):
     return []
 
 def fake_exists(self):
@@ -108,17 +108,17 @@ def controller(**args):
 
 
 def test_osx_build_missing(mocker):
-    mocker.patch("ai2thor.controller.platform.system", fake_darwin_system)
+    mocker.patch("ai2thor.controller.platform_system", fake_darwin_system)
     mocker.patch("ai2thor.controller.Controller.find_platform_builds", fake_find_platform_builds)
 
     with pytest.raises(Exception) as ex:
         c = controller()
 
-    assert str(ex.value).startswith("No build exists for arch=Darwin and commits: ")
+    assert str(ex.value).startswith("No build exists for arch=Darwin platforms=OSXIntel64 and commits:")
 
 
 def test_osx_build_invalid_commit_id(mocker):
-    mocker.patch("ai2thor.controller.platform.system", fake_darwin_system)
+    mocker.patch("ai2thor.controller.platform_system", fake_darwin_system)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.exists", fake_not_exists)
 
     fake_commit_id = "1234567TEST"
@@ -127,12 +127,12 @@ def test_osx_build_invalid_commit_id(mocker):
 
     assert (
         str(ex.value)
-        == "Invalid commit_id: %s - no build exists for arch=Darwin" % fake_commit_id
+        == "Invalid commit_id: %s - no build exists for arch=Darwin platforms=OSXIntel64" % fake_commit_id
     )
 
 
 def test_osx_build(mocker):
-    mocker.patch("ai2thor.controller.platform.system", fake_darwin_system)
+    mocker.patch("ai2thor.controller.platform_system", fake_darwin_system)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.exists", fake_exists)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.download", noop_download)
 
@@ -143,7 +143,7 @@ def test_osx_build(mocker):
 
 
 def test_linux_explicit_xdisplay(mocker):
-    mocker.patch("ai2thor.controller.platform.system", fake_linux_system)
+    mocker.patch("ai2thor.controller.platform_system", fake_linux_system)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.exists", fake_exists)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.download", noop_download)
     mocker.patch("ai2thor.controller.ai2thor.platform.Linux64.validate", fake_validate)
@@ -156,7 +156,7 @@ def test_linux_explicit_xdisplay(mocker):
 
 def test_linux_invalid_linux64_invalid_cr(mocker):
 
-    mocker.patch("ai2thor.controller.platform.system", fake_linux_system)
+    mocker.patch("ai2thor.controller.platform_system", fake_linux_system)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.exists", fake_exists)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.download", noop_download)
     mocker.patch(
@@ -179,7 +179,7 @@ def test_linux_invalid_linux64_invalid_cr(mocker):
 
 def test_linux_invalid_linux64_valid_cr(mocker):
 
-    mocker.patch("ai2thor.controller.platform.system", fake_linux_system)
+    mocker.patch("ai2thor.controller.platform_system", fake_linux_system)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.exists", fake_exists)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.download", noop_download)
     mocker.patch(
@@ -200,7 +200,7 @@ def test_linux_invalid_linux64_valid_cr(mocker):
 
 def test_linux_valid_linux64_valid_cloudrendering(mocker):
 
-    mocker.patch("ai2thor.controller.platform.system", fake_linux_system)
+    mocker.patch("ai2thor.controller.platform_system", fake_linux_system)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.exists", fake_exists)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.download", noop_download)
     mocker.patch(
@@ -216,7 +216,7 @@ def test_linux_valid_linux64_valid_cloudrendering(mocker):
 
 def test_linux_valid_linux64_valid_cloudrendering_enabled_cr(mocker):
 
-    mocker.patch("ai2thor.controller.platform.system", fake_linux_system)
+    mocker.patch("ai2thor.controller.platform_system", fake_linux_system)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.exists", fake_exists)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.download", noop_download)
     mocker.patch(
@@ -224,6 +224,7 @@ def test_linux_valid_linux64_valid_cloudrendering_enabled_cr(mocker):
     )
     mocker.patch("ai2thor.controller.ai2thor.platform.Linux64.validate", fake_validate)
     mocker.patch("ai2thor.platform.CloudRendering.enabled", True)
+    mocker.patch("ai2thor.platform.Linux64.enabled", False)
 
     fake_commit_id = "1234567TEST"
     c = controller(commit_id=fake_commit_id)
@@ -233,7 +234,7 @@ def test_linux_valid_linux64_valid_cloudrendering_enabled_cr(mocker):
 
 def test_linux_valid_linux64_invalid_cloudrendering(mocker):
 
-    mocker.patch("ai2thor.controller.platform.system", fake_linux_system)
+    mocker.patch("ai2thor.controller.platform_system", fake_linux_system)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.exists", fake_exists)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.download", noop_download)
     mocker.patch(
@@ -250,7 +251,7 @@ def test_linux_valid_linux64_invalid_cloudrendering(mocker):
 
 def test_linux_missing_linux64(mocker):
 
-    mocker.patch("ai2thor.controller.platform.system", fake_linux_system)
+    mocker.patch("ai2thor.controller.platform_system", fake_linux_system)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.exists", fake_cr_exists)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.download", noop_download)
     mocker.patch(
@@ -266,7 +267,7 @@ def test_linux_missing_linux64(mocker):
 
 def test_linux_missing_cloudrendering(mocker):
 
-    mocker.patch("ai2thor.controller.platform.system", fake_linux_system)
+    mocker.patch("ai2thor.controller.platform_system", fake_linux_system)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.exists", fake_linux64_exists)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.download", noop_download)
     mocker.patch("ai2thor.controller.ai2thor.platform.Linux64.validate", fake_validate)
@@ -301,7 +302,7 @@ def test_invalid_commit(mocker):
 
 
 def test_scene_names(mocker):
-    mocker.patch("ai2thor.controller.platform.system", fake_darwin_system)
+    mocker.patch("ai2thor.controller.platform_system", fake_darwin_system)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.exists", fake_exists)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.download", noop_download)
     c = controller()
@@ -311,7 +312,7 @@ def test_scene_names(mocker):
 
 
 def test_invalid_action(mocker):
-    mocker.patch("ai2thor.controller.platform.system", fake_darwin_system)
+    mocker.patch("ai2thor.controller.platform_system", fake_darwin_system)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.exists", fake_exists)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.download", noop_download)
     fake_event = Event(
@@ -335,7 +336,7 @@ def test_invalid_action(mocker):
 
 
 def test_fix_visibility_distance_env(mocker):
-    mocker.patch("ai2thor.controller.platform.system", fake_darwin_system)
+    mocker.patch("ai2thor.controller.platform_system", fake_darwin_system)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.exists", fake_exists)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.download", noop_download)
     try:
@@ -359,7 +360,7 @@ def test_fix_visibility_distance_env(mocker):
 
 
 def test_raise_for_failure(mocker):
-    mocker.patch("ai2thor.controller.platform.system", fake_darwin_system)
+    mocker.patch("ai2thor.controller.platform_system", fake_darwin_system)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.exists", fake_exists)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.download", noop_download)
 
@@ -382,7 +383,7 @@ def test_raise_for_failure(mocker):
 
 
 def test_failure(mocker):
-    mocker.patch("ai2thor.controller.platform.system", fake_darwin_system)
+    mocker.patch("ai2thor.controller.platform_system", fake_darwin_system)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.exists", fake_exists)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.download", noop_download)
     fake_event = Event(
@@ -404,7 +405,7 @@ def test_failure(mocker):
 
 
 def test_last_action(mocker):
-    mocker.patch("ai2thor.controller.platform.system", fake_darwin_system)
+    mocker.patch("ai2thor.controller.platform_system", fake_darwin_system)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.exists", fake_exists)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.download", noop_download)
     fake_event = Event(
@@ -428,7 +429,7 @@ def test_last_action(mocker):
 
 
 def test_unity_command(mocker):
-    mocker.patch("ai2thor.controller.platform.system", fake_linux_system)
+    mocker.patch("ai2thor.controller.platform_system", fake_linux_system)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.exists", fake_exists)
     mocker.patch("ai2thor.controller.ai2thor.build.Build.download", noop_download)
     mocker.patch("ai2thor.controller.ai2thor.platform.Linux64.validate", fake_validate)


### PR DESCRIPTION
This PR adds a new parameter `platform` to the `ai2thor.controller.Controller` constructor.  Prior to this, in order to run say a CloudRendering and Linux64 (Xorg dependent Unity), you would have to do something like this:

```python
import ai2thor.controller
import ai2thor.platform
ai2thor.platform.CloudRendering.enabled = True
ai2thor.platform.Linux64.enabled = False

cloudrendering_controller = ai2thor.controller.Controller()

ai2thor.platform.CloudRendering.enabled = False
ai2thor.platform.Linux64.enabled = True

xorg_controller = ai2thor.controller.Controller()
```

With this change, the following can now be done:
```python
import ai2thor.controller
from ai2thor.platform import CloudRendering, Linux64
xorg_controller = ai2thor.controller.Controller(platform=Linux64)
cloundrendering_controller = ai2thor.controller.Controller(platform=CloudRendering)
```

I feel this change makes the process of expressing a particular backend `platform` explicit and more concise. If no platform is provided, we will iterate through the list of candidate platforms and find one that has its dependencies satisfied.

