### PR TITLE
UX Updates

### DIFF
--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -4231,7 +4231,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             actionFinished(true);
         }
 
-        public void CreateHouseFromJson(ProceduralHouse house) {
+        public void CreateHouse(ProceduralHouse house) {
             var rooms = house.rooms.SelectMany(
                 room => house.rooms
             );
@@ -4328,7 +4328,11 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             actionFinished(true, geoList);
         }
 
-        public void SpawnAsset(string assetId, string generatedId = "asset_0", Vector3? position = null) {
+        public void SpawnAsset(
+            string assetId,
+            string generatedId,
+            Vector3? position = null
+        ) {
             var assetDb = GameObject.FindObjectOfType<ProceduralAssetDatabase>();
             if (assetDb == null) {
                 errorMessage = "ProceduralAssetDatabase not in scene.";
@@ -4493,7 +4497,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         public void BakeNavMesh() {
             var navmesh = GameObject.FindObjectOfType<NavMeshSurface>();
             if (navmesh == null) {
-                actionFinished(false, null, "No NavMeshSurface component found, make sure scene was proceduraly created by `CreateHouseFromJson`.");
+                actionFinished(false, null, "No NavMeshSurface component found, make sure scene was proceduraly created by `CreateHouse`.");
                 return;
             }
             navmesh.BuildNavMesh();

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -3530,7 +3530,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         Dictionary<string, object> action = new Dictionary<string, object>();
 
                         // AssetDatabase.Refresh();
-                        action["action"] = "CreateHouseFromJson";
+                        action["action"] = "CreateHouse";
                         var ROOM_BASE_PATH = "/Resources/rooms/";
 
                         path = Application.dataPath + "/Resources/rooms/house_full.json";
@@ -3597,6 +3597,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         Dictionary<string, object> action = new Dictionary<string, object>();
                         action["action"] = "SpawnAsset";
                         action["assetId"] = "Dining_Table_16_1";
+                        action["generatedId"] = "asset_0";
                         // action["skyboxColor"] = new Color(0, 0, 0, 1);
 
                         if (splitcommand.Length == 2) {


### PR DESCRIPTION
* Requires `generatedId` to be passed in with `SpawnAsset`. This avoids the unintuitive issue of calling `SpawnAsset` multiple times without `generatedId`, and having the same `objectId` appear again for different objects.
* Renames `CreateHouseFromJson` to `CreateHouse`, since a `Json` is technically not what's being passed in from the Python side. It is also more compact.