### PR TITLE
Calling changequality for CloudRendering after startup; 

### DIFF
--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -670,6 +670,11 @@ class Controller(object):
             self.width = target_width
             self.height = target_height
 
+        # the command line -quality parameter is not respected with the CloudRendering
+        # engine, so the quality is manually changed after launch
+        if self._build.platform == ai2thor.platform.CloudRendering:
+            self.step(action="ChangeQuality", quality=self.quality)
+
         # updates the initialization parameters
         self.initialization_parameters.update(init_params)
 

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -54,7 +54,7 @@ public class AgentManager : MonoBehaviour {
     private bool fastActionEmit = true;
 
     // it is public to be accessible from the debug input field.
-    public HashSet<string> agentManagerActions = new HashSet<string> { "Reset", "Initialize", "AddThirdPartyCamera", "UpdateThirdPartyCamera", "ChangeResolution", "CoordinateFromRaycastThirdPartyCamera" };
+    public HashSet<string> agentManagerActions = new HashSet<string> { "Reset", "Initialize", "AddThirdPartyCamera", "UpdateThirdPartyCamera", "ChangeResolution", "CoordinateFromRaycastThirdPartyCamera", "ChangeQuality" };
 
     public bool doResetMaterials = false;
     public bool doResetColors = false;
@@ -764,6 +764,25 @@ public class AgentManager : MonoBehaviour {
         this.resetAllImageSynthesis();
         this.primaryAgent.actionFinished(true);
     }
+
+    public void ChangeQuality(string quality) {
+        string[] names = QualitySettings.names;
+        for (int i = 0; i < names.Length; i++) {
+            if (names[i] == quality) {
+                QualitySettings.SetQualityLevel(i, true);
+                break;
+            }
+        }
+
+        ScreenSpaceAmbientOcclusion script = GameObject.Find("FirstPersonCharacter").GetComponent<ScreenSpaceAmbientOcclusion>();
+        if (quality == "Low" || quality == "Very Low") {
+            script.enabled = false;
+        } else {
+            script.enabled = true;
+        }
+        this.primaryAgent.actionFinished(true);
+    }
+
 
     public void ChangeResolution(int x, int y) {
         Screen.SetResolution(width: x, height: y, false);

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -5815,24 +5815,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
 
-        public void ChangeQuality(ServerAction action) {
-            string[] names = QualitySettings.names;
-            for (int i = 0; i < names.Length; i++) {
-                if (names[i] == action.quality) {
-                    QualitySettings.SetQualityLevel(i, true);
-                    break;
-                }
-            }
-
-            ScreenSpaceAmbientOcclusion script = GameObject.Find("FirstPersonCharacter").GetComponent<ScreenSpaceAmbientOcclusion>();
-            if (action.quality == "Low" || action.quality == "Very Low") {
-                script.enabled = false;
-            } else {
-                script.enabled = true;
-            }
-            actionFinished(true);
-        }
-
         public void DisableScreenSpaceAmbientOcclusion() {
             ScreenSpaceAmbientOcclusion script = GameObject.Find("FirstPersonCharacter").GetComponent<ScreenSpaceAmbientOcclusion>();
             script.enabled = false;


### PR DESCRIPTION
The CloudRendering platform does not respect command-line parameters, so the Quality is updated manually after startup/reset.

* moving ChangeQuality to AgentManager
* Calling ChangeQuality for CloudRendering after startup

