### PR TITLE
Expert action accepting target position

### DIFF
--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -2776,10 +2776,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         ServerAction action = new ServerAction();
                         action.action = "ObjectNavExpertAction";
 
-                        // pass in a min range, max range, delay
-                        if (splitcommand.Length > 1) {
+                        if (splitcommand.Length == 2) {
                             // ID of spawner
                             action.objectType = splitcommand[1];
+                        }
+                        else if (splitcommand.Length >= 4) {
+                            // Target position
+                            action.position = new Vector3(float.Parse(splitcommand[1]), float.Parse(splitcommand[2]), float.Parse(splitcommand[3]));
                         }
 
                         CurrentActiveController().ProcessControlCommand(action);


### PR DESCRIPTION
Adds  option of `position` argument to `ObjectNavExpertAction` to track a position instead of a SimObject when `objectType` and `objectId` are not passed.