### PR TITLE
Changing the maxUpwardLookAngle of the locobot so that it can look upwards by up to 30 degrees.

### DIFF
--- a/unity/Assets/Scripts/LocobotFPSAgentController.cs
+++ b/unity/Assets/Scripts/LocobotFPSAgentController.cs
@@ -52,9 +52,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             standingLocalCameraPosition = m_Camera.transform.localPosition;
             crouchingLocalCameraPosition = m_Camera.transform.localPosition + new Vector3(0, -0.2206f, 0);// smaller y offset if Bot
 
-            // limit camera from looking too far down
-            this.maxDownwardLookAngle = 30f;
-            this.maxUpwardLookAngle = 30f + 1e-6f; // Adding 1e-6f in case of floating point issues.
+            // limit camera from looking too far down/up
+            this.maxDownwardLookAngle = 60f + 1e-6f; // Adding 1e-6f in case of floating point issues.
+            this.maxUpwardLookAngle = 30f + 1e-6f;
             // this.horizonAngles = new float[] { 30.0f, 0.0f, 330.0f };
         }
 

--- a/unity/Assets/Scripts/LocobotFPSAgentController.cs
+++ b/unity/Assets/Scripts/LocobotFPSAgentController.cs
@@ -54,7 +54,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             // limit camera from looking too far down
             this.maxDownwardLookAngle = 30f;
-            this.maxUpwardLookAngle = 29f;
+            this.maxUpwardLookAngle = 30f + 1e-6f; // Adding 1e-6f in case of floating point issues.
             // this.horizonAngles = new float[] { 30.0f, 0.0f, 330.0f };
         }
 

--- a/unity/Assets/Scripts/LocobotFPSAgentController.cs
+++ b/unity/Assets/Scripts/LocobotFPSAgentController.cs
@@ -53,8 +53,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             crouchingLocalCameraPosition = m_Camera.transform.localPosition + new Vector3(0, -0.2206f, 0);// smaller y offset if Bot
 
             // limit camera from looking too far down/up
-            this.maxDownwardLookAngle = 60f + 1e-6f; // Adding 1e-6f in case of floating point issues.
-            this.maxUpwardLookAngle = 30f + 1e-6f;
+            this.maxDownwardLookAngle = 60f;
+            this.maxUpwardLookAngle = 30f;
             // this.horizonAngles = new float[] { 30.0f, 0.0f, 330.0f };
         }
 


### PR DESCRIPTION
This reverts a change made several months ago and allows the locobot to look upwards above the horizon line.

This PR also allows the locobot to look downwards by up to 60 degrees as is mentioned in the documentation.