### PR TITLE
Enable JavascriptInterface within AgentManager

### DIFF
--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -130,6 +130,10 @@ public class AgentManager : MonoBehaviour {
 #if UNITY_WEBGL
         physicsSceneManager.UnpausePhysicsAutoSim();
         primaryAgent.InitializeBody();
+        JavaScriptInterface jsInterface = primaryAgent.GetComponent<JavaScriptInterface>();
+        if (jsInterface != null) {
+            jsInterface.enabled = true;
+        }
 #endif
 
         StartCoroutine(EmitFrame());

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -132,7 +132,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 #if UNITY_WEBGL
                 Debug.Log("Player Control Set To:Webgl");
                 setControlMode(ControlMode.FPS);
-                CurrentActiveController().GetComponent<JavaScriptInterface>().enabled = true;
 #endif
 #if CROWDSOURCE_TASK
                 Debug.Log("CROWDSOURCE_TASK");


### PR DESCRIPTION
The WebGL demo was throwing a nullreferenceexception from DebugInputField because the `CurrentActiveController()` had not yet been initialized within the AgentManager.  The line in question was attempting to enable the `JavascriptInterface` component.  This has been moved to the AgentManager instead immediately after the `primaryAgent` initialization.