### PR TITLE
Bug fixes to `RemoveFromScene`

### DIFF
--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1216,7 +1216,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         public void RemoveFromScene(string objectId) {
             SimObjPhysics sop = getSimObjectFromId(objectId: objectId);
             Destroy(sop.transform.gameObject);
-            physicsSceneManager.SetupScene();
+            physicsSceneManager.SetupScene(generateObjectIds: false);
             actionFinished(success: true);
         }
 
@@ -1243,7 +1243,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             foreach (GameObject go in gameObjects) {
                 Destroy(go);
             }
-            physicsSceneManager.SetupScene();
+            physicsSceneManager.SetupScene(generateObjectIds: false);
             actionFinished(success: true);
         }
 

--- a/unity/Assets/Scripts/PhysicsSceneManager.cs
+++ b/unity/Assets/Scripts/PhysicsSceneManager.cs
@@ -62,9 +62,9 @@ public class PhysicsSceneManager : MonoBehaviour {
         }
     }
 
-    public void SetupScene() {
+    public void SetupScene(bool generateObjectIds = true) {
         ObjectIdToSimObjPhysics.Clear();
-        GatherSimObjPhysInScene();
+        GatherSimObjPhysInScene(generateObjectIds: generateObjectIds);
         GatherAllRBsInScene();
     }
     // Use this for initialization
@@ -197,14 +197,16 @@ public class PhysicsSceneManager : MonoBehaviour {
         }
     }
 
-    public void GatherSimObjPhysInScene() {
+    public void GatherSimObjPhysInScene(bool generateObjectIds = true) {
         List<SimObjPhysics> allPhysObjects = new List<SimObjPhysics>();
 
         allPhysObjects.AddRange(FindObjectsOfType<SimObjPhysics>());
         allPhysObjects.Sort((x, y) => (x.Type.ToString().CompareTo(y.Type.ToString())));
 
         foreach (SimObjPhysics o in allPhysObjects) {
-            Generate_ObjectID(o);
+            if (generateObjectIds) {
+                Generate_ObjectID(o);
+            }
 
             // debug in editor, make sure no two object share ids for some reason
 #if UNITY_EDITOR


### PR DESCRIPTION
`RemoveFromScene` was previously just disabling an object, but, according to the documentation, it should completely destroy the object in the scene. Also fixes an issue where the set of objectIds was not being updated after removing the object from the scene.