### PR TITLE
Remove SSAO component from FirstPersonCharacter

### DIFF
--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -773,13 +773,7 @@ public class AgentManager : MonoBehaviour {
                 break;
             }
         }
-
-        ScreenSpaceAmbientOcclusion script = GameObject.Find("FirstPersonCharacter").GetComponent<ScreenSpaceAmbientOcclusion>();
-        if (quality == "Low" || quality == "Very Low") {
-            script.enabled = false;
-        } else {
-            script.enabled = true;
-        }
+        
         this.primaryAgent.actionFinished(true);
     }
 

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -5814,13 +5814,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
         }
 
-
-        public void DisableScreenSpaceAmbientOcclusion() {
-            ScreenSpaceAmbientOcclusion script = GameObject.Find("FirstPersonCharacter").GetComponent<ScreenSpaceAmbientOcclusion>();
-            script.enabled = false;
-            actionFinished(true);
-        }
-
         // in case you want to change the timescale
         public void ChangeTimeScale(ServerAction action) {
             if (action.timeScale > 0) {

--- a/unity/Assets/Standard Assets/Characters/FirstPersonCharacter/Prefabs/FPSController.prefab
+++ b/unity/Assets/Standard Assets/Characters/FirstPersonCharacter/Prefabs/FPSController.prefab
@@ -261,7 +261,6 @@ GameObject:
   - component: {fileID: 6767686627676241163}
   - component: {fileID: 114317082596199212}
   - component: {fileID: 114176532703538896}
-  - component: {fileID: 114785506931627080}
   - component: {fileID: 992261166}
   - component: {fileID: 2007864991}
   - component: {fileID: 2007864990}
@@ -395,27 +394,6 @@ MonoBehaviour:
   heightDensity: 2
   startDistance: 0
   fogShader: {fileID: 4800000, guid: 70d8568987ac0499f952b54c7c13e265, type: 3}
---- !u!114 &114785506931627080
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 100002}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b0923359e9e352a4b9b11c7b7161ad67, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Radius: 0.4
-  m_SampleCount: 1
-  m_OcclusionIntensity: 1.5
-  m_Blur: 2
-  m_Downsampling: 2
-  m_OcclusionAttenuation: 1
-  m_MinZ: 0.01
-  m_SSAOShader: {fileID: 4800000, guid: 43ca18288c424f645aaa1e9e07f04c50, type: 3}
-  m_RandomTexture: {fileID: 2800000, guid: a181ca8e3c62f3e4b8f183f6c586b032, type: 3}
 --- !u!114 &992261166
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
This PR removes the ScreenSpaceAmbientOcclusion component from the FirstPersonCharacter/FPSController prefab.  We no longer use SSAO and it can get re-enabled if `ChangeQuality` is called with a value other than Low or Very Low.  This results in the following frame:
![out](https://user-images.githubusercontent.com/326692/153497958-151b8150-ec69-46d0-ad2a-2ab61fcf0e1e.png)

Note the difference when compared to the frame received with quality set to Ultra, but never calling `ChangeQuality`
![base-frame-1](https://user-images.githubusercontent.com/326692/153498176-df32e562-0052-43cd-bfc3-02b42cb9e30e.png)

