### PR TITLE
Adding `strict_map_key=False` as an argument for `msgpack.loads`.

### DIFF
--- a/ai2thor/fifo_server.py
+++ b/ai2thor/fifo_server.py
@@ -134,9 +134,9 @@ class FifoServer(ai2thor.server.Server):
             if field_type is FieldType.METADATA:
                 # print("body length %s" % len(body))
                 # print(body)
-                metadata = msgpack.loads(body, raw=False)
+                metadata = msgpack.loads(body, raw=False, strict_map_key=False)
             elif field_type is FieldType.METADATA_PATCH:
-                metadata_patch = msgpack.loads(body, raw=False)
+                metadata_patch = msgpack.loads(body, raw=False, strict_map_key=False)
                 agents = self.raw_metadata["agents"]
                 metadata = dict(
                     agents=[{} for i in range(len(agents))],

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -6391,7 +6391,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
         public float roundToGridSize(float x, float gridSize, bool roundUp) {
-            int mFactor = (int)(1.0f / gridSize);
+            int mFactor = Convert.ToInt32(1.0f / gridSize);
             if (Math.Abs(mFactor - 1.0f / gridSize) > 1e-3) {
                 throw new Exception("1.0 / gridSize should be an integer.");
             }
@@ -6469,7 +6469,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             // Debug.Log(xMax);
             // Debug.Log(zMin);
             // Debug.Log(zMax);
-
 
             List<GameObject> agentGameObjects = new List<GameObject>();
             foreach (BaseFPSAgentController agent in agentManager.agents) {


### PR DESCRIPTION
Without this parameter `msgpack` would fail when given data corresponding to a dictionary with integer valued keys.

Also made a small change to integer rounding for one function.