### PR TITLE
Fix Python+WSGI -> Unity Editor

### DIFF
--- a/ai2thor/build.py
+++ b/ai2thor/build.py
@@ -58,6 +58,8 @@ class EditorBuild(object):
         self.server_types = ["FIFO", "WSGI"]
         self.url = None
         self.unity_proc = None
+        external_system_platforms = dict(Linux=Linux64, Darwin=OSXIntel64)
+        self.platform = external_system_platforms[platform.system()]
 
     def download(self):
         pass

--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -657,7 +657,9 @@ class Controller(object):
         # with CloudRendering the command-line height/width aren't respected, so
         # we compare here with what the desired height/width are and
         # update the resolution if they are different
-        if (
+        # if Python is running against the Unity Editor then
+        # ChangeResolution won't have an affect, so it gets skipped
+        if (self.server.unity_proc is not None) and (
             target_width != self.last_event.screen_width
             or target_height != self.last_event.screen_height
         ):
@@ -1304,7 +1306,7 @@ class Controller(object):
         self.last_event = self.server.receive()
 
         # we should be able to get rid of this since we check the resolution in .reset()
-        if height < 300 or width < 300:
+        if self.server.unity_proc is not None and (height < 300 or width < 300):
             self.last_event = self.step("ChangeResolution", x=width, y=height)
 
         return self.last_event


### PR DESCRIPTION
Calls to `ChangeResolution` fail when connecting from Python to the Unity Editor.  This PR resolves that.