### PR TITLE
mapping gpu_device to Vulkan device index

### DIFF
--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -977,8 +977,12 @@ class Controller(object):
                 % (fullscreen, QUALITY_SETTINGS[self.quality], width, height)
             )
         
-        if self.gpu_device:
-            command += " -force-device-index %d" % self.gpu_device
+        if self.gpu_device is not None:
+            # This parameter only applies to the CloudRendering platform.
+            # Vulkan maps the passed in parameter to device-index - 1 when compared
+            # to the nvidia-smi device ids
+            device_index = self.gpu_device if self.gpu_device < 1 else self.gpu_device + 1
+            command += " -force-device-index %d" % device_index
 
         return shlex.split(command)
 

--- a/ai2thor/tests/test_controller.py
+++ b/ai2thor/tests/test_controller.py
@@ -437,6 +437,75 @@ def test_last_action(mocker):
     assert c.last_action == action2
     assert e.metadata["lastActionSuccess"]
 
+def test_unity_command_force_device_index(mocker):
+    mocker.patch("ai2thor.controller.platform_system", fake_linux_system)
+    mocker.patch("ai2thor.controller.ai2thor.build.Build.exists", fake_exists)
+    mocker.patch("ai2thor.controller.ai2thor.build.Build.download", noop_download)
+    mocker.patch("ai2thor.controller.ai2thor.platform.select_platforms", select_platforms_linux_cr)
+    mocker.patch(
+        "ai2thor.controller.ai2thor.platform.CloudRendering.validate", fake_validate
+    )
+    mocker.patch(
+        "ai2thor.controller.ai2thor.platform.Linux64.validate",
+        fake_invalid_linux64_validate,
+    )
+
+    mocker.patch("ai2thor.platform.CloudRendering.enabled", True)
+    original_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
+    try:
+        os.environ["CUDA_VISIBLE_DEVICES"] = "2,3,4"
+
+        c = controller(platform=CloudRendering, gpu_device=1)
+        assert c.unity_command(650, 550, False) == [
+            c._build.executable_path,
+            "-screen-fullscreen",
+            "0",
+            "-screen-quality",
+            "7",
+            "-screen-width",
+            "650",
+            "-screen-height",
+            "550",
+            '-force-device-index',
+            '4'
+        ]
+    finally:
+        if original_visible_devices:
+            os.environ["CUDA_VISIBLE_DEVICES"] = original_visible_devices
+        else:
+            del os.environ["CUDA_VISIBLE_DEVICES"]
+
+    c = controller(platform=CloudRendering, gpu_device=5)
+    assert c.unity_command(650, 550, False) == [
+        c._build.executable_path,
+        "-screen-fullscreen",
+        "0",
+        "-screen-quality",
+        "7",
+        "-screen-width",
+        "650",
+        "-screen-height",
+        "550",
+        '-force-device-index',
+        '6'
+    ]
+
+    c = controller(platform=CloudRendering, gpu_device=0)
+    assert c.unity_command(650, 550, False) == [
+        c._build.executable_path,
+        "-screen-fullscreen",
+        "0",
+        "-screen-quality",
+        "7",
+        "-screen-width",
+        "650",
+        "-screen-height",
+        "550",
+        '-force-device-index',
+        '0'
+    ]
+
+
 
 def test_unity_command(mocker):
     mocker.patch("ai2thor.controller.platform_system", fake_linux_system)


### PR DESCRIPTION
This PR ensures that the `gpu_device` Controller param matches the indexes returned from nvidia-smi.  