### PR TITLE
Remove `Destroy` inside of GenerateMetadata

### DIFF
--- a/unity/Assets/Scripts/IK_Robot_Arm_Controller.cs
+++ b/unity/Assets/Scripts/IK_Robot_Arm_Controller.cs
@@ -40,6 +40,8 @@ public partial class IK_Robot_Arm_Controller : MonoBehaviour {
 
     private const float extendedArmLength = 0.6325f;
 
+    private GameObject surrogateChild = null;
+
     public CollisionListener collisionListener;
 
     void Start() {
@@ -746,7 +748,9 @@ public partial class IK_Robot_Arm_Controller : MonoBehaviour {
         List<JointMetadata> joints = new List<JointMetadata>();
 
         // Declare variables used for processing metadata
-        GameObject surrogateChild = new GameObject();
+        if (surrogateChild == null) {
+            surrogateChild = new GameObject();
+        }
         Transform parentJoint;
         float angleRot;
         Vector3 vectorRot;
@@ -824,7 +828,10 @@ public partial class IK_Robot_Arm_Controller : MonoBehaviour {
             joints.Add(jointMeta);
         }
 
-        Destroy(surrogateChild);
+        surrogateChild.transform.SetParent(null);
+        surrogateChild.transform.position = Vector3.zero;
+        surrogateChild.transform.rotation = Quaternion.identity;
+
         meta.joints = joints.ToArray();
 
         // metadata for any objects currently held by the hand on the arm

--- a/unity/Assets/Scripts/IK_Robot_Arm_Controller.cs
+++ b/unity/Assets/Scripts/IK_Robot_Arm_Controller.cs
@@ -174,7 +174,7 @@ public partial class IK_Robot_Arm_Controller : MonoBehaviour {
                 point0: point0,
                 point1: point1,
                 radius: radius,
-                layerMask: LayerMask.GetMask("SimObjVisible", "Procedural1", "Procedural2", "Procedural3", "Procedural0"),
+                layerMask: LayerMask.GetMask("SimObjVisible"),
                 queryTriggerInteraction: QueryTriggerInteraction.Ignore
             );
             foreach (Collider col in cols) {
@@ -188,7 +188,7 @@ public partial class IK_Robot_Arm_Controller : MonoBehaviour {
                 center: b.transform.TransformPoint(b.center),
                 halfExtents: b.size / 2.0f,
                 orientation: b.transform.rotation,
-                layerMask: LayerMask.GetMask("SimObjVisible", "Procedural1", "Procedural2", "Procedural3", "Procedural0"),
+                layerMask: LayerMask.GetMask("SimObjVisible"),
                 queryTriggerInteraction: QueryTriggerInteraction.Ignore
             );
             foreach (Collider col in cols) {

--- a/unity/Assets/Scripts/Stretch_Robot_Arm_Controller.cs
+++ b/unity/Assets/Scripts/Stretch_Robot_Arm_Controller.cs
@@ -43,6 +43,8 @@ public partial class Stretch_Robot_Arm_Controller : MonoBehaviour {
 
     //private const float extendedArmLength = 0.8065f;
 
+    private GameObject surrogateChild = null;
+
     public CollisionListener collisionListener;
 
     void Start() {
@@ -644,7 +646,9 @@ public partial class Stretch_Robot_Arm_Controller : MonoBehaviour {
         List<JointMetadata> joints = new List<JointMetadata>();
 
         // Declare variables used for processing metadata
-        GameObject surrogateChild = new GameObject();
+        if (surrogateChild == null) {
+            surrogateChild = new GameObject();
+        }
         Transform parentJoint;
         float angleRot;
         Vector3 vectorRot;
@@ -726,7 +730,10 @@ public partial class Stretch_Robot_Arm_Controller : MonoBehaviour {
             joints.Add(jointMeta);
         }
 
-        Destroy(surrogateChild);
+        surrogateChild.transform.SetParent(null);
+        surrogateChild.transform.position = Vector3.zero;
+        surrogateChild.transform.rotation = Quaternion.identity;
+
         meta.joints = joints.ToArray();
 
         // metadata for any objects currently held by the hand on the arm

--- a/unity/Assets/Scripts/Stretch_Robot_Arm_Controller.cs
+++ b/unity/Assets/Scripts/Stretch_Robot_Arm_Controller.cs
@@ -169,7 +169,7 @@ public partial class Stretch_Robot_Arm_Controller : MonoBehaviour {
                 point0: point0,
                 point1: point1,
                 radius: radius,
-                layerMask: LayerMask.GetMask("SimObjVisible", "Procedural1", "Procedural2", "Procedural3", "Procedural0"),
+                layerMask: LayerMask.GetMask("SimObjVisible"),
                 queryTriggerInteraction: QueryTriggerInteraction.Ignore
             );
             foreach (Collider col in cols) {
@@ -183,7 +183,7 @@ public partial class Stretch_Robot_Arm_Controller : MonoBehaviour {
                 center: b.transform.TransformPoint(b.center),
                 halfExtents: b.size / 2.0f,
                 orientation: b.transform.rotation,
-                layerMask: LayerMask.GetMask("SimObjVisible", "Procedural1", "Procedural2", "Procedural3", "Procedural0"),
+                layerMask: LayerMask.GetMask("SimObjVisible"),
                 queryTriggerInteraction: QueryTriggerInteraction.Ignore
             );
             foreach (Collider col in cols) {


### PR DESCRIPTION
We've found rare cases where the `Controller` hangs forever if `Destroy` is called. Hanging occurs very inconsistently and after several millions of steps during training, making it extremely hard to debug.

This attempts to work around the use of the Destroy function here by reusing the same surrogateChild object if it has been created, otherwise, it creates a new one.