### PR TITLE
Clone GameObject when generating OOBB

### DIFF
--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -2108,6 +2108,25 @@ def test_rotate_hand(controller):
     assert_near(h1["localRotation"], dict(x=0, y=0, z=0))
     assert_near(h2["localRotation"], dict(x=90, y=180, z=0))
 
+def test_settle_physics(fifo_controller):
+    from dictdiffer import diff
+    fifo_controller.reset(agentMode="arm")
+
+    for i in range(30):
+        fifo_controller.step("AdvancePhysicsStep", raise_for_failure=True)
+
+    first_objs = {o['objectId']: o for o in fifo_controller.last_event.metadata["objects"]}
+
+    for i in range(30):
+        fifo_controller.step("AdvancePhysicsStep", raise_for_failure=True)
+
+    diffs = []
+    last_objs = {o['objectId']: o for o in fifo_controller.last_event.metadata["objects"]}
+    for object_id, object_metadata in first_objs.items():
+        for d in (diff(object_metadata, last_objs.get(object_id, {}), tolerance=0.00001, ignore=set(["receptacleObjectIds"]))):
+            diffs.append((object_id, d))
+ 
+    assert diffs == []
 
 @pytest.mark.parametrize("controller", fifo_wsgi)
 def test_fill_liquid(controller):

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "werkzeug>=0.15.0",  # needed for unix socket support
     ],
     setup_requires=["pytest-runner"],
-    tests_require=["pytest", "pytest-timeout", "pytest-cov", "jsonschema", "shapely", "pytest-mock"],
+    tests_require=["pytest", "pytest-timeout", "pytest-cov", "jsonschema", "shapely", "pytest-mock", "dictdiffer"],
     scripts=["scripts/ai2thor-xorg"],
     include_package_data=False,
 )

--- a/unity/Assets/Scripts/CanOpen_Object.cs
+++ b/unity/Assets/Scripts/CanOpen_Object.cs
@@ -65,7 +65,13 @@ public class CanOpen_Object : MonoBehaviour {
         // init Itween in all doors to prep for animation
         if (MovingParts != null) {
             foreach (GameObject go in MovingParts) {
-                iTween.Init(go);
+                // within SimObjPhysics the GameObject is cloned in order to calculate the OOBB.  During 
+                // the Instantiate call,  the existing dynamically created iTween components are copied.  If iTween.Init
+                // is called again on a GameObject with an existing iTween component a NullReferenceException
+                // will get thrown from iTween.RetrieveArgs()
+                if (go.GetComponent<iTween>() != null) {
+                    iTween.Init(go);
+                }
 
                 // check to make sure all doors have a Fridge_Door.cs script on them, if not throw a warning
                 // if (!go.GetComponent<Fridge_Door>())

--- a/unity/Assets/Scripts/CanOpen_Object.cs
+++ b/unity/Assets/Scripts/CanOpen_Object.cs
@@ -64,6 +64,8 @@ public class CanOpen_Object : MonoBehaviour {
         if (MovingParts != null) {
             // init Itween in all doors to prep for animation
             foreach (GameObject go in MovingParts) {
+                // Init is getting called in Awake() vs Start() so that cloned gameobjects can add MovingParts
+                // before iTween.Awake() gets called which would throw an error if this was done in Start()
                 iTween.Init(go);
 
                 // check to make sure all doors have a Fridge_Door.cs script on them, if not throw a warning

--- a/unity/Assets/Scripts/CanOpen_Object.cs
+++ b/unity/Assets/Scripts/CanOpen_Object.cs
@@ -60,24 +60,21 @@ public class CanOpen_Object : MonoBehaviour {
         return MustBeOffToOpen;
     }
 
-    // Use this for initialization
-    void Start() {
-        // init Itween in all doors to prep for animation
+    void Awake() {
         if (MovingParts != null) {
+            // init Itween in all doors to prep for animation
             foreach (GameObject go in MovingParts) {
-                // within SimObjPhysics the GameObject is cloned in order to calculate the OOBB.  During 
-                // the Instantiate call,  the existing dynamically created iTween components are copied.  If iTween.Init
-                // is called again on a GameObject with an existing iTween component a NullReferenceException
-                // will get thrown from iTween.RetrieveArgs()
-                if (go.GetComponent<iTween>() != null) {
-                    iTween.Init(go);
-                }
+                iTween.Init(go);
 
                 // check to make sure all doors have a Fridge_Door.cs script on them, if not throw a warning
                 // if (!go.GetComponent<Fridge_Door>())
                 // Debug.Log("Fridge Door is missing Fridge_Door.cs component! OH NO!");
             }
         }
+    }
+
+    // Use this for initialization
+    void Start() {
 
 #if UNITY_EDITOR
         if (!this.GetComponent<SimObjPhysics>().DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanOpen)) {

--- a/unity/Assets/Scripts/CanToggleOnOff.cs
+++ b/unity/Assets/Scripts/CanToggleOnOff.cs
@@ -111,13 +111,16 @@ public class CanToggleOnOff : MonoBehaviour {
 
 #endif
 
-    // Use this for initialization
-    void Start() {
+    void Awake() {
         if (MovingParts != null) {
             foreach (GameObject go in MovingParts) {
-                iTween.Init(go);
+                    iTween.Init(go);
             }
         }
+    }
+
+    // Use this for initialization
+    void Start() {
 
 #if UNITY_EDITOR
         if (!this.GetComponent<SimObjPhysics>().DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanToggleOnOff)) {

--- a/unity/Assets/Scripts/CanToggleOnOff.cs
+++ b/unity/Assets/Scripts/CanToggleOnOff.cs
@@ -114,7 +114,9 @@ public class CanToggleOnOff : MonoBehaviour {
     void Awake() {
         if (MovingParts != null) {
             foreach (GameObject go in MovingParts) {
-                    iTween.Init(go);
+                // Init is getting called in Awake() vs Start() so that cloned gameobjects can add MovingParts
+                // before iTween.Awake() gets called which would throw an error if this was done in Start()
+                iTween.Init(go);
             }
         }
     }

--- a/unity/Assets/Scripts/SimObjPhysics.cs
+++ b/unity/Assets/Scripts/SimObjPhysics.cs
@@ -302,7 +302,11 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
 
             }
 
+            // The GameObject is cloned instead of teleporting/rotating to avoid
+            // waking up the rigidbody, which can cause the SimObj to shift by tiny amounts
+            // since it will never sleep.
             GameObject clone = Instantiate(this.gameObject, Vector3.zero, Quaternion.identity);
+
 
             // Get all colliders on the sop, excluding colliders if they are not enabled
             List<(Collider, LayerMask)> cols = new List<(Collider, LayerMask)>();

--- a/unity/Assets/Scripts/SimObjPhysics.cs
+++ b/unity/Assets/Scripts/SimObjPhysics.cs
@@ -354,6 +354,14 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj {
 
             DestroyImmediate(clone);
 
+            // iTween adds references to the iTween.tweens List
+            for (int i = 0; i < iTween.tweens.Count; i++) {
+                if (((GameObject)iTween.tweens[i]["target"]) == null) {
+                   iTween.tweens.RemoveAt(i);
+                }
+            }
+
+
             // Get corner points of SimObject's new BoundingBox, in its correct transformation
             List<Vector3> points = new List<Vector3>();
             points.Add(this.transform.TransformPoint(newBB.center + new Vector3(newBB.size.x, -newBB.size.y, newBB.size.z) * 0.5f));


### PR DESCRIPTION
I discovered that the way that we generate OOBB will wake some rigid bodies up causing them to never settle.  This can be observed by calling `Physics.Simulate()` repeatedly and examining the position and rotation values for the `Lettuce` object in FloorPlan28.  The issue is that when any change is done to the transform of a GameObject Unity will wake the RigidBody.  What this PR does is clone the GameObject and place it at the origin and then perform the OOBB calculation.

One thing that I also noticed was that during the `Object.Instantiate` call , `iTween.Init` needed be be called on the newly cloned objects otherwise iTween would throw an error about a null GameObject. This is the reason for moving the `iTween.Init` calls to `Awake` from `Start` for `CanOpen` and `CanToggle`.