### PR TITLE
Better error message when passing in unknown scene

### DIFF
--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -629,19 +629,11 @@ class Controller(object):
         # scenes in build can be an empty set when GetScenesInBuild doesn't exist as an action
         # for old builds
         if self.scenes_in_build and scene not in self.scenes_in_build:
-
-            def key_sort_func(scene_name):
-                m = re.search(
-                    r"FloorPlan[_]?([a-zA-Z\-]*)([0-9]+)_?([0-9]+)?.*$", scene_name
-                )
-                last_val = m.group(3) if m.group(3) is not None else -1
-                return m.group(1), int(m.group(2)), int(last_val)
-
             raise ValueError(
                 "\nScene '{}' not contained in build (scene names are case sensitive)."
                 "\nPlease choose one of the following scene names:\n\n{}".format(
                     scene,
-                    ", ".join(sorted(list(self.scenes_in_build), key=key_sort_func)),
+                    ", ".join(sorted(list(self.scenes_in_build))),
                 )
             )
 


### PR DESCRIPTION
There is currently a pretty ugly error message on `main` when an unknown scene in passed in:
![image](https://user-images.githubusercontent.com/28768645/152228220-942e472e-e3ad-4017-9ce3-38ad7a4e7fad.png)

The error message occurs because we try to sort by the pattern `re.search(r"FloorPlan[_]?([a-zA-Z\-]*)([0-9]+)_?([0-9]+)?.*$", scene_name)`. But, not all scenes in the `main` build work with the pattern anymore. For instance, trying it with `FloorPlan_ExpRoom` results in `None`, which then results in the AttributeError: `'NoneType' object has no attribute 'group'`.

This PR just calls `sorted()` instead of trying to sort by `key_sort_func`. The downside is that it may be a little less natural, where `FloorPlan10` might come before `FloorPlan1`, but it's much more robust to new scene names in the build.

Full notebook: https://colab.research.google.com/drive/1207Px1enUPqzJ2mTIkvrc-OA7eygpEyT?usp=sharing