### PR TITLE
ai2thor-xorg UseDisplayDevice None

### DIFF
--- a/scripts/ai2thor-xorg
+++ b/scripts/ai2thor-xorg
@@ -57,6 +57,22 @@ def find_devices(excluded_device_ids):
 
     return devices
 
+def active_display_bus_ids():
+    # this determines whether a monitor is connected to the GPU
+    # if one is, the following Option is added for the Screen "UseDisplayDevice" "None"
+    command = "nvidia-smi --query-gpu=pci.bus_id,display_active --format=csv,noheader"
+    active_bus_ids = set()
+    result = subprocess.run(command, shell=True, stdout=subprocess.PIPE)
+    if result.returncode == 0:
+        for line in result.stdout.decode().strip().split("\n"):
+            nvidia_bus_id, display_status = re.split(r",\s?", line.strip())
+            bus_id = "PCI:" + ":".join(
+                map(lambda x: str(int(x, 16)), re.split(r"[:\.]", nvidia_bus_id)[1:])
+            )
+            if display_status.lower() == "enabled":
+                active_bus_ids.add(bus_id)
+
+    return active_bus_ids
 
 def pci_records():
     records = []
@@ -136,6 +152,7 @@ def generate_xorg_conf(
         excluded_device_ids: List[int], width: int, height: int
 ):
     devices = find_devices(excluded_device_ids)
+    active_display_devices = active_display_bus_ids()
 
     xorg_conf = []
 
@@ -160,6 +177,7 @@ Section "Screen"
     DefaultDepth    24
     Option         "AllowEmptyInitialConfiguration" "True"
     Option         "Interactive" "False"
+    {extra_options}
     SubSection     "Display"
         Depth       24
         Virtual {width} {height}
@@ -168,8 +186,14 @@ EndSection
 """
     screen_records = []
     for i, bus_id in enumerate(devices):
+        extra_options = ""
+        if bus_id in active_display_devices:
+            # See https://github.com/allenai/ai2thor/pull/990
+            # when a monitor is connected, this option must be used otherwise
+            # Xorg will fail to start
+            extra_options = 'Option         "UseDisplayDevice" "None"'
         xorg_conf.append(device_section.format(device_id=i, bus_id=bus_id))
-        xorg_conf.append(screen_section.format(device_id=i, screen_id=i, width=width, height=height))
+        xorg_conf.append(screen_section.format(device_id=i, screen_id=i, width=width, height=height, extra_options=extra_options))
         screen_records.append(
             'Screen {screen_id} "Screen{screen_id}" 0 0'.format(screen_id=i)
         )


### PR DESCRIPTION
When a monitor is connected to a graphics device it must be excluded from a headless Xorg configuration otherwise X will fail to start.  This option is documented here: https://download.nvidia.com/XFree86/Linux-x86/1.0-8756/README/appendix-d.html

Tesla/GRID GPUs don't support this option and Xorg will fail to start if the option is present.  This is the reason that the option can't simply be included for all configurations.