### PR TITLE
remove agentControllerType from ServerAction

### DIFF
--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -57,7 +57,6 @@ def build_controller(**args):
 
 _wsgi_controller = build_controller(server_class=WsgiServer)
 _fifo_controller = build_controller(server_class=FifoServer)
-_stochastic_controller = build_controller(agentControllerType="stochastic", agentMode="stochastic")
 
 
 def skip_reset(controller):
@@ -85,18 +84,12 @@ def wsgi_controller():
 
 
 @pytest.fixture
-def stochastic_controller():
-    return reset_controller(_stochastic_controller)
-
-
-@pytest.fixture
 def fifo_controller():
     return reset_controller(_fifo_controller)
 
 
 fifo_wsgi = [_fifo_controller, _wsgi_controller]
 fifo = [_fifo_controller]
-fifo_wsgi_stoch = [_fifo_controller, _wsgi_controller, _stochastic_controller]
 
 BASE_FP28_POSITION = dict(x=-1.5, z=-1.5, y=0.901,)
 BASE_FP28_LOCATION = dict(
@@ -109,16 +102,6 @@ def teleport_to_base_location(controller: Controller):
 
     controller.step("TeleportFull", **BASE_FP28_LOCATION)
     assert controller.last_event.metadata["lastActionSuccess"]
-
-
-def setup_function(function):
-    for c in fifo_wsgi_stoch:
-        reset_controller(c)
-
-
-def teardown_module(module):
-    for c in fifo_wsgi_stoch:
-        c.stop()
 
 
 def assert_near(point1, point2, error_message=""):
@@ -135,18 +118,6 @@ def assert_images_near(image1, image2, max_mean_pixel_diff=1):
 
 def assert_images_far(image1, image2, min_mean_pixel_diff=10):
     return np.mean(np.abs(image1 - image2).flatten()) >= min_mean_pixel_diff
-
-
-def test_stochastic_controller(stochastic_controller):
-    stochastic_controller.reset(TEST_SCENE)
-    assert stochastic_controller.last_event.metadata["lastActionSuccess"]
-
-def test_stochastic_mismatch(fifo_controller):
-    try:
-        c = fifo_controller.reset(agentControllerType="stochastic", agentMode="default")
-    except RuntimeError as e:
-        error_message = str(e)
-    assert error_message and error_message.startswith("Invalid combination of agentControllerType=stochastic and agentMode=default")
 
 
 # Issue #514 found that the thirdPartyCamera image code was causing multi-agents to end
@@ -336,21 +307,6 @@ def test_target_invocation_exception(controller):
     assert event.metadata[
         "errorMessage"
     ], "errorMessage should not be empty when OpenObject(x > 1)."
-
-
-@pytest.mark.parametrize("controller", fifo_wsgi_stoch)
-def test_lookup(controller):
-
-    e = controller.step(dict(action="RotateLook", rotation=0, horizon=0))
-    position = controller.last_event.metadata["agent"]["position"]
-    horizon = controller.last_event.metadata["agent"]["cameraHorizon"]
-    assert horizon == 0.0
-    e = controller.step(dict(action="LookUp"))
-    assert e.metadata["agent"]["position"] == position
-    assert e.metadata["agent"]["cameraHorizon"] == -30.0
-    assert e.metadata["agent"]["rotation"] == dict(x=0, y=0, z=0)
-    e = controller.step(dict(action="LookUp"))
-    assert e.metadata["agent"]["cameraHorizon"] == -30.0
 
 
 @pytest.mark.parametrize("controller", fifo_wsgi)

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -57,6 +57,7 @@ def build_controller(**args):
 
 _wsgi_controller = build_controller(server_class=WsgiServer)
 _fifo_controller = build_controller(server_class=FifoServer)
+_stochastic_controller = build_controller(agentControllerType="stochastic", agentMode="stochastic")
 
 
 def skip_reset(controller):
@@ -84,12 +85,18 @@ def wsgi_controller():
 
 
 @pytest.fixture
+def stochastic_controller():
+    return reset_controller(_stochastic_controller)
+
+
+@pytest.fixture
 def fifo_controller():
     return reset_controller(_fifo_controller)
 
 
 fifo_wsgi = [_fifo_controller, _wsgi_controller]
 fifo = [_fifo_controller]
+fifo_wsgi_stoch = [_fifo_controller, _wsgi_controller, _stochastic_controller]
 
 BASE_FP28_POSITION = dict(x=-1.5, z=-1.5, y=0.901,)
 BASE_FP28_LOCATION = dict(
@@ -102,6 +109,16 @@ def teleport_to_base_location(controller: Controller):
 
     controller.step("TeleportFull", **BASE_FP28_LOCATION)
     assert controller.last_event.metadata["lastActionSuccess"]
+
+
+def setup_function(function):
+    for c in fifo_wsgi_stoch:
+        reset_controller(c)
+
+
+def teardown_module(module):
+    for c in fifo_wsgi_stoch:
+        c.stop()
 
 
 def assert_near(point1, point2, error_message=""):
@@ -118,6 +135,18 @@ def assert_images_near(image1, image2, max_mean_pixel_diff=1):
 
 def assert_images_far(image1, image2, min_mean_pixel_diff=10):
     return np.mean(np.abs(image1 - image2).flatten()) >= min_mean_pixel_diff
+
+
+def test_stochastic_controller(stochastic_controller):
+    stochastic_controller.reset(TEST_SCENE)
+    assert stochastic_controller.last_event.metadata["lastActionSuccess"]
+
+def test_stochastic_mismatch(fifo_controller):
+    try:
+        c = fifo_controller.reset(agentControllerType="stochastic", agentMode="default")
+    except RuntimeError as e:
+        error_message = str(e)
+    assert error_message and error_message.startswith("Invalid combination of agentControllerType=stochastic and agentMode=default")
 
 
 # Issue #514 found that the thirdPartyCamera image code was causing multi-agents to end
@@ -307,6 +336,21 @@ def test_target_invocation_exception(controller):
     assert event.metadata[
         "errorMessage"
     ], "errorMessage should not be empty when OpenObject(x > 1)."
+
+
+@pytest.mark.parametrize("controller", fifo_wsgi_stoch)
+def test_lookup(controller):
+
+    e = controller.step(dict(action="RotateLook", rotation=0, horizon=0))
+    position = controller.last_event.metadata["agent"]["position"]
+    horizon = controller.last_event.metadata["agent"]["cameraHorizon"]
+    assert horizon == 0.0
+    e = controller.step(dict(action="LookUp"))
+    assert e.metadata["agent"]["position"] == position
+    assert e.metadata["agent"]["cameraHorizon"] == -30.0
+    assert e.metadata["agent"]["rotation"] == dict(x=0, y=0, z=0)
+    e = controller.step(dict(action="LookUp"))
+    assert e.metadata["agent"]["cameraHorizon"] == -30.0
 
 
 @pytest.mark.parametrize("controller", fifo_wsgi)

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -165,91 +165,48 @@ public class AgentManager : MonoBehaviour {
         //"locobot" agentMode can use either default or "stochastic" agentControllerType
         //"drone" agentMode can ONLY use "drone" agentControllerType, and NOTHING ELSE (for now?)
         if (action.agentMode.ToLower() == "default") {
-            if (action.agentControllerType.ToLower() != "physics" && action.agentControllerType.ToLower() != "stochastic") {
-                Debug.Log("default mode must use either physics or stochastic controller. Defaulting to physics");
-                action.agentControllerType = "";
-                SetUpPhysicsController();
-            }
+            SetUpPhysicsController();
 
-            // if not stochastic, default to physics controller
-            if (action.agentControllerType.ToLower() == "physics") {
-                // set up physics controller
-                SetUpPhysicsController();
-            }
-
-            // if stochastic, set up stochastic controller
-            else if (action.agentControllerType.ToLower() == "stochastic") {
-                // set up stochastic controller
-                primaryAgent.actionFinished(success: false, errorMessage: "Invalid combination of agentControllerType=stochastic and agentMode=default. In order to use agentControllerType=stochastic, agentMode must be set to stochastic");
-		return;
-            }
         } else if (action.agentMode.ToLower() == "locobot") {
-            // if not stochastic, default to stochastic
-            if (action.agentControllerType.ToLower() != "stochastic") {
-                Debug.Log("'bot' mode only fully supports the 'stochastic' controller type at the moment. Forcing agentControllerType to 'stochastic'");
-                action.agentControllerType = "stochastic";
-            } 
             // LocobotController is a subclass of Stochastic which just the agentMode (VisibilityCapsule) changed
             SetUpLocobotController(action);
-            
+
         } else if (action.agentMode.ToLower() == "drone") {
-            if (action.agentControllerType.ToLower() != "drone") {
-                Debug.Log("'drone' agentMode is only compatible with 'drone' agentControllerType, forcing agentControllerType to 'drone'");
-                action.agentControllerType = "drone";
-            }
             SetUpDroneController(action);
+
         } else if (action.agentMode.ToLower() == "stretch") {
-                SetUpStretchController(action);
+            SetUpStretchController(action);
 
-                action.autoSimulation = false;
-                physicsSceneManager.MakeAllObjectsMoveable();
+            action.autoSimulation = false;
+            physicsSceneManager.MakeAllObjectsMoveable();
 
-                if (action.massThreshold.HasValue) {
-                    if (action.massThreshold.Value > 0.0) {
-                        SetUpMassThreshold(action.massThreshold.Value);
-                    } else {
-                        var error = "massThreshold must have nonzero value - invalid value: " + action.massThreshold.Value;
-                        Debug.Log(error);
-                        primaryAgent.actionFinished(false, error);
-                        return;
-                    }
+            if (action.massThreshold.HasValue) {
+                if (action.massThreshold.Value > 0.0) {
+                    SetUpMassThreshold(action.massThreshold.Value);
+                } else {
+                    var error = "massThreshold must have nonzero value - invalid value: " + action.massThreshold.Value;
+                    Debug.Log(error);
+                    primaryAgent.actionFinished(false, error);
+                    return;
                 }
-        } else if (action.agentMode.ToLower() == "arm") {
-
-            if (action.agentControllerType == "") {
-                action.agentControllerType = "mid-level";
-                Debug.Log("Defaulting to mid-level.");
             }
 
-            if (action.agentControllerType.ToLower() != "low-level" && action.agentControllerType.ToLower() != "mid-level") {
-                var error = "'arm' mode must use either low-level or mid-level controller.";
-                Debug.Log(error);
-                primaryAgent.actionFinished(success: false, errorMessage: error);
-                return;
-            } else if (action.agentControllerType.ToLower() == "mid-level") {
-                // set up physics controller
-                SetUpArmController(true);
-                // the arm should currently be used only with autoSimulation off
-                // as we manually control Physics during its movement
-                action.autoSimulation = false;
-                physicsSceneManager.MakeAllObjectsMoveable();
+        } else if (action.agentMode.ToLower() == "arm") {
+            SetUpArmController(true);
+            // the arm should currently be used only with autoSimulation off
+            // as we manually control Physics during its movement
+            action.autoSimulation = false;
+            physicsSceneManager.MakeAllObjectsMoveable();
 
-                if (action.massThreshold.HasValue) {
-                    if (action.massThreshold.Value > 0.0) {
-                        SetUpMassThreshold(action.massThreshold.Value);
-                    } else {
-                        var error = "massThreshold must have nonzero value - invalid value: " + action.massThreshold.Value;
-                        Debug.Log(error);
-                        primaryAgent.actionFinished(success: false, errorMessage: error);
-                        return;
-                    }
+            if (action.massThreshold.HasValue) {
+                if (action.massThreshold.Value > 0.0) {
+                    SetUpMassThreshold(action.massThreshold.Value);
+                } else {
+                    var error = "massThreshold must have nonzero value - invalid value: " + action.massThreshold.Value;
+                    Debug.Log(error);
+                    primaryAgent.actionFinished(success: false, errorMessage: error);
+                    return;
                 }
-
-            } else {
-                var error = "unsupported";
-                Debug.Log(error);
-                primaryAgent.actionFinished(success: false, errorMessage: error);
-                return;
             }
         }
 
@@ -276,7 +233,6 @@ public class AgentManager : MonoBehaviour {
         if (action.alwaysReturnVisibleRange) {
             ((PhysicsRemoteFPSAgentController)primaryAgent).alwaysReturnVisibleRange = action.alwaysReturnVisibleRange;
         }
-        print("start addAgents");
         StartCoroutine(addAgents(action));
 
     }
@@ -1895,9 +1851,7 @@ public class ServerAction {
     public float maxDistance;// used in target circle spawning function
     public float noise;
     public ControllerInitialization controllerInitialization = null;
-    public string agentControllerType = "";
     public string agentMode = "default"; // mode of Agent, valid values are "default" "locobot" "drone", note certain modes are only compatible with certain controller types
-
     public float agentRadius = 2.0f;
     public int maxStepCount;
     public float rotateStepDegrees = 90.0f; // default rotation amount for RotateRight/RotateLeft actions


### PR DESCRIPTION
The `agentControllerType` member of the ServerAction class has not been used for a while, as all our agent modes now default to the correct physics/stochastic properties innately. This removes references to `agentControllerType` that were needlessly making the Initialize code harder to parse.

Currently the build fails with these changes as there is a test checking for a specific error message when the agentControllerType has a mismatch, however I believe this test should be altered since actually checking for this is effectively redundant now that the concept of a "controller type" has been integrated into the agent modes themselves.