### PR TITLE
adds `ObjectsFromThirdPartyCamera` action

### DIFF
--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -2570,7 +2570,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
         public VisibilityCheck isSimObjVisible(Camera camera, SimObjPhysics sop, float maxDistance) {
             VisibilityCheck visCheck = new VisibilityCheck();
-            // check against all visibility points, accumulate count. If at least one point is visible, set object to visible
+            // check against all visibility points
             if (sop.VisibilityPoints != null && sop.VisibilityPoints.Length > 0) {
                 Transform[] visPoints = sop.VisibilityPoints;
 
@@ -2682,7 +2682,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
             return visCheck;
         }
-
+        
         // pass in forceVisible bool to force grab all objects of type sim obj
         // if not, gather all visible sim objects maxVisibleDistance away from camera view
         public SimObjPhysics[] VisibleSimObjs(bool forceVisible = false) {
@@ -2692,6 +2692,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 return GetAllVisibleSimObjPhysics(m_Camera, maxVisibleDistance);
             }
         }
+
         protected SimObjPhysics[] GetAllVisibleSimObjPhysics(
             Camera camera,
             float maxDistance,
@@ -3155,6 +3156,32 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         public List<SimObjPhysics> GetAllVisibleSimObjPhysics(float maxDistance) {
             var camera = this.GetComponentInChildren<Camera>();
             return new List<SimObjPhysics>(GetAllVisibleSimObjPhysics(camera, maxDistance));
+        }
+
+        //check visibility and interactability from specific camera (third party camera)
+        public void ObjectsFromThirdPartyCamera(int thirdPartyCameraIndex, float? maxDistance = null) {
+            if(!maxDistance.HasValue) {
+                maxDistance = maxVisibleDistance;
+            }
+
+            SimObjPhysics[] interactableObjects;
+            SimObjPhysics[] visibleObjects = GetAllVisibleSimObjPhysicsDistance(
+                agentManager.thirdPartyCameras[thirdPartyCameraIndex],
+                maxDistance.Value,
+                null, out interactableObjects);
+//.Select(sop => sop.ObjectID).ToList()
+
+            Dictionary<SimObjPhysics, VisibilityCheck> objectsVisibleAndInteractable = new Dictionary<SimObjPhysics, VisibilityCheck>();
+
+            foreach (SimObjPhysics sop in visibleObjects) {
+                VisibilityCheck vc = new VisibilityCheck();
+                vc.visible = true;
+                vc.interactable = interactableObjects.Contains(sop);
+
+                objectsVisibleAndInteractable.Add(sop, vc);
+            }
+
+            actionFinishedEmit(true, objectsVisibleAndInteractable);
         }
 
         // not sure what this does, maybe delete?

--- a/unity/Assets/UnitTests/TestThirdPartyCamera.cs
+++ b/unity/Assets/UnitTests/TestThirdPartyCamera.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System;
 using UnityEngine;
 using UnityEngine.TestTools;
+using UnityStandardAssets.Characters.FirstPerson;
 
 namespace Tests {
     public class TestThirdPartyCamera : TestBase {
@@ -49,8 +50,50 @@ namespace Tests {
 
             Assert.NotNull(GameObject.Find("ThirdPartyCamera0"));
             Assert.NotNull(GameObject.Find("ThirdPartyCamera1"));
-
         }
 
+        [UnityTest]
+        public IEnumerator TestObjectsFromThirdPartyCamera() {
+            Dictionary<string, object> action = new Dictionary<string, object>();
+
+            action["action"] = "Initialize";
+            action["fieldOfView"] = 90f;
+            action["snapToGrid"] = true;
+            yield return step(action);
+
+            action.Clear();
+
+            action["action"] = "AddThirdPartyCamera";
+            action["position"] = new Vector3(0.0f, 1.3f, -0.3f);
+            action["rotation"] = Vector3.zero;
+            action["orthographic"] = false;
+            yield return step(action);
+
+            action.Clear();
+
+            action["action"] = "ObjectsFromThirdPartyCamera";
+            action["thirdPartyCameraIndex"] = 0;
+            yield return step(action);
+
+            bool result = true;
+            List<String> visibleObjectNames = new List<String>() {
+                "Apple_34d5f204", "Book_3d15d052", "Bread_a13c4e42", "CounterTop_bafd4140", "CreditCard_acee2f3e"
+            };
+
+            foreach (KeyValuePair<SimObjPhysics, VisibilityCheck> kvp in (Dictionary<SimObjPhysics, VisibilityCheck>)actionReturn) {
+                Debug.Log(kvp.Key.name);
+                if(!visibleObjectNames.Contains(kvp.Key.name)) {
+                    result = false;
+                    break;
+                }
+
+                if(!kvp.Value.visible || !kvp.Value.interactable) {
+                    result = false;
+                    break;
+                }
+            }
+
+            Assert.AreEqual(result, true);
+        }
     }
 }


### PR DESCRIPTION
Adds new action that takes a third party camera index and returns all objects both visible and interactable from that Third Party Camera.

Also added a unit test for this new action.

Addresses issue #910