### PR TITLE
snapToGrid error when stepDegrees not 90, 180, 270

### DIFF
--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -554,6 +554,11 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
         public abstract void InitializeBody();
 
+         private bool ValidRotateStepDegreesWithSnapToGrid(float rotateDegrees) {
+            // float eps = 0.00001f;
+            return rotateDegrees == 90.0f || rotateDegrees == 180.0f || rotateDegrees == 270.0f || (rotateDegrees % 360.0f) == 0.0f;
+        }
+
         public void Initialize(ServerAction action) {
             this.InitializeBody();
             m_Camera.GetComponent<FirstPersonCharacterCull>().SwitchRenderersToHide(this.VisibilityCapsule);
@@ -593,6 +598,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             // default is 90 defined in the ServerAction class, specify whatever you want the default to be
             if (action.rotateStepDegrees > 0.0) {
                 this.rotateStepDegrees = action.rotateStepDegrees;
+            }
+
+             if (action.snapToGrid && !ValidRotateStepDegreesWithSnapToGrid(action.rotateStepDegrees)) {
+                errorMessage = $"Invalid values 'rotateStepDegrees': ${action.rotateStepDegrees} and 'snapToGrid':${action.snapToGrid}. 'snapToGrid': 'True'a is not supported when 'rotateStepDegrees' is different from grid rotation steps of 0, 90, 180, 270 or 360.";
+                Debug.Log(errorMessage);
+                actionFinished(false);
+                return;
             }
 
             this.snapToGrid = action.snapToGrid;

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -601,7 +601,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
 
              if (action.snapToGrid && !ValidRotateStepDegreesWithSnapToGrid(action.rotateStepDegrees)) {
-                errorMessage = $"Invalid values 'rotateStepDegrees': ${action.rotateStepDegrees} and 'snapToGrid':${action.snapToGrid}. 'snapToGrid': 'True'a is not supported when 'rotateStepDegrees' is different from grid rotation steps of 0, 90, 180, 270 or 360.";
+                errorMessage = $"Invalid values 'rotateStepDegrees': ${action.rotateStepDegrees} and 'snapToGrid':${action.snapToGrid}. 'snapToGrid': 'True' is not supported when 'rotateStepDegrees' is different from grid rotation steps of 0, 90, 180, 270 or 360.";
                 Debug.Log(errorMessage);
                 actionFinished(false);
                 return;


### PR DESCRIPTION
* Throws error when setting `snapToGrid` to `true` and `rotateStepDegrees` to something different than 0, 90, 180, 270 or modulo 0 of 360, which mean can make it go outside of the grid.