### PR TITLE
Fixes visibility point array references to child sim objects in some scenes

### DIFF
--- a/unity/Assets/Physics/SimObjsPhysics/Common Objects/SideTable/Prefabs/Side_Table_Master_Prefabs/Side_Table_313_Master.prefab
+++ b/unity/Assets/Physics/SimObjsPhysics/Common Objects/SideTable/Prefabs/Side_Table_Master_Prefabs/Side_Table_313_Master.prefab
@@ -1009,7 +1009,6 @@ MonoBehaviour:
   - {fileID: 4108774495106233449}
   - {fileID: 4108774494315300713}
   - {fileID: 4108774494077948761}
-  - {fileID: 4110147598288647554}
   ReceptacleTriggerBoxes:
   - {fileID: 4107675160526823676}
   debugIsVisible: 0

--- a/unity/Assets/Scenes/FloorPlan10_physics.unity
+++ b/unity/Assets/Scenes/FloorPlan10_physics.unity
@@ -675,12 +675,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 34859004}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &36089790 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4406262787677314, guid: 80d6102ee754f9541a3a6665b3f834ad,
-    type: 3}
-  m_PrefabInstance: {fileID: 1023532007}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &36249582
 GameObject:
   m_ObjectHideFlags: 0
@@ -4022,12 +4016,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!4 &217680028 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4644260605404268, guid: 80d6102ee754f9541a3a6665b3f834ad,
-    type: 3}
-  m_PrefabInstance: {fileID: 1023532007}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &219404293 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1000013987753920, guid: c6cf98ada65b04564908f4a586bec7f4,
@@ -6134,12 +6122,6 @@ Transform:
   m_Father: {fileID: 1562174004}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &324803307 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4342891542320454, guid: 80d6102ee754f9541a3a6665b3f834ad,
-    type: 3}
-  m_PrefabInstance: {fileID: 1023532007}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &327293151
 GameObject:
   m_ObjectHideFlags: 0
@@ -8335,12 +8317,6 @@ Transform:
   m_Father: {fileID: 1637975487}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &423153990 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4120894875314578, guid: 80d6102ee754f9541a3a6665b3f834ad,
-    type: 3}
-  m_PrefabInstance: {fileID: 1023532007}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &426054397
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -19932,11 +19908,6 @@ MonoBehaviour:
   - {fileID: 1887480151}
   - {fileID: 1885794983}
   - {fileID: 2111484568}
-  - {fileID: 423153990}
-  - {fileID: 1312821954}
-  - {fileID: 324803307}
-  - {fileID: 217680028}
-  - {fileID: 36089790}
   ReceptacleTriggerBoxes:
   - {fileID: 1289846782}
   debugIsVisible: 0
@@ -31802,12 +31773,6 @@ MonoBehaviour:
   isOpen: 0
   isCurrentlyResetting: 1
   movementType: 0
---- !u!4 &1312821954 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4338731436642380, guid: 80d6102ee754f9541a3a6665b3f834ad,
-    type: 3}
-  m_PrefabInstance: {fileID: 1023532007}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1313221034
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity/Assets/Scenes/FloorPlan12_physics.unity
+++ b/unity/Assets/Scenes/FloorPlan12_physics.unity
@@ -1310,12 +1310,6 @@ Transform:
   m_Father: {fileID: 874013307}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &60514953 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4276476098489386, guid: 03544085c8acd8546a745fbc3572b6e7,
-    type: 3}
-  m_PrefabInstance: {fileID: 121603747}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &60781295
 GameObject:
   m_ObjectHideFlags: 0
@@ -3148,18 +3142,6 @@ MonoBehaviour:
   - {fileID: 957563515}
   - {fileID: 283699946}
   - {fileID: 1568005274}
-  - {fileID: 1443202052}
-  - {fileID: 1674691325}
-  - {fileID: 1562421871}
-  - {fileID: 60514953}
-  - {fileID: 198353112}
-  - {fileID: 2113376215}
-  - {fileID: 1208604750}
-  - {fileID: 638783775}
-  - {fileID: 581604245}
-  - {fileID: 1920468311}
-  - {fileID: 1263477174}
-  - {fileID: 424313044}
   ReceptacleTriggerBoxes:
   - {fileID: 762358166}
   debugIsVisible: 0
@@ -4677,12 +4659,6 @@ Transform:
   m_Father: {fileID: 1012241527}
   m_RootOrder: 35
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &198353112 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4656896109456624, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 10742965}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &200670387
 GameObject:
   m_ObjectHideFlags: 0
@@ -8288,12 +8264,6 @@ Transform:
   m_Father: {fileID: 49052523}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &424313044 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4431565732573528, guid: 8f1141233b0ae344a99cb6b708d8be8e,
-    type: 3}
-  m_PrefabInstance: {fileID: 376365021}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &428636570 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1170333579371094, guid: 6877aba5a696347dbb6c01f851f2da28,
@@ -11408,12 +11378,6 @@ BoxCollider:
   m_CorrespondingSourceObject: {fileID: 65919964912782424, guid: 8f1141233b0ae344a99cb6b708d8be8e,
     type: 3}
   m_PrefabInstance: {fileID: 376365021}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &581604245 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4554004289956208, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 10742965}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &583430305
 GameObject:
@@ -14672,12 +14636,6 @@ Transform:
   m_Father: {fileID: 974662609}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &629041066 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4587355602094888, guid: ec9a5dc36c14eeb4c844ee8bb18add94,
-    type: 3}
-  m_PrefabInstance: {fileID: 642154164}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &632753967
 GameObject:
   m_ObjectHideFlags: 0
@@ -14799,12 +14757,6 @@ Transform:
   m_Father: {fileID: 1012241527}
   m_RootOrder: 53
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &638783775 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4091593805175234, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 10742965}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &639764005
 GameObject:
   m_ObjectHideFlags: 0
@@ -16802,12 +16754,6 @@ Transform:
   m_Father: {fileID: 1012241527}
   m_RootOrder: 72
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &806964926 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4792648429302226, guid: ec9a5dc36c14eeb4c844ee8bb18add94,
-    type: 3}
-  m_PrefabInstance: {fileID: 642154164}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &810255224
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -22132,12 +22078,6 @@ Transform:
   m_Father: {fileID: 77731347}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1097028220 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4525503980398188, guid: ec9a5dc36c14eeb4c844ee8bb18add94,
-    type: 3}
-  m_PrefabInstance: {fileID: 642154164}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1107657057
 GameObject:
   m_ObjectHideFlags: 0
@@ -24355,12 +24295,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1935878913}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &1208604750 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4570583755185738, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 10742965}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1209347192
 GameObject:
   m_ObjectHideFlags: 0
@@ -24921,12 +24855,6 @@ Transform:
   m_Father: {fileID: 1872847035}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1263477174 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4407758678994436, guid: 8f1141233b0ae344a99cb6b708d8be8e,
-    type: 3}
-  m_PrefabInstance: {fileID: 376365021}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1266927219
 GameObject:
   m_ObjectHideFlags: 0
@@ -27220,12 +27148,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6877aba5a696347dbb6c01f851f2da28, type: 3}
---- !u!4 &1383333548 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4806343889647342, guid: ec9a5dc36c14eeb4c844ee8bb18add94,
-    type: 3}
-  m_PrefabInstance: {fileID: 642154164}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1384102200
 GameObject:
   m_ObjectHideFlags: 0
@@ -29456,12 +29378,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!4 &1443202052 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4748579774428674, guid: 03544085c8acd8546a745fbc3572b6e7,
-    type: 3}
-  m_PrefabInstance: {fileID: 121603747}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1443873615
 GameObject:
   m_ObjectHideFlags: 0
@@ -32198,12 +32114,6 @@ Transform:
   m_Father: {fileID: 974662609}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1562421871 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4657896152941474, guid: 03544085c8acd8546a745fbc3572b6e7,
-    type: 3}
-  m_PrefabInstance: {fileID: 121603747}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1566645504
 GameObject:
   m_ObjectHideFlags: 0
@@ -35493,12 +35403,6 @@ Transform:
   m_Father: {fileID: 608310071}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1674691325 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4108780765355600, guid: 03544085c8acd8546a745fbc3572b6e7,
-    type: 3}
-  m_PrefabInstance: {fileID: 121603747}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1675860794
 GameObject:
   m_ObjectHideFlags: 0
@@ -37964,10 +37868,6 @@ MonoBehaviour:
   - {fileID: 418822771}
   - {fileID: 490769550}
   - {fileID: 1590606854}
-  - {fileID: 629041066}
-  - {fileID: 1097028220}
-  - {fileID: 1383333548}
-  - {fileID: 806964926}
   ReceptacleTriggerBoxes:
   - {fileID: 1069432392}
   debugIsVisible: 0
@@ -41387,12 +41287,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1919866813}
   m_Mesh: {fileID: 4300022, guid: b49ec6cb90049488095d224fde6eba8e, type: 3}
---- !u!4 &1920468311 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4968738936553170, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 10742965}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1920547033
 GameObject:
   m_ObjectHideFlags: 0
@@ -43756,12 +43650,6 @@ Transform:
   m_Father: {fileID: 974662609}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &2113376215 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4591445477991182, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 10742965}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2119643407
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity/Assets/Scenes/FloorPlan15_physics.unity
+++ b/unity/Assets/Scenes/FloorPlan15_physics.unity
@@ -121,12 +121,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 23800000, guid: cc370e2fa06dd4860bda9c94bc39fa0f, type: 2}
---- !u!4 &1707917 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4091593805175234, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 1168108871}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7082724
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2352,12 +2346,6 @@ Transform:
   m_Father: {fileID: 179992551}
   m_RootOrder: 20
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &160284385 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4657896152941474, guid: 03544085c8acd8546a745fbc3572b6e7,
-    type: 3}
-  m_PrefabInstance: {fileID: 722475718}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &163765270
 GameObject:
   m_ObjectHideFlags: 0
@@ -3999,12 +3987,6 @@ Transform:
   m_Father: {fileID: 1286886148}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &282174466 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4748579774428674, guid: 03544085c8acd8546a745fbc3572b6e7,
-    type: 3}
-  m_PrefabInstance: {fileID: 722475718}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &282817142
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11435,16 +11417,6 @@ MonoBehaviour:
   - {fileID: 1119532671}
   - {fileID: 1990054364}
   - {fileID: 1727744845}
-  - {fileID: 752798491}
-  - {fileID: 1495715592}
-  - {fileID: 1628266714}
-  - {fileID: 1707917}
-  - {fileID: 1211962599}
-  - {fileID: 1124317237}
-  - {fileID: 282174466}
-  - {fileID: 674476070}
-  - {fileID: 160284385}
-  - {fileID: 1002346978}
   ReceptacleTriggerBoxes:
   - {fileID: 2145491692}
   debugIsVisible: 0
@@ -11521,12 +11493,6 @@ MonoBehaviour:
   isOpen: 0
   isCurrentlyResetting: 1
   movementType: 0
---- !u!4 &674476070 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4108780765355600, guid: 03544085c8acd8546a745fbc3572b6e7,
-    type: 3}
-  m_PrefabInstance: {fileID: 722475718}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &675495035
 GameObject:
   m_ObjectHideFlags: 0
@@ -13424,12 +13390,6 @@ Transform:
   m_Father: {fileID: 179992551}
   m_RootOrder: 89
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &752798491 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4656896109456624, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 1168108871}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &761182581
 GameObject:
   m_ObjectHideFlags: 0
@@ -17622,12 +17582,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.9907466, y: 0.2243168, z: 0.027752284}
   m_Center: {x: 0.017005233, y: 0.032814696, z: 0.566911}
---- !u!4 &1002346978 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4276476098489386, guid: 03544085c8acd8546a745fbc3572b6e7,
-    type: 3}
-  m_PrefabInstance: {fileID: 722475718}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1002356874
 GameObject:
   m_ObjectHideFlags: 0
@@ -19654,12 +19608,6 @@ Transform:
   m_Father: {fileID: 994315322}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1124317237 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4968738936553170, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 1168108871}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1133606185 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1170333579371094, guid: 6877aba5a696347dbb6c01f851f2da28,
@@ -21254,12 +21202,6 @@ Transform:
   m_Father: {fileID: 138924139}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1211962599 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4554004289956208, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 1168108871}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1212918721
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -25465,12 +25407,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0b0d3d43ad51845dcb55b9eb473e66f3, type: 3}
---- !u!4 &1495715592 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4591445477991182, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 1168108871}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1497063768
 GameObject:
   m_ObjectHideFlags: 0
@@ -27876,12 +27812,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4195352195057886, guid: ed89725c445d47143bcc700dcc07a1ff,
     type: 3}
   m_PrefabInstance: {fileID: 745119478}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &1628266714 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4570583755185738, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 1168108871}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1628453710
 GameObject:

--- a/unity/Assets/Scenes/FloorPlan18_physics.unity
+++ b/unity/Assets/Scenes/FloorPlan18_physics.unity
@@ -10397,12 +10397,6 @@ Transform:
   m_Father: {fileID: 647838569}
   m_RootOrder: 144
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &462538665 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4738599405571354, guid: d8ef0fb3ca4de9140a79b4a8062f7ad2,
-    type: 3}
-  m_PrefabInstance: {fileID: 736027972}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &466459449
 GameObject:
   m_ObjectHideFlags: 0
@@ -17741,12 +17735,6 @@ Transform:
   m_Father: {fileID: 647838569}
   m_RootOrder: 72
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &740078104 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4874282336178846, guid: d8ef0fb3ca4de9140a79b4a8062f7ad2,
-    type: 3}
-  m_PrefabInstance: {fileID: 736027972}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &742567366
 GameObject:
   m_ObjectHideFlags: 0
@@ -29735,10 +29723,6 @@ MonoBehaviour:
   - {fileID: 574054032}
   - {fileID: 715567669}
   - {fileID: 1443506264}
-  - {fileID: 740078104}
-  - {fileID: 1511390249}
-  - {fileID: 1344088975}
-  - {fileID: 462538665}
   ReceptacleTriggerBoxes:
   - {fileID: 1008703379}
   debugIsVisible: 0
@@ -32776,12 +32760,6 @@ Transform:
   m_Father: {fileID: 647838569}
   m_RootOrder: 67
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1344088975 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4117261005153142, guid: d8ef0fb3ca4de9140a79b4a8062f7ad2,
-    type: 3}
-  m_PrefabInstance: {fileID: 736027972}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1347542270
 GameObject:
   m_ObjectHideFlags: 0
@@ -36932,12 +36910,6 @@ Transform:
   m_Father: {fileID: 435785915}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1511390249 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4169695733842618, guid: d8ef0fb3ca4de9140a79b4a8062f7ad2,
-    type: 3}
-  m_PrefabInstance: {fileID: 736027972}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1514788516 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4549816473023804, guid: 7c555b18ae7184f2aa6fb740c91052d6,

--- a/unity/Assets/Scenes/FloorPlan21_physics.unity
+++ b/unity/Assets/Scenes/FloorPlan21_physics.unity
@@ -647,7 +647,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4115332676641648, guid: 522e58c31e30e6a4887c532f9b91f55b, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.00000026285744
+      value: 0.00000026358887
       objectReference: {fileID: 0}
     - target: {fileID: 4115332676641648, guid: 522e58c31e30e6a4887c532f9b91f55b, type: 3}
       propertyPath: m_LocalRotation.y
@@ -3383,23 +3383,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4101266122864490, guid: fa9dc18e3f20c4ce8902adaa8c57615c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.5228315
+      value: -0.52284575
       objectReference: {fileID: 0}
     - target: {fileID: 4101266122864490, guid: fa9dc18e3f20c4ce8902adaa8c57615c, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.88616407
+      value: 0.8861931
       objectReference: {fileID: 0}
     - target: {fileID: 4101266122864490, guid: fa9dc18e3f20c4ce8902adaa8c57615c, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1.0813938
+      value: 1.0814162
       objectReference: {fileID: 0}
     - target: {fileID: 4101266122864490, guid: fa9dc18e3f20c4ce8902adaa8c57615c, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.000027761587
+      value: 0.000015165788
       objectReference: {fileID: 0}
     - target: {fileID: 4101266122864490, guid: fa9dc18e3f20c4ce8902adaa8c57615c, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.0000032610183
+      value: -0.00000075764547
       objectReference: {fileID: 0}
     - target: {fileID: 4101266122864490, guid: fa9dc18e3f20c4ce8902adaa8c57615c, type: 3}
       propertyPath: m_LocalRotation.y
@@ -3407,7 +3407,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4101266122864490, guid: fa9dc18e3f20c4ce8902adaa8c57615c, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.0000010575167
+      value: 0.000001904089
       objectReference: {fileID: 0}
     - target: {fileID: 4101266122864490, guid: fa9dc18e3f20c4ce8902adaa8c57615c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -4075,31 +4075,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4655522276753128, guid: d076bd718d60d8d41bfdb895097f5f9a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.2813091
+      value: -0.28131747
       objectReference: {fileID: 0}
     - target: {fileID: 4655522276753128, guid: d076bd718d60d8d41bfdb895097f5f9a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.96986544
+      value: 0.9698888
       objectReference: {fileID: 0}
     - target: {fileID: 4655522276753128, guid: d076bd718d60d8d41bfdb895097f5f9a, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1.1529399
+      value: 1.1530739
       objectReference: {fileID: 0}
     - target: {fileID: 4655522276753128, guid: d076bd718d60d8d41bfdb895097f5f9a, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.91591144
+      value: 0.915689
       objectReference: {fileID: 0}
     - target: {fileID: 4655522276753128, guid: d076bd718d60d8d41bfdb895097f5f9a, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.3261222
+      value: 0.32674
       objectReference: {fileID: 0}
     - target: {fileID: 4655522276753128, guid: d076bd718d60d8d41bfdb895097f5f9a, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.1179227
+      value: -0.11803307
       objectReference: {fileID: 0}
     - target: {fileID: 4655522276753128, guid: d076bd718d60d8d41bfdb895097f5f9a, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.2021012
+      value: 0.20204678
       objectReference: {fileID: 0}
     - target: {fileID: 4655522276753128, guid: d076bd718d60d8d41bfdb895097f5f9a, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -6035,27 +6035,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4613403647489294, guid: 03544085c8acd8546a745fbc3572b6e7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.87289745
+      value: 0.87288535
       objectReference: {fileID: 0}
     - target: {fileID: 4613403647489294, guid: 03544085c8acd8546a745fbc3572b6e7, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.19682874
+      value: -0.19682905
       objectReference: {fileID: 0}
     - target: {fileID: 4613403647489294, guid: 03544085c8acd8546a745fbc3572b6e7, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.8653833
+      value: 0.86538607
       objectReference: {fileID: 0}
     - target: {fileID: 4613403647489294, guid: 03544085c8acd8546a745fbc3572b6e7, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.00058283267
+      value: 0.00058036385
       objectReference: {fileID: 0}
     - target: {fileID: 4613403647489294, guid: 03544085c8acd8546a745fbc3572b6e7, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.50111014
+      value: 0.50110537
       objectReference: {fileID: 0}
     - target: {fileID: 4613403647489294, guid: 03544085c8acd8546a745fbc3572b6e7, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00027768014
+      value: -0.00028290576
       objectReference: {fileID: 0}
     - target: {fileID: 4613403647489294, guid: 03544085c8acd8546a745fbc3572b6e7, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
@@ -6600,15 +6600,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4091875589209426, guid: a8d2de9b2cef7e2438bebea42b7a98af, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.7401041
+      value: 0.7401045
       objectReference: {fileID: 0}
     - target: {fileID: 4091875589209426, guid: a8d2de9b2cef7e2438bebea42b7a98af, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.007052627
+      value: -0.0070325052
       objectReference: {fileID: 0}
     - target: {fileID: 4091875589209426, guid: a8d2de9b2cef7e2438bebea42b7a98af, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.5964979
+      value: -0.59646815
       objectReference: {fileID: 0}
     - target: {fileID: 4091875589209426, guid: a8d2de9b2cef7e2438bebea42b7a98af, type: 3}
       propertyPath: m_LocalRotation.w
@@ -6616,15 +6616,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4091875589209426, guid: a8d2de9b2cef7e2438bebea42b7a98af, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.0000021122385
+      value: -0.00000040978225
       objectReference: {fileID: 0}
     - target: {fileID: 4091875589209426, guid: a8d2de9b2cef7e2438bebea42b7a98af, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.0000038616236
+      value: -0.0000071299555
       objectReference: {fileID: 0}
     - target: {fileID: 4091875589209426, guid: a8d2de9b2cef7e2438bebea42b7a98af, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.000005055909
+      value: 0.0000011914447
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a8d2de9b2cef7e2438bebea42b7a98af, type: 3}
@@ -8412,31 +8412,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4624894442502850, guid: 9586dab557c6ee1419fb3f4821302b2c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.8224584
+      value: -1.822471
       objectReference: {fileID: 0}
     - target: {fileID: 4624894442502850, guid: 9586dab557c6ee1419fb3f4821302b2c, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.86693853
+      value: 0.8669614
       objectReference: {fileID: 0}
     - target: {fileID: 4624894442502850, guid: 9586dab557c6ee1419fb3f4821302b2c, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1.0026209
+      value: -1.0026131
       objectReference: {fileID: 0}
     - target: {fileID: 4624894442502850, guid: 9586dab557c6ee1419fb3f4821302b2c, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9992283
+      value: 0.99922216
       objectReference: {fileID: 0}
     - target: {fileID: 4624894442502850, guid: 9586dab557c6ee1419fb3f4821302b2c, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.015279432
+      value: 0.01521963
       objectReference: {fileID: 0}
     - target: {fileID: 4624894442502850, guid: 9586dab557c6ee1419fb3f4821302b2c, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.0018223866
+      value: -0.0018263191
       objectReference: {fileID: 0}
     - target: {fileID: 4624894442502850, guid: 9586dab557c6ee1419fb3f4821302b2c, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.036139246
+      value: 0.036334697
       objectReference: {fileID: 0}
     - target: {fileID: 54405510439664564, guid: 9586dab557c6ee1419fb3f4821302b2c,
         type: 3}
@@ -9115,37 +9115,37 @@ PrefabInstance:
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.83891934
+      value: 0.8391414
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.22371927
+      value: 0.22472055
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.39383036
+      value: 0.39319137
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.13134581
+      value: -0.13202818
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.0019129199
+      value: 0.0011415966
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.991333
+      value: 0.9912449
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.0018679948
+      value: 0.0008646548
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
@@ -9580,17 +9580,17 @@ PrefabInstance:
     - target: {fileID: 1517508792023774915, guid: 4cb443386094b4d5f9eeb05b6c4daa3d,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.35086244
+      value: -0.35087284
       objectReference: {fileID: 0}
     - target: {fileID: 1517508792023774915, guid: 4cb443386094b4d5f9eeb05b6c4daa3d,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.02563119
+      value: -0.02560246
       objectReference: {fileID: 0}
     - target: {fileID: 1517508792023774915, guid: 4cb443386094b4d5f9eeb05b6c4daa3d,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.857292
+      value: 0.8573025
       objectReference: {fileID: 0}
     - target: {fileID: 1517508792023774915, guid: 4cb443386094b4d5f9eeb05b6c4daa3d,
         type: 3}
@@ -9600,17 +9600,17 @@ PrefabInstance:
     - target: {fileID: 1517508792023774915, guid: 4cb443386094b4d5f9eeb05b6c4daa3d,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.0000015894528
+      value: -0.0000003056338
       objectReference: {fileID: 0}
     - target: {fileID: 1517508792023774915, guid: 4cb443386094b4d5f9eeb05b6c4daa3d,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.00008143497
+      value: -0.00007093232
       objectReference: {fileID: 0}
     - target: {fileID: 1517508792023774915, guid: 4cb443386094b4d5f9eeb05b6c4daa3d,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00000006024941
+      value: 0.0000000029233287
       objectReference: {fileID: 0}
     - target: {fileID: 1517508792023774915, guid: 4cb443386094b4d5f9eeb05b6c4daa3d,
         type: 3}
@@ -9836,31 +9836,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4643057185841836, guid: d1c543ac24a514417b2705739b3c0ba7, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.2610002
+      value: -1.2610015
       objectReference: {fileID: 0}
     - target: {fileID: 4643057185841836, guid: d1c543ac24a514417b2705739b3c0ba7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.03130302
+      value: -0.03129202
       objectReference: {fileID: 0}
     - target: {fileID: 4643057185841836, guid: d1c543ac24a514417b2705739b3c0ba7, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -3.6109996
+      value: -3.6109974
       objectReference: {fileID: 0}
     - target: {fileID: 4643057185841836, guid: d1c543ac24a514417b2705739b3c0ba7, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.70710725
+      value: 0.70711356
       objectReference: {fileID: 0}
     - target: {fileID: 4643057185841836, guid: d1c543ac24a514417b2705739b3c0ba7, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.00000027323193
+      value: -0.000007361276
       objectReference: {fileID: 0}
     - target: {fileID: 4643057185841836, guid: d1c543ac24a514417b2705739b3c0ba7, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.70710635
+      value: -0.70710003
       objectReference: {fileID: 0}
     - target: {fileID: 4643057185841836, guid: d1c543ac24a514417b2705739b3c0ba7, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.000000035132167
+      value: -0.0000015586163
       objectReference: {fileID: 0}
     - target: {fileID: 4643057185841836, guid: d1c543ac24a514417b2705739b3c0ba7, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
@@ -10763,31 +10763,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4818036067491336, guid: fdc09cab87950cc4c98ff3080290b1b6, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.88195616
+      value: 0.88110465
       objectReference: {fileID: 0}
     - target: {fileID: 4818036067491336, guid: fdc09cab87950cc4c98ff3080290b1b6, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.6562656
+      value: 0.657388
       objectReference: {fileID: 0}
     - target: {fileID: 4818036067491336, guid: fdc09cab87950cc4c98ff3080290b1b6, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.3399895
+      value: 0.3402083
       objectReference: {fileID: 0}
     - target: {fileID: 4818036067491336, guid: fdc09cab87950cc4c98ff3080290b1b6, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9999913
+      value: 0.99998903
       objectReference: {fileID: 0}
     - target: {fileID: 4818036067491336, guid: fdc09cab87950cc4c98ff3080290b1b6, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.0016586479
+      value: 0.0020430062
       objectReference: {fileID: 0}
     - target: {fileID: 4818036067491336, guid: fdc09cab87950cc4c98ff3080290b1b6, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.002825722
+      value: 0.0036223228
       objectReference: {fileID: 0}
     - target: {fileID: 4818036067491336, guid: fdc09cab87950cc4c98ff3080290b1b6, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.0025931543
+      value: 0.0021688014
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fdc09cab87950cc4c98ff3080290b1b6, type: 3}
@@ -11109,31 +11109,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4042404749135100, guid: bf146d8dcd333a448b5b553e2ed3bb4e, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.6469995
+      value: 0.64699095
       objectReference: {fileID: 0}
     - target: {fileID: 4042404749135100, guid: bf146d8dcd333a448b5b553e2ed3bb4e, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.87437695
+      value: 0.8743437
       objectReference: {fileID: 0}
     - target: {fileID: 4042404749135100, guid: bf146d8dcd333a448b5b553e2ed3bb4e, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.06898792
+      value: -0.068983324
       objectReference: {fileID: 0}
     - target: {fileID: 4042404749135100, guid: bf146d8dcd333a448b5b553e2ed3bb4e, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.92332697
+      value: 0.92332786
       objectReference: {fileID: 0}
     - target: {fileID: 4042404749135100, guid: bf146d8dcd333a448b5b553e2ed3bb4e, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.002332989
+      value: 0.0029692063
       objectReference: {fileID: 0}
     - target: {fileID: 4042404749135100, guid: bf146d8dcd333a448b5b553e2ed3bb4e, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.38400656
+      value: 0.38400006
       objectReference: {fileID: 0}
     - target: {fileID: 4042404749135100, guid: bf146d8dcd333a448b5b553e2ed3bb4e, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00092784537
+      value: 0.00081948936
       objectReference: {fileID: 0}
     - target: {fileID: 4042404749135100, guid: bf146d8dcd333a448b5b553e2ed3bb4e, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
@@ -12181,37 +12181,37 @@ PrefabInstance:
     - target: {fileID: 626195691514342360, guid: 2529fc1a396a4443fade9b51897cb9a5,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.7900741
+      value: 0.78948843
       objectReference: {fileID: 0}
     - target: {fileID: 626195691514342360, guid: 2529fc1a396a4443fade9b51897cb9a5,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.6559067
+      value: 0.6563818
       objectReference: {fileID: 0}
     - target: {fileID: 626195691514342360, guid: 2529fc1a396a4443fade9b51897cb9a5,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.5478483
+      value: 0.54821855
       objectReference: {fileID: 0}
     - target: {fileID: 626195691514342360, guid: 2529fc1a396a4443fade9b51897cb9a5,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9999978
+      value: 0.99999624
       objectReference: {fileID: 0}
     - target: {fileID: 626195691514342360, guid: 2529fc1a396a4443fade9b51897cb9a5,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.001188316
+      value: 0.0022369048
       objectReference: {fileID: 0}
     - target: {fileID: 626195691514342360, guid: 2529fc1a396a4443fade9b51897cb9a5,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.00076527585
+      value: -0.00007227149
       objectReference: {fileID: 0}
     - target: {fileID: 626195691514342360, guid: 2529fc1a396a4443fade9b51897cb9a5,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.0015701521
+      value: 0.0016124033
       objectReference: {fileID: 0}
     - target: {fileID: 629410298267782516, guid: 2529fc1a396a4443fade9b51897cb9a5,
         type: 3}
@@ -12702,37 +12702,37 @@ PrefabInstance:
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.74998534
+      value: 0.7500468
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.22456837
+      value: 0.22561647
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.2877479
+      value: 0.28727043
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.9999932
+      value: -0.9999813
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.0006410777
+      value: -0.004619032
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.0030660986
+      value: -0.0038241085
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.001930682
+      value: 0.0012019291
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
@@ -16936,12 +16936,12 @@ PrefabInstance:
     - target: {fileID: 3389595269524055914, guid: 9cff5d78530613543b8d9c1ef0fa33ec,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.03216815
+      value: -0.032168806
       objectReference: {fileID: 0}
     - target: {fileID: 3389595269524055914, guid: 9cff5d78530613543b8d9c1ef0fa33ec,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -3.5079987
+      value: -3.5079994
       objectReference: {fileID: 0}
     - target: {fileID: 3389595269524055914, guid: 9cff5d78530613543b8d9c1ef0fa33ec,
         type: 3}
@@ -16951,17 +16951,17 @@ PrefabInstance:
     - target: {fileID: 3389595269524055914, guid: 9cff5d78530613543b8d9c1ef0fa33ec,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.0000000182282
+      value: -0.00000007259703
       objectReference: {fileID: 0}
     - target: {fileID: 3389595269524055914, guid: 9cff5d78530613543b8d9c1ef0fa33ec,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.0000006678916
+      value: 0.00000043779698
       objectReference: {fileID: 0}
     - target: {fileID: 3389595269524055914, guid: 9cff5d78530613543b8d9c1ef0fa33ec,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.000000019915916
+      value: -0.00000004800728
       objectReference: {fileID: 0}
     - target: {fileID: 3389595269524055914, guid: 9cff5d78530613543b8d9c1ef0fa33ec,
         type: 3}
@@ -17507,15 +17507,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4176478889463182, guid: 9f81ad5d25f70a14e85d3af2c1265ece, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.95099276
+      value: 0.9509934
       objectReference: {fileID: 0}
     - target: {fileID: 4176478889463182, guid: 9f81ad5d25f70a14e85d3af2c1265ece, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.8721617
+      value: 0.8721596
       objectReference: {fileID: 0}
     - target: {fileID: 4176478889463182, guid: 9f81ad5d25f70a14e85d3af2c1265ece, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.019002607
+      value: 0.019003773
       objectReference: {fileID: 0}
     - target: {fileID: 4176478889463182, guid: 9f81ad5d25f70a14e85d3af2c1265ece, type: 3}
       propertyPath: m_LocalRotation.w
@@ -17523,15 +17523,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4176478889463182, guid: 9f81ad5d25f70a14e85d3af2c1265ece, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.00000017380806
+      value: 0.000019831712
       objectReference: {fileID: 0}
     - target: {fileID: 4176478889463182, guid: 9f81ad5d25f70a14e85d3af2c1265ece, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.000009537122
+      value: -0.0000148600675
       objectReference: {fileID: 0}
     - target: {fileID: 4176478889463182, guid: 9f81ad5d25f70a14e85d3af2c1265ece, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.000003798504
+      value: -0.000036410038
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9f81ad5d25f70a14e85d3af2c1265ece, type: 3}
@@ -17685,37 +17685,37 @@ PrefabInstance:
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.76171833
+      value: 0.761859
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.22425574
+      value: 0.22524208
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.3374764
+      value: 0.3369736
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.041546375
+      value: -0.042263117
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.0022855652
+      value: 0.0017700485
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.99912363
+      value: 0.9991047
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.004546657
+      value: 0.0007984638
       objectReference: {fileID: 0}
     - target: {fileID: 3897009944158510405, guid: ebbe78a841a52364ab6a35badd4b6c22,
         type: 3}
@@ -18741,15 +18741,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4287940584782898, guid: 4efd4977fabeaf34d9f3402544390362, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.6600002
+      value: 0.6600003
       objectReference: {fileID: 0}
     - target: {fileID: 4287940584782898, guid: 4efd4977fabeaf34d9f3402544390362, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.0058057383
+      value: -0.0057629496
       objectReference: {fileID: 0}
     - target: {fileID: 4287940584782898, guid: 4efd4977fabeaf34d9f3402544390362, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.109992675
+      value: -0.10999274
       objectReference: {fileID: 0}
     - target: {fileID: 4287940584782898, guid: 4efd4977fabeaf34d9f3402544390362, type: 3}
       propertyPath: m_LocalRotation.w
@@ -18757,15 +18757,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4287940584782898, guid: 4efd4977fabeaf34d9f3402544390362, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.0000071229006
+      value: -0.0000001279459
       objectReference: {fileID: 0}
     - target: {fileID: 4287940584782898, guid: 4efd4977fabeaf34d9f3402544390362, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.000008407888
+      value: 0.000008840627
       objectReference: {fileID: 0}
     - target: {fileID: 4287940584782898, guid: 4efd4977fabeaf34d9f3402544390362, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.000021365862
+      value: -0.000000067055225
       objectReference: {fileID: 0}
     - target: {fileID: 54582007869483682, guid: 4efd4977fabeaf34d9f3402544390362,
         type: 3}
@@ -18931,31 +18931,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4627990185706254, guid: 70c8a3866dcb34ed995697f124934b9c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.8730967
+      value: 0.8730895
       objectReference: {fileID: 0}
     - target: {fileID: 4627990185706254, guid: 70c8a3866dcb34ed995697f124934b9c, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.86505675
+      value: 0.86510015
       objectReference: {fileID: 0}
     - target: {fileID: 4627990185706254, guid: 70c8a3866dcb34ed995697f124934b9c, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1.2559544
+      value: -1.2559774
       objectReference: {fileID: 0}
     - target: {fileID: 4627990185706254, guid: 70c8a3866dcb34ed995697f124934b9c, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7074307
+      value: 0.70746505
       objectReference: {fileID: 0}
     - target: {fileID: 4627990185706254, guid: 70c8a3866dcb34ed995697f124934b9c, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.0014682658
+      value: 0.0014464742
       objectReference: {fileID: 0}
     - target: {fileID: 4627990185706254, guid: 70c8a3866dcb34ed995697f124934b9c, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.706777
+      value: -0.70674324
       objectReference: {fileID: 0}
     - target: {fileID: 4627990185706254, guid: 70c8a3866dcb34ed995697f124934b9c, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.0024143006
+      value: 0.002267666
       objectReference: {fileID: 0}
     - target: {fileID: 4627990185706254, guid: 70c8a3866dcb34ed995697f124934b9c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
@@ -20265,17 +20265,17 @@ PrefabInstance:
     - target: {fileID: 8873704766655386261, guid: 912b7e9972840cc48bd89b613f4d049d,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -2.037574
+      value: -2.0375752
       objectReference: {fileID: 0}
     - target: {fileID: 8873704766655386261, guid: 912b7e9972840cc48bd89b613f4d049d,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.83050555
+      value: 0.8305326
       objectReference: {fileID: 0}
     - target: {fileID: 8873704766655386261, guid: 912b7e9972840cc48bd89b613f4d049d,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1.1650835
+      value: -1.1650783
       objectReference: {fileID: 0}
     - target: {fileID: 8873704766655386261, guid: 912b7e9972840cc48bd89b613f4d049d,
         type: 3}
@@ -20285,17 +20285,17 @@ PrefabInstance:
     - target: {fileID: 8873704766655386261, guid: 912b7e9972840cc48bd89b613f4d049d,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.0015740566
+      value: 0.0015775472
       objectReference: {fileID: 0}
     - target: {fileID: 8873704766655386261, guid: 912b7e9972840cc48bd89b613f4d049d,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.0047093793
+      value: 0.0047097853
       objectReference: {fileID: 0}
     - target: {fileID: 8873704766655386261, guid: 912b7e9972840cc48bd89b613f4d049d,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.0000066783396
+      value: 0.0000073644624
       objectReference: {fileID: 0}
     - target: {fileID: 8873704766655386261, guid: 912b7e9972840cc48bd89b613f4d049d,
         type: 3}
@@ -22559,19 +22559,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4511095621582240, guid: 8f1141233b0ae344a99cb6b708d8be8e, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.6532832
+      value: 0.65328294
       objectReference: {fileID: 0}
     - target: {fileID: 4511095621582240, guid: 8f1141233b0ae344a99cb6b708d8be8e, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.27059793
+      value: 0.27059814
       objectReference: {fileID: 0}
     - target: {fileID: 4511095621582240, guid: 8f1141233b0ae344a99cb6b708d8be8e, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.27059707
+      value: 0.27059686
       objectReference: {fileID: 0}
     - target: {fileID: 4511095621582240, guid: 8f1141233b0ae344a99cb6b708d8be8e, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.65328026
+      value: 0.65328056
       objectReference: {fileID: 0}
     - target: {fileID: 4511095621582240, guid: 8f1141233b0ae344a99cb6b708d8be8e, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -23554,11 +23554,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4340207458070068, guid: 455a094c271f5394f9d1f479ae9a4a8b, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.8746942
+      value: 0.87469417
       objectReference: {fileID: 0}
     - target: {fileID: 4340207458070068, guid: 455a094c271f5394f9d1f479ae9a4a8b, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.28800046
+      value: -0.28800052
       objectReference: {fileID: 0}
     - target: {fileID: 4340207458070068, guid: 455a094c271f5394f9d1f479ae9a4a8b, type: 3}
       propertyPath: m_LocalRotation.w
@@ -23566,15 +23566,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4340207458070068, guid: 455a094c271f5394f9d1f479ae9a4a8b, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.00000042526315
+      value: -0.000000040991722
       objectReference: {fileID: 0}
     - target: {fileID: 4340207458070068, guid: 455a094c271f5394f9d1f479ae9a4a8b, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.0000025846416
+      value: -0.0000026361838
       objectReference: {fileID: 0}
     - target: {fileID: 4340207458070068, guid: 455a094c271f5394f9d1f479ae9a4a8b, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.00000073212414
+      value: 0.0000009904818
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 455a094c271f5394f9d1f479ae9a4a8b, type: 3}
@@ -24367,31 +24367,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4334840752624284, guid: b535842c08243b349ad9f6fe18034185, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.034356415
+      value: 0.034356117
       objectReference: {fileID: 0}
     - target: {fileID: 4334840752624284, guid: b535842c08243b349ad9f6fe18034185, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.009306192
+      value: -0.009306252
       objectReference: {fileID: 0}
     - target: {fileID: 4334840752624284, guid: b535842c08243b349ad9f6fe18034185, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.06267314
+      value: -0.06267302
       objectReference: {fileID: 0}
     - target: {fileID: 4334840752624284, guid: b535842c08243b349ad9f6fe18034185, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.27060238
+      value: 0.27060303
       objectReference: {fileID: 0}
     - target: {fileID: 4334840752624284, guid: b535842c08243b349ad9f6fe18034185, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.6532576
+      value: -0.6532612
       objectReference: {fileID: 0}
     - target: {fileID: 4334840752624284, guid: b535842c08243b349ad9f6fe18034185, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.6533069
+      value: -0.65330124
       objectReference: {fileID: 0}
     - target: {fileID: 4334840752624284, guid: b535842c08243b349ad9f6fe18034185, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.27059
+      value: 0.2705945
       objectReference: {fileID: 0}
     - target: {fileID: 4334840752624284, guid: b535842c08243b349ad9f6fe18034185, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -24755,15 +24755,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4931733808133278, guid: dade90b9136994290b13bcaa1e6806c2, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.9948146
+      value: -1.9948074
       objectReference: {fileID: 0}
     - target: {fileID: 4931733808133278, guid: dade90b9136994290b13bcaa1e6806c2, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.6903565
+      value: 0.6903554
       objectReference: {fileID: 0}
     - target: {fileID: 4931733808133278, guid: dade90b9136994290b13bcaa1e6806c2, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -3.650944
+      value: -3.6511571
       objectReference: {fileID: 0}
     - target: {fileID: 4931733808133278, guid: dade90b9136994290b13bcaa1e6806c2, type: 3}
       propertyPath: m_LocalRotation.w
@@ -24771,15 +24771,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4931733808133278, guid: dade90b9136994290b13bcaa1e6806c2, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.0000010534527
+      value: 0.00000223913
       objectReference: {fileID: 0}
     - target: {fileID: 4931733808133278, guid: dade90b9136994290b13bcaa1e6806c2, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.000028240771
+      value: 0.000020367705
       objectReference: {fileID: 0}
     - target: {fileID: 4931733808133278, guid: dade90b9136994290b13bcaa1e6806c2, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00000016775448
+      value: -0.0000005365
       objectReference: {fileID: 0}
     - target: {fileID: 4931733808133278, guid: dade90b9136994290b13bcaa1e6806c2, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -25454,31 +25454,43 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4520317742381546, guid: dbfbe7486d13926429f13e9c57702493, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.988538
+      value: -1.9885416
       objectReference: {fileID: 0}
     - target: {fileID: 4520317742381546, guid: dbfbe7486d13926429f13e9c57702493, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.84888095
+      value: 0.83035344
       objectReference: {fileID: 0}
     - target: {fileID: 4520317742381546, guid: dbfbe7486d13926429f13e9c57702493, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1.5891684
+      value: -1.5891676
       objectReference: {fileID: 0}
     - target: {fileID: 4520317742381546, guid: dbfbe7486d13926429f13e9c57702493, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.00014115135
+      value: -0.68740416
       objectReference: {fileID: 0}
     - target: {fileID: 4520317742381546, guid: dbfbe7486d13926429f13e9c57702493, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.6874041
+      value: -0.00032890198
       objectReference: {fileID: 0}
     - target: {fileID: 4520317742381546, guid: dbfbe7486d13926429f13e9c57702493, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.000056819546
+      value: 0.7262751
       objectReference: {fileID: 0}
     - target: {fileID: 4520317742381546, guid: dbfbe7486d13926429f13e9c57702493, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.7262752
+      value: -0.00015608
+      objectReference: {fileID: 0}
+    - target: {fileID: 4520317742381546, guid: dbfbe7486d13926429f13e9c57702493, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -0.006
+      objectReference: {fileID: 0}
+    - target: {fileID: 4520317742381546, guid: dbfbe7486d13926429f13e9c57702493, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -93.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 4520317742381546, guid: dbfbe7486d13926429f13e9c57702493, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -359.983
       objectReference: {fileID: 0}
     - target: {fileID: 54616535284173798, guid: dbfbe7486d13926429f13e9c57702493,
         type: 3}
@@ -26491,31 +26503,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4468376325903498, guid: 4e98163d12cf5b844967076eb276319d, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.8881259
+      value: 0.8871681
       objectReference: {fileID: 0}
     - target: {fileID: 4468376325903498, guid: 4e98163d12cf5b844967076eb276319d, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.65641576
+      value: 0.6578364
       objectReference: {fileID: 0}
     - target: {fileID: 4468376325903498, guid: 4e98163d12cf5b844967076eb276319d, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.2646076
+      value: 0.2648247
       objectReference: {fileID: 0}
     - target: {fileID: 4468376325903498, guid: 4e98163d12cf5b844967076eb276319d, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.99998885
+      value: 0.99998564
       objectReference: {fileID: 0}
     - target: {fileID: 4468376325903498, guid: 4e98163d12cf5b844967076eb276319d, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.0016703142
+      value: 0.0019864573
       objectReference: {fileID: 0}
     - target: {fileID: 4468376325903498, guid: 4e98163d12cf5b844967076eb276319d, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.003652885
+      value: 0.0044269855
       objectReference: {fileID: 0}
     - target: {fileID: 4468376325903498, guid: 4e98163d12cf5b844967076eb276319d, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.002481116
+      value: 0.0022841715
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4e98163d12cf5b844967076eb276319d, type: 3}
@@ -27464,31 +27476,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4603158493763888, guid: 76e4dba10d66931489eff319fe25de9c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.6475755
+      value: -1.6476324
       objectReference: {fileID: 0}
     - target: {fileID: 4603158493763888, guid: 76e4dba10d66931489eff319fe25de9c, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.87859654
+      value: 0.878604
       objectReference: {fileID: 0}
     - target: {fileID: 4603158493763888, guid: 76e4dba10d66931489eff319fe25de9c, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1.1390104
+      value: -1.1389903
       objectReference: {fileID: 0}
     - target: {fileID: 4603158493763888, guid: 76e4dba10d66931489eff319fe25de9c, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9999971
+      value: 0.99999756
       objectReference: {fileID: 0}
     - target: {fileID: 4603158493763888, guid: 76e4dba10d66931489eff319fe25de9c, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.00003633002
+      value: 0.00008723906
       objectReference: {fileID: 0}
     - target: {fileID: 4603158493763888, guid: 76e4dba10d66931489eff319fe25de9c, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.002292739
+      value: 0.0022242372
       objectReference: {fileID: 0}
     - target: {fileID: 4603158493763888, guid: 76e4dba10d66931489eff319fe25de9c, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.0008488244
+      value: -0.00021820774
       objectReference: {fileID: 0}
     - target: {fileID: 54789938220433148, guid: 76e4dba10d66931489eff319fe25de9c,
         type: 3}
@@ -28258,31 +28270,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4840955435415930, guid: 00036467bafd340d6a5dada84cfabfe5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.9037769
+      value: -1.9037863
       objectReference: {fileID: 0}
     - target: {fileID: 4840955435415930, guid: 00036467bafd340d6a5dada84cfabfe5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.8738579
+      value: 0.8738822
       objectReference: {fileID: 0}
     - target: {fileID: 4840955435415930, guid: 00036467bafd340d6a5dada84cfabfe5, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1.402523
+      value: -1.4025168
       objectReference: {fileID: 0}
     - target: {fileID: 4840955435415930, guid: 00036467bafd340d6a5dada84cfabfe5, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.63164026
+      value: 0.6316006
       objectReference: {fileID: 0}
     - target: {fileID: 4840955435415930, guid: 00036467bafd340d6a5dada84cfabfe5, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.11297745
+      value: -0.11288744
       objectReference: {fileID: 0}
     - target: {fileID: 4840955435415930, guid: 00036467bafd340d6a5dada84cfabfe5, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.30750266
+      value: -0.30757108
       objectReference: {fileID: 0}
     - target: {fileID: 4840955435415930, guid: 00036467bafd340d6a5dada84cfabfe5, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.7026442
+      value: 0.7026643
       objectReference: {fileID: 0}
     - target: {fileID: 54165944952663604, guid: 00036467bafd340d6a5dada84cfabfe5,
         type: 3}
@@ -29001,31 +29013,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4843470684545140, guid: f04343d5a0f16304392b506c7a5d7b0f, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.7789923
+      value: 0.778993
       objectReference: {fileID: 0}
     - target: {fileID: 4843470684545140, guid: f04343d5a0f16304392b506c7a5d7b0f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.88017225
+      value: 0.8801625
       objectReference: {fileID: 0}
     - target: {fileID: 4843470684545140, guid: f04343d5a0f16304392b506c7a5d7b0f, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.04801482
+      value: -0.048012145
       objectReference: {fileID: 0}
     - target: {fileID: 4843470684545140, guid: f04343d5a0f16304392b506c7a5d7b0f, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9659311
+      value: 0.9659323
       objectReference: {fileID: 0}
     - target: {fileID: 4843470684545140, guid: f04343d5a0f16304392b506c7a5d7b0f, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.000046828296
+      value: 0.00015056334
       objectReference: {fileID: 0}
     - target: {fileID: 4843470684545140, guid: f04343d5a0f16304392b506c7a5d7b0f, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.25879955
+      value: 0.25879464
       objectReference: {fileID: 0}
     - target: {fileID: 4843470684545140, guid: f04343d5a0f16304392b506c7a5d7b0f, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.00014178199
+      value: 0.00016115546
       objectReference: {fileID: 0}
     - target: {fileID: 4843470684545140, guid: f04343d5a0f16304392b506c7a5d7b0f, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -29232,31 +29244,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4041571560229498, guid: c93822d17e7093747959a673fb9f6ae1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.87379664
+      value: -0.87378025
       objectReference: {fileID: 0}
     - target: {fileID: 4041571560229498, guid: c93822d17e7093747959a673fb9f6ae1, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.92717904
+      value: 0.92750543
       objectReference: {fileID: 0}
     - target: {fileID: 4041571560229498, guid: c93822d17e7093747959a673fb9f6ae1, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.9891392
+      value: 0.9892453
       objectReference: {fileID: 0}
     - target: {fileID: 4041571560229498, guid: c93822d17e7093747959a673fb9f6ae1, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.97772455
+      value: 0.9777195
       objectReference: {fileID: 0}
     - target: {fileID: 4041571560229498, guid: c93822d17e7093747959a673fb9f6ae1, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.0016286123
+      value: -0.00048797898
       objectReference: {fileID: 0}
     - target: {fileID: 4041571560229498, guid: c93822d17e7093747959a673fb9f6ae1, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.20988531
+      value: 0.20991513
       objectReference: {fileID: 0}
     - target: {fileID: 4041571560229498, guid: c93822d17e7093747959a673fb9f6ae1, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.00039433932
+      value: 0.0001641129
       objectReference: {fileID: 0}
     - target: {fileID: 4041571560229498, guid: c93822d17e7093747959a673fb9f6ae1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
@@ -31963,37 +31975,37 @@ PrefabInstance:
     - target: {fileID: 8857152442721663885, guid: e44fe2cf6937f48acb4e8c98f48fb12a,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.6107454
+      value: -1.610744
       objectReference: {fileID: 0}
     - target: {fileID: 8857152442721663885, guid: e44fe2cf6937f48acb4e8c98f48fb12a,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.024867535
+      value: -0.024866045
       objectReference: {fileID: 0}
     - target: {fileID: 8857152442721663885, guid: e44fe2cf6937f48acb4e8c98f48fb12a,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1.4241992
+      value: -1.4242373
       objectReference: {fileID: 0}
     - target: {fileID: 8857152442721663885, guid: e44fe2cf6937f48acb4e8c98f48fb12a,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.8543207
+      value: 0.8543065
       objectReference: {fileID: 0}
     - target: {fileID: 8857152442721663885, guid: e44fe2cf6937f48acb4e8c98f48fb12a,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.011652057
+      value: -0.011653163
       objectReference: {fileID: 0}
     - target: {fileID: 8857152442721663885, guid: e44fe2cf6937f48acb4e8c98f48fb12a,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.5195718
+      value: -0.519595
       objectReference: {fileID: 0}
     - target: {fileID: 8857152442721663885, guid: e44fe2cf6937f48acb4e8c98f48fb12a,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.0067512095
+      value: -0.006755039
       objectReference: {fileID: 0}
     - target: {fileID: 8857152442721663885, guid: e44fe2cf6937f48acb4e8c98f48fb12a,
         type: 3}
@@ -32837,37 +32849,37 @@ PrefabInstance:
     - target: {fileID: 7525009459317085850, guid: 657fd426710204418a2142a929a1a58e,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.9298412
+      value: -1.929837
       objectReference: {fileID: 0}
     - target: {fileID: 7525009459317085850, guid: 657fd426710204418a2142a929a1a58e,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.03515941
+      value: -0.03513515
       objectReference: {fileID: 0}
     - target: {fileID: 7525009459317085850, guid: 657fd426710204418a2142a929a1a58e,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1.398213
+      value: -1.3982186
       objectReference: {fileID: 0}
     - target: {fileID: 7525009459317085850, guid: 657fd426710204418a2142a929a1a58e,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.70603746
+      value: 0.70604193
       objectReference: {fileID: 0}
     - target: {fileID: 7525009459317085850, guid: 657fd426710204418a2142a929a1a58e,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.0000054398147
+      value: -0.0000043625446
       objectReference: {fileID: 0}
     - target: {fileID: 7525009459317085850, guid: 657fd426710204418a2142a929a1a58e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7081745
+      value: 0.70817006
       objectReference: {fileID: 0}
     - target: {fileID: 7525009459317085850, guid: 657fd426710204418a2142a929a1a58e,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.000009486684
+      value: 0.000010563758
       objectReference: {fileID: 0}
     - target: {fileID: 7525009459317085850, guid: 657fd426710204418a2142a929a1a58e,
         type: 3}
@@ -33843,31 +33855,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4289084853422284, guid: 7fd6bd431a682344db67dfc67a2fcab6, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -2.0709963
+      value: -2.070956
       objectReference: {fileID: 0}
     - target: {fileID: 4289084853422284, guid: 7fd6bd431a682344db67dfc67a2fcab6, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.92632616
+      value: 0.9263236
       objectReference: {fileID: 0}
     - target: {fileID: 4289084853422284, guid: 7fd6bd431a682344db67dfc67a2fcab6, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.77200603
+      value: 0.7720191
       objectReference: {fileID: 0}
     - target: {fileID: 4289084853422284, guid: 7fd6bd431a682344db67dfc67a2fcab6, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.68383044
+      value: 0.68383116
       objectReference: {fileID: 0}
     - target: {fileID: 4289084853422284, guid: 7fd6bd431a682344db67dfc67a2fcab6, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.000014283055
+      value: -0.0000020156635
       objectReference: {fileID: 0}
     - target: {fileID: 4289084853422284, guid: 7fd6bd431a682344db67dfc67a2fcab6, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.729641
+      value: -0.7296403
       objectReference: {fileID: 0}
     - target: {fileID: 4289084853422284, guid: 7fd6bd431a682344db67dfc67a2fcab6, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.000013299287
+      value: -0.00000073760737
       objectReference: {fileID: 0}
     - target: {fileID: 4289084853422284, guid: 7fd6bd431a682344db67dfc67a2fcab6, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
@@ -37095,37 +37107,37 @@ PrefabInstance:
     - target: {fileID: 4520672013405550090, guid: f347d103855cf4a85a1d3321c35bbd96,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.7702643
+      value: -0.7702638
       objectReference: {fileID: 0}
     - target: {fileID: 4520672013405550090, guid: f347d103855cf4a85a1d3321c35bbd96,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.032992736
+      value: -0.032992676
       objectReference: {fileID: 0}
     - target: {fileID: 4520672013405550090, guid: f347d103855cf4a85a1d3321c35bbd96,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -3.5417373
+      value: -3.541737
       objectReference: {fileID: 0}
     - target: {fileID: 4520672013405550090, guid: f347d103855cf4a85a1d3321c35bbd96,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.000028837469
+      value: -0.000029650051
       objectReference: {fileID: 0}
     - target: {fileID: 4520672013405550090, guid: f347d103855cf4a85a1d3321c35bbd96,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.0032193712
+      value: 0.00322581
       objectReference: {fileID: 0}
     - target: {fileID: 4520672013405550090, guid: f347d103855cf4a85a1d3321c35bbd96,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.99999475
+      value: 0.9999948
       objectReference: {fileID: 0}
     - target: {fileID: 4520672013405550090, guid: f347d103855cf4a85a1d3321c35bbd96,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.00039105112
+      value: -0.00035379827
       objectReference: {fileID: 0}
     - target: {fileID: 4520672013405550090, guid: f347d103855cf4a85a1d3321c35bbd96,
         type: 3}
@@ -37184,37 +37196,37 @@ PrefabInstance:
     - target: {fileID: 5218227465579007626, guid: 5a33987fb5dac40a0872bbe647d3e922,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.7689422
+      value: 0.769325
       objectReference: {fileID: 0}
     - target: {fileID: 5218227465579007626, guid: 5a33987fb5dac40a0872bbe647d3e922,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.030702174
+      value: -0.030345708
       objectReference: {fileID: 0}
     - target: {fileID: 5218227465579007626, guid: 5a33987fb5dac40a0872bbe647d3e922,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.4434977
+      value: 0.44230852
       objectReference: {fileID: 0}
     - target: {fileID: 5218227465579007626, guid: 5a33987fb5dac40a0872bbe647d3e922,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.99999404
+      value: 0.9999921
       objectReference: {fileID: 0}
     - target: {fileID: 5218227465579007626, guid: 5a33987fb5dac40a0872bbe647d3e922,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.0019923279
+      value: 0.0031571763
       objectReference: {fileID: 0}
     - target: {fileID: 5218227465579007626, guid: 5a33987fb5dac40a0872bbe647d3e922,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.00047397002
+      value: 0.0012153421
       objectReference: {fileID: 0}
     - target: {fileID: 5218227465579007626, guid: 5a33987fb5dac40a0872bbe647d3e922,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.0027732204
+      value: -0.0021334656
       objectReference: {fileID: 0}
     - target: {fileID: 5218227465579007626, guid: 5a33987fb5dac40a0872bbe647d3e922,
         type: 3}

--- a/unity/Assets/Scenes/FloorPlan21_physics.unity
+++ b/unity/Assets/Scenes/FloorPlan21_physics.unity
@@ -344,10 +344,6 @@ MonoBehaviour:
   - {fileID: 538722555}
   - {fileID: 2122854997}
   - {fileID: 1883527012}
-  - {fileID: 208537710}
-  - {fileID: 523922482}
-  - {fileID: 817388275}
-  - {fileID: 727609248}
   ReceptacleTriggerBoxes:
   - {fileID: 1245071549}
   debugIsVisible: 0
@@ -2624,12 +2620,6 @@ Transform:
   m_Father: {fileID: 746940465}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &208537710 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4155253401998692, guid: b535842c08243b349ad9f6fe18034185,
-    type: 3}
-  m_PrefabInstance: {fileID: 1412944259}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &208732352
 GameObject:
   m_ObjectHideFlags: 0
@@ -8029,12 +8019,6 @@ Transform:
   m_Father: {fileID: 242715598}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &523922482 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4605530397411024, guid: b535842c08243b349ad9f6fe18034185,
-    type: 3}
-  m_PrefabInstance: {fileID: 1412944259}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &530653365
 GameObject:
   m_ObjectHideFlags: 0
@@ -11291,12 +11275,6 @@ Transform:
   m_Father: {fileID: 922788200}
   m_RootOrder: 104
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &727609248 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4159293908784396, guid: b535842c08243b349ad9f6fe18034185,
-    type: 3}
-  m_PrefabInstance: {fileID: 1412944259}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &729434285
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13394,12 +13372,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 588b43f56a2dd4e599d593c538844eb4, type: 3}
---- !u!4 &817388275 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4648121779304014, guid: b535842c08243b349ad9f6fe18034185,
-    type: 3}
-  m_PrefabInstance: {fileID: 1412944259}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &819627300
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity/Assets/Scenes/FloorPlan25_physics.unity
+++ b/unity/Assets/Scenes/FloorPlan25_physics.unity
@@ -2564,12 +2564,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!4 &160195986 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4679336976360926, guid: c6fedd6d89fc3b147bca7de7606a712d,
-    type: 3}
-  m_PrefabInstance: {fileID: 61848579}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &166551804
 GameObject:
   m_ObjectHideFlags: 0
@@ -3807,12 +3801,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!4 &286509995 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4592158002023782, guid: f04343d5a0f16304392b506c7a5d7b0f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1987980656}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &287304266
 GameObject:
   m_ObjectHideFlags: 0
@@ -3980,12 +3968,6 @@ Transform:
   m_Father: {fileID: 1957905716}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &299691082 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261868079265054, guid: f04343d5a0f16304392b506c7a5d7b0f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1987980656}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &308407830
 GameObject:
   m_ObjectHideFlags: 0
@@ -6020,12 +6002,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.08944091, y: 0.29977557, z: 0.13915816}
   m_Center: {x: -0.0000029373914, y: -0.017696058, z: 0.009889186}
---- !u!4 &427413296 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4976701536669826, guid: c6fedd6d89fc3b147bca7de7606a712d,
-    type: 3}
-  m_PrefabInstance: {fileID: 61848579}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &429104760
 GameObject:
   m_ObjectHideFlags: 0
@@ -6873,13 +6849,6 @@ MonoBehaviour:
   - {fileID: 1502958598}
   - {fileID: 762725207}
   - {fileID: 1295031216}
-  - {fileID: 299691082}
-  - {fileID: 286509995}
-  - {fileID: 2077796786}
-  - {fileID: 1993761343}
-  - {fileID: 490885011}
-  - {fileID: 951991393}
-  - {fileID: 1761309178}
   ReceptacleTriggerBoxes:
   - {fileID: 345966817}
   debugIsVisible: 0
@@ -7279,12 +7248,6 @@ Transform:
   m_Father: {fileID: 1387038514}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &490885011 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4070048948680822, guid: f04343d5a0f16304392b506c7a5d7b0f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1987980656}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &495781261
 GameObject:
   m_ObjectHideFlags: 0
@@ -14009,12 +13972,6 @@ Transform:
   m_Father: {fileID: 1581769082}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &869074598 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4541269618607896, guid: c6fedd6d89fc3b147bca7de7606a712d,
-    type: 3}
-  m_PrefabInstance: {fileID: 61848579}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &870724761
 GameObject:
   m_ObjectHideFlags: 0
@@ -15378,12 +15335,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4744e610a62c12c469020c63d73628bb, type: 3}
---- !u!4 &951991393 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4852329233568062, guid: f04343d5a0f16304392b506c7a5d7b0f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1987980656}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &952116039
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15489,12 +15440,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 709f921ada058144aa05c031ba993334, type: 3}
---- !u!4 &952782917 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4514412547887958, guid: c6fedd6d89fc3b147bca7de7606a712d,
-    type: 3}
-  m_PrefabInstance: {fileID: 61848579}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &956011522 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1682789330437360, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
@@ -20057,12 +20002,6 @@ Transform:
   m_Father: {fileID: 1066135024}
   m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1213171569 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4817531035689588, guid: c6fedd6d89fc3b147bca7de7606a712d,
-    type: 3}
-  m_PrefabInstance: {fileID: 61848579}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1217483616
 GameObject:
   m_ObjectHideFlags: 0
@@ -28313,12 +28252,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.9667553, y: 0, z: 1.0192351}
   m_Center: {x: -1.7016616, y: 0.22215597, z: 1.3590094}
---- !u!4 &1726468159 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4623768930026964, guid: c6fedd6d89fc3b147bca7de7606a712d,
-    type: 3}
-  m_PrefabInstance: {fileID: 61848579}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1730430616 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3393919604232115232, guid: 4744e610a62c12c469020c63d73628bb,
@@ -28742,12 +28675,6 @@ Transform:
   m_Father: {fileID: 1416119364}
   m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1761309178 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4306328986420940, guid: f04343d5a0f16304392b506c7a5d7b0f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1987980656}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1762002548
 GameObject:
   m_ObjectHideFlags: 0
@@ -30059,12 +29986,6 @@ Transform:
   m_Father: {fileID: 2069811642}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1893376665 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4079187646326356, guid: c6fedd6d89fc3b147bca7de7606a712d,
-    type: 3}
-  m_PrefabInstance: {fileID: 61848579}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1899800384
 GameObject:
   m_ObjectHideFlags: 0
@@ -31667,13 +31588,6 @@ MonoBehaviour:
   - {fileID: 1330081631}
   - {fileID: 1809131580}
   - {fileID: 1474422756}
-  - {fileID: 427413296}
-  - {fileID: 869074598}
-  - {fileID: 1213171569}
-  - {fileID: 1893376665}
-  - {fileID: 1726468159}
-  - {fileID: 952782917}
-  - {fileID: 160195986}
   ReceptacleTriggerBoxes:
   - {fileID: 227069109}
   debugIsVisible: 0
@@ -35078,12 +34992,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &1993761343 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4000798592362378, guid: f04343d5a0f16304392b506c7a5d7b0f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1987980656}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1995802989
 GameObject:
   m_ObjectHideFlags: 0
@@ -36943,12 +36851,6 @@ Transform:
   m_Father: {fileID: 1396754610}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &2077796786 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4924317538327088, guid: f04343d5a0f16304392b506c7a5d7b0f,
-    type: 3}
-  m_PrefabInstance: {fileID: 1987980656}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2087248818
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/unity/Assets/Scenes/FloorPlan26_physics.unity
+++ b/unity/Assets/Scenes/FloorPlan26_physics.unity
@@ -543,12 +543,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &20210780 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4656896109456624, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 354466666}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &22516073
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4558,12 +4552,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4575429849768824, guid: ec49c23979f923740a98ad289833a5f2,
     type: 3}
   m_PrefabInstance: {fileID: 1937414248}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &137342702 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4968738936553170, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 354466666}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &144434864 stripped
 MonoBehaviour:
@@ -11316,16 +11304,6 @@ MonoBehaviour:
   - {fileID: 1267253140}
   - {fileID: 1414578212}
   - {fileID: 1739067763}
-  - {fileID: 20210780}
-  - {fileID: 904502244}
-  - {fileID: 748311853}
-  - {fileID: 1128777839}
-  - {fileID: 1345990074}
-  - {fileID: 137342702}
-  - {fileID: 1495396587}
-  - {fileID: 877274929}
-  - {fileID: 634405783}
-  - {fileID: 1535421758}
   ReceptacleTriggerBoxes:
   - {fileID: 1020761332}
   debugIsVisible: 0
@@ -11920,12 +11898,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4122276284449954, guid: 123d5caca1bedab449727f958ee5f5e7,
     type: 3}
   m_PrefabInstance: {fileID: 1272549928}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &634405783 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4657896152941474, guid: 03544085c8acd8546a745fbc3572b6e7,
-    type: 3}
-  m_PrefabInstance: {fileID: 157354059}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &635195078
 GameObject:
@@ -13682,12 +13654,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.31397307, y: 0.23205598, z: 0.21256652}
   m_Center: {x: 0.000000045898705, y: 0.000000021104992, z: 0.106283225}
---- !u!4 &748311853 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4570583755185738, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 354466666}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &749414920
 GameObject:
   m_ObjectHideFlags: 0
@@ -16453,12 +16419,6 @@ Transform:
   m_Father: {fileID: 1535922817}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &877274929 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4108780765355600, guid: 03544085c8acd8546a745fbc3572b6e7,
-    type: 3}
-  m_PrefabInstance: {fileID: 157354059}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &877607878
 GameObject:
   m_ObjectHideFlags: 0
@@ -16781,12 +16741,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4951662166496182, guid: 1061d6bcb5a5f462c8f551c086ec50d0,
     type: 3}
   m_PrefabInstance: {fileID: 901426529}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &904502244 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4591445477991182, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 354466666}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &909578244
 GameObject:
@@ -20401,12 +20355,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1128390589}
   m_Mesh: {fileID: 4300136, guid: 8f375c0755db44db18960497b85bff49, type: 3}
---- !u!4 &1128777839 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4091593805175234, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 354466666}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1133429984
 GameObject:
   m_ObjectHideFlags: 0
@@ -24070,12 +24018,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9cff5d78530613543b8d9c1ef0fa33ec, type: 3}
---- !u!4 &1345990074 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4554004289956208, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 354466666}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1347674502
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -26395,12 +26337,6 @@ Transform:
   m_Father: {fileID: 1218286589}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1495396587 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4748579774428674, guid: 03544085c8acd8546a745fbc3572b6e7,
-    type: 3}
-  m_PrefabInstance: {fileID: 157354059}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1496463396
 GameObject:
   m_ObjectHideFlags: 0
@@ -27112,12 +27048,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4488622536216656, guid: 2373f26c9f49443848ef0cf39c944887,
     type: 3}
   m_PrefabInstance: {fileID: 1532321768}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &1535421758 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4276476098489386, guid: 03544085c8acd8546a745fbc3572b6e7,
-    type: 3}
-  m_PrefabInstance: {fileID: 157354059}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1535922816
 GameObject:

--- a/unity/Assets/Scenes/FloorPlan2_physics.unity
+++ b/unity/Assets/Scenes/FloorPlan2_physics.unity
@@ -8303,8 +8303,6 @@ MonoBehaviour:
   - {fileID: 972449596}
   - {fileID: 1342663458}
   - {fileID: 1363771765}
-  - {fileID: 1972955910}
-  - {fileID: 1429558963}
   ReceptacleTriggerBoxes:
   - {fileID: 1624981526}
   debugIsVisible: 0
@@ -47772,12 +47770,6 @@ MonoBehaviour:
   isOpen: 0
   isCurrentlyResetting: 1
   movementType: 0
---- !u!4 &1429558963 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4431565732573528, guid: 8f1141233b0ae344a99cb6b708d8be8e,
-    type: 3}
-  m_PrefabInstance: {fileID: 860587997}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1429751890
 GameObject:
   m_ObjectHideFlags: 0
@@ -64232,12 +64224,6 @@ Transform:
   m_Father: {fileID: 406852861}
   m_RootOrder: 33
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1972955910 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4407758678994436, guid: 8f1141233b0ae344a99cb6b708d8be8e,
-    type: 3}
-  m_PrefabInstance: {fileID: 860587997}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1974676849
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity/Assets/Scenes/FloorPlan409_physics.unity
+++ b/unity/Assets/Scenes/FloorPlan409_physics.unity
@@ -886,12 +886,6 @@ Transform:
   m_Father: {fileID: 100330244}
   m_RootOrder: 101
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &96588043 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4361049977104692, guid: 62f8fabf487b643f495e78223dbbc769,
-    type: 3}
-  m_PrefabInstance: {fileID: 970167275}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &100330243
 GameObject:
   m_ObjectHideFlags: 0
@@ -3440,12 +3434,6 @@ Transform:
   m_Father: {fileID: 100330244}
   m_RootOrder: 89
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &377854137 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4505397767759070, guid: 62f8fabf487b643f495e78223dbbc769,
-    type: 3}
-  m_PrefabInstance: {fileID: 970167275}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &378161814 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1195772804979278, guid: 5ff2f790828fbc04190295e93c6d649f,
@@ -4051,12 +4039,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.023576975, y: 0.29682827, z: 0.36677998}
   m_Center: {x: -0.24199498, y: -0.0017431229, z: 0.0015162826}
---- !u!4 &432635888 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4081742687852858, guid: 62f8fabf487b643f495e78223dbbc769,
-    type: 3}
-  m_PrefabInstance: {fileID: 970167275}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &433574407
 GameObject:
   m_ObjectHideFlags: 0
@@ -15628,12 +15610,6 @@ Transform:
   m_Father: {fileID: 1595665087}
   m_RootOrder: 26
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1260353278 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4213480252525654, guid: 62f8fabf487b643f495e78223dbbc769,
-    type: 3}
-  m_PrefabInstance: {fileID: 970167275}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1266586180
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -16027,12 +16003,6 @@ MonoBehaviour:
   - {fileID: 794849256}
   - {fileID: 1248133348}
   - {fileID: 1890474844}
-  - {fileID: 1260353278}
-  - {fileID: 1990028868}
-  - {fileID: 96588043}
-  - {fileID: 377854137}
-  - {fileID: 1421655951}
-  - {fileID: 432635888}
   ReceptacleTriggerBoxes:
   - {fileID: 1007358201}
   debugIsVisible: 0
@@ -17512,12 +17482,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.46985602, y: 0.26256713, z: 0.007873416}
   m_Center: {x: 0.0030158758, y: -0.0017431229, z: 0.1664893}
---- !u!4 &1421655951 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4150381260731800, guid: 62f8fabf487b643f495e78223dbbc769,
-    type: 3}
-  m_PrefabInstance: {fileID: 970167275}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1422458204
 GameObject:
   m_ObjectHideFlags: 0
@@ -24800,12 +24764,6 @@ Transform:
   m_Father: {fileID: 1392223725}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1990028868 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4362746275855098, guid: 62f8fabf487b643f495e78223dbbc769,
-    type: 3}
-  m_PrefabInstance: {fileID: 970167275}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1991537464
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity/Assets/Scenes/FloorPlan7_physics.unity
+++ b/unity/Assets/Scenes/FloorPlan7_physics.unity
@@ -1504,12 +1504,6 @@ Transform:
   m_Father: {fileID: 1816139755}
   m_RootOrder: 225
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &56169031 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4591445477991182, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 1005671795}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &62526929
 GameObject:
   m_ObjectHideFlags: 0
@@ -8084,12 +8078,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.46958762, y: 0.74858695, z: 0.38863075}
   m_Center: {x: -0.22814533, y: 0, z: -0.14952499}
---- !u!4 &358702696 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4656896109456624, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 1005671795}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &359968243 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1682789330437360, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
@@ -10245,12 +10233,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4764689ff1b454595b0f96f8940e176b, type: 3}
---- !u!4 &482919920 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4968738936553170, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 1005671795}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &484037508
 GameObject:
   m_ObjectHideFlags: 0
@@ -10511,12 +10493,6 @@ Transform:
   m_Father: {fileID: 1816139755}
   m_RootOrder: 78
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &497841591 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4091593805175234, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 1005671795}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &497854264
 GameObject:
   m_ObjectHideFlags: 0
@@ -14474,12 +14450,6 @@ Transform:
   m_Father: {fileID: 1736503747}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &656464590 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4108780765355600, guid: 03544085c8acd8546a745fbc3572b6e7,
-    type: 3}
-  m_PrefabInstance: {fileID: 1231952557}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &658112959
 GameObject:
   m_ObjectHideFlags: 0
@@ -19584,12 +19554,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.49704984, y: 0.55384374, z: 0.7965927}
   m_Center: {x: -0.2118014, y: 0.0015338659, z: 0.061090767}
---- !u!4 &859926889 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4570583755185738, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 1005671795}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &861548258
 GameObject:
   m_ObjectHideFlags: 0
@@ -34743,12 +34707,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1624473806}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &1398143838 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4657896152941474, guid: 03544085c8acd8546a745fbc3572b6e7,
-    type: 3}
-  m_PrefabInstance: {fileID: 1231952557}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1399340729
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -37232,12 +37190,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.44999993, y: 0.535, z: 0.043112457}
   m_Center: {x: 0.22499996, y: 0, z: 0}
---- !u!4 &1503361397 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4554004289956208, guid: bf146d8dcd333a448b5b553e2ed3bb4e,
-    type: 3}
-  m_PrefabInstance: {fileID: 1005671795}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1503829663
 GameObject:
   m_ObjectHideFlags: 0
@@ -50280,12 +50232,6 @@ Transform:
   m_Father: {fileID: 1816139755}
   m_RootOrder: 181
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1915320718 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4748579774428674, guid: 03544085c8acd8546a745fbc3572b6e7,
-    type: 3}
-  m_PrefabInstance: {fileID: 1231952557}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1915942657
 GameObject:
   m_ObjectHideFlags: 0
@@ -50810,12 +50756,6 @@ Transform:
   m_Father: {fileID: 1456857757}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &1953321941 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4276476098489386, guid: 03544085c8acd8546a745fbc3572b6e7,
-    type: 3}
-  m_PrefabInstance: {fileID: 1231952557}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1953791456 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4208264001939292, guid: 365ddce364272443ca748cfb98355a45,
@@ -56484,16 +56424,6 @@ MonoBehaviour:
   - {fileID: 471441059}
   - {fileID: 268041082}
   - {fileID: 605930911}
-  - {fileID: 1915320718}
-  - {fileID: 656464590}
-  - {fileID: 1398143838}
-  - {fileID: 1953321941}
-  - {fileID: 358702696}
-  - {fileID: 56169031}
-  - {fileID: 859926889}
-  - {fileID: 497841591}
-  - {fileID: 1503361397}
-  - {fileID: 482919920}
   ReceptacleTriggerBoxes:
   - {fileID: 1815298761}
   debugIsVisible: 0


### PR DESCRIPTION
Fixes toward issue #975 

Some nested sim objects were set up such that their parent sim object referenced the nested object's visibility points in the parent sim object's array. This caused the arrays to have null references when the child sim object was removed from the scene via actions like `RemoveFromScene`.

This PR fixes all objects erroneously referenced in this way.