### PR TITLE
unset display device

### DIFF
--- a/scripts/ai2thor-xorg
+++ b/scripts/ai2thor-xorg
@@ -160,6 +160,7 @@ Section "Screen"
     DefaultDepth    24
     Option         "AllowEmptyInitialConfiguration" "True"
     Option         "Interactive" "False"
+    Option         "UseDisplayDevice" "None"
     SubSection     "Display"
         Depth       24
         Virtual {width} {height}


### PR DESCRIPTION
When assigning display devices to X screens, the NVIDIA X driver by default assigns display devices in the order they are found [as explained here](https://download.nvidia.com/XFree86/Linux-x86/1.0-8756/README/appendix-d.html).
In headless mode, it does not seem meaningful to rely on this default behaviour. 

Leaving this option to the default setting also causes a problem when an X server is running connected to a (physical) display device, and we attempt to start a new X server to use AI2THOR in headless mode, for example via SSH.  Concretely, if an X server `:0` is already running using a display device and we attempt to start a new server `:1` via `sudo ai2thor-xorg start 1`. The script will run but examining the log file shows that the X server does not start.
Example error from log file:
```
(lines omitted)


[250998.533] (II) NVIDIA GLX Module  510.47.03  Mon Jan 24 22:57:16 UTC 2022
[250998.533] (II) NVIDIA: The X server supports PRIME Render Offload.
[250998.534] (--) NVIDIA(0): Valid display device(s) on GPU-0 at PCI:1:0:0
[250998.534] (--) NVIDIA(0):     DFP-0
[250998.534] (--) NVIDIA(0):     DFP-1
[250998.534] (--) NVIDIA(0):     DFP-2
[250998.534] (--) NVIDIA(0):     DFP-3 (boot)
[250998.534] (--) NVIDIA(0):     DFP-4
[250998.534] (--) NVIDIA(0):     DFP-5
[250998.534] (--) NVIDIA(0):     DFP-6
[250998.535] (II) NVIDIA(0): NVIDIA GPU NVIDIA GeForce RTX 3090 (GA102-A) at PCI:1:0:0
[250998.535] (II) NVIDIA(0):     (GPU-0)
[250998.535] (--) NVIDIA(0): Memory: 25165824 kBytes
[250998.535] (--) NVIDIA(0): VideoBIOS: 94.02.42.00.f1
[250998.535] (II) NVIDIA(0): Detected PCI Express Link width: 16X
[250998.535] (--) NVIDIA(GPU-0): DFP-0: disconnected
[250998.535] (--) NVIDIA(GPU-0): DFP-0: Internal TMDS
[250998.535] (--) NVIDIA(GPU-0): DFP-0: 165.0 MHz maximum pixel clock
[250998.535] (--) NVIDIA(GPU-0): 
[250998.535] (--) NVIDIA(GPU-0): DELL P2415Q (DFP-1): connected
[250998.535] (--) NVIDIA(GPU-0): DELL P2415Q (DFP-1): Internal DisplayPort
[250998.535] (--) NVIDIA(GPU-0): DELL P2415Q (DFP-1): 2670.0 MHz maximum pixel clock
[250998.535] (--) NVIDIA(GPU-0): 
[250998.537] (--) NVIDIA(GPU-0): DFP-2: disconnected
[250998.537] (--) NVIDIA(GPU-0): DFP-2: Internal TMDS
[250998.537] (--) NVIDIA(GPU-0): DFP-2: 165.0 MHz maximum pixel clock
[250998.537] (--) NVIDIA(GPU-0): 
[250998.537] (--) NVIDIA(GPU-0): DELL P2415Q (DFP-3): connected
[250998.537] (--) NVIDIA(GPU-0): DELL P2415Q (DFP-3): Internal DisplayPort
[250998.537] (--) NVIDIA(GPU-0): DELL P2415Q (DFP-3): 2670.0 MHz maximum pixel clock
[250998.538] (--) NVIDIA(GPU-0): 
[250998.540] (--) NVIDIA(GPU-0): DFP-4: disconnected
[250998.540] (--) NVIDIA(GPU-0): DFP-4: Internal TMDS
[250998.540] (--) NVIDIA(GPU-0): DFP-4: 165.0 MHz maximum pixel clock
[250998.540] (--) NVIDIA(GPU-0): 
[250998.540] (--) NVIDIA(GPU-0): DFP-5: disconnected
[250998.540] (--) NVIDIA(GPU-0): DFP-5: Internal DisplayPort
[250998.540] (--) NVIDIA(GPU-0): DFP-5: 2670.0 MHz maximum pixel clock
[250998.540] (--) NVIDIA(GPU-0): 
[250998.540] (--) NVIDIA(GPU-0): DFP-6: disconnected
[250998.540] (--) NVIDIA(GPU-0): DFP-6: Internal TMDS
[250998.540] (--) NVIDIA(GPU-0): DFP-6: 165.0 MHz maximum pixel clock
[250998.540] (--) NVIDIA(GPU-0): 
[250998.680] (==) NVIDIA(0): 
[250998.680] (==) NVIDIA(0): No modes were requested; the default mode "nvidia-auto-select"
[250998.680] (==) NVIDIA(0):     will be used as the requested mode.
[250998.680] (==) NVIDIA(0): 
[250998.685] (II) NVIDIA(0): Validated MetaModes:
[250998.685] (II) NVIDIA(0):     "DFP-3:nvidia-auto-select,DFP-1:nvidia-auto-select"
[250998.685] (**) NVIDIA(0): Virtual screen size configured to be 3840 x 2160
[250998.685] (WW) NVIDIA(0): Mode "DFP-3:nvidia-auto-select,DFP-1:nvidia-auto-select" is
[250998.685] (WW) NVIDIA(0):     larger than virtual size 3840 x 2160; discarding mode
[250998.685] (EE) NVIDIA(0): Failure to construct a valid MetaMode list: no MetaModes
[250998.685] (EE) NVIDIA(0):     remaining.
[250998.685] (EE) NVIDIA(0):  *** Aborting ***
[250998.685] (EE) NVIDIA(0): Failing initialization of X screen
[250998.685] (II) UnloadModule: "nvidia"
[250998.685] (II) UnloadSubModule: "glxserver_nvidia"
[250998.685] (II) Unloading glxserver_nvidia
[250998.685] (II) UnloadSubModule: "wfb"
[250998.685] (II) UnloadSubModule: "fb"
[250998.685] (EE) Screen(s) found, but none have a usable configuration.
[250998.685] (EE) 
Fatal server error:
[250998.685] (EE) no screens found(EE) 
[250998.685] (EE) 
Please consult the The X.Org Foundation support 
	 at http://wiki.x.org
 for help. 
[250998.685] (EE) Please also check the log file at "/var/log/ai2thor-xorg.1.log" for additional information.
[250998.685] (EE) 
[250998.710] (EE) Server terminated with error (1). Closing log file.

```