### PR TITLE
Improvements to how timeouts are handled.

### DIFF
--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -960,11 +960,10 @@ class Controller(object):
             raise RestartError(message)
         except Exception:
             self.server.stop()
-            warnings.warn(
+            raise RuntimeError(
                 f"Error encountered when running action {action}"
                 f" in scene {self.last_event.metadata['sceneName']}."
             )
-            raise
 
         if not self.last_event.metadata["lastActionSuccess"]:
             if self.last_event.metadata["errorCode"] in [

--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -1047,7 +1047,7 @@ class Controller(object):
             pass
 
         self.unity_pid = proc.pid
-        atexit.register(lambda: proc.poll() is None and proc.kill())
+        atexit.register(lambda: self.server.stop())
 
     @property
     def tmp_dir(self):

--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -958,9 +958,9 @@ class Controller(object):
             self.start(width=self.width, height=self.height, x_display=self.x_display)
             self.reset()
             raise RestartError(message)
-        except Exception:
+        except Exception as e:
             self.server.stop()
-            raise RuntimeError(
+            raise (TimeoutError if isinstance(e, TimeoutError) else RuntimeError)(
                 f"Error encountered when running action {action}"
                 f" in scene {self.last_event.metadata['sceneName']}."
             )

--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -1312,8 +1312,13 @@ class Controller(object):
             unity_params = self.server.unity_params()
             self._start_unity_thread(env, width, height, unity_params, image_name)
 
-        # receive the first request
-        self.last_event = self.server.receive()
+        # receive the first request, give unity at least 5 minutes to start
+        self.last_event = self.server.receive(
+            timeout=max(
+                60.0 * 5,
+                self.server_timeout * 5 if self.server_timeout is not None else 0.0
+            )
+        )
 
         # we should be able to get rid of this since we check the resolution in .reset()
         if self.server.unity_proc is not None and (height < 300 or width < 300):

--- a/ai2thor/fifo_server.py
+++ b/ai2thor/fifo_server.py
@@ -134,7 +134,7 @@ class FifoServer(ai2thor.server.Server):
 
         return message
 
-    def _recv_message(self):
+    def _recv_message(self, timeout: Optional[float]):
         if self.server_pipe is None:
             self.server_pipe = open(self.server_pipe_path, "rb")
 
@@ -144,7 +144,7 @@ class FifoServer(ai2thor.server.Server):
             header = self._read_with_timeout(
                 server_pipe=self.server_pipe,
                 message_size=self.header_size,
-                timeout=self.timeout
+                timeout=self.timeout if timeout is None else timeout
             )  # message type + length
             if len(header) == 0:
                 self.unity_proc.wait(timeout=5)
@@ -175,7 +175,7 @@ class FifoServer(ai2thor.server.Server):
             body = self._read_with_timeout(
                 server_pipe=self.server_pipe,
                 message_size=message_length,
-                timeout=self.timeout
+                timeout=self.timeout if timeout is None else timeout
             )
 
             # print("field type")
@@ -223,9 +223,11 @@ class FifoServer(ai2thor.server.Server):
         self.client_pipe.write(header + body + self.eom_header)
         self.client_pipe.flush()
 
-    def receive(self):
+    def receive(self, timeout: Optional[float] = None):
 
-        metadata, files = self._recv_message()
+        metadata, files = self._recv_message(
+            timeout=self.timeout if timeout is None else timeout
+        )
 
         if metadata is None:
             raise ValueError("no metadata received from recv_message")

--- a/ai2thor/fifo_server.py
+++ b/ai2thor/fifo_server.py
@@ -53,6 +53,7 @@ class FifoServer(ai2thor.server.Server):
         self,
         width,
         height,
+        timeout: Optional[float],
         depth_format=ai2thor.server.DepthFormat.Meters,
         add_depth_noise=False,
     ):
@@ -99,7 +100,13 @@ class FifoServer(ai2thor.server.Server):
         }
 
         self.eom_header = self._create_header(FieldType.END_OF_MESSAGE, b"")
-        super().__init__(width, height, depth_format, add_depth_noise)
+        super().__init__(
+            width=width,
+            height=height,
+            timeout=timeout,
+            depth_format=depth_format,
+            add_depth_noise=add_depth_noise
+        )
 
     def _create_header(self, message_type, body):
         return struct.pack(self.header_format, message_type, len(body))

--- a/ai2thor/fifo_server.py
+++ b/ai2thor/fifo_server.py
@@ -264,7 +264,11 @@ class FifoServer(ai2thor.server.Server):
         return params
 
     def stop(self):
-        self.client_pipe.close()
-        self.server_pipe.close()
+        if self.client_pipe is not None:
+            self.client_pipe.close()
+
+        if self.server_pipe is not None:
+            self.server_pipe.close()
+            
         if self.unity_proc is not None and self.unity_proc.poll() is None:
             self.unity_proc.kill()

--- a/ai2thor/fifo_server.py
+++ b/ai2thor/fifo_server.py
@@ -53,7 +53,7 @@ class FifoServer(ai2thor.server.Server):
         self,
         width,
         height,
-        timeout: Optional[float],
+        timeout: Optional[float] = 100.0,
         depth_format=ai2thor.server.DepthFormat.Meters,
         add_depth_noise=False,
     ):

--- a/ai2thor/fifo_server.py
+++ b/ai2thor/fifo_server.py
@@ -13,6 +13,7 @@ import tempfile
 import time
 from collections import defaultdict
 from enum import IntEnum, unique
+from io import TextIOWrapper
 from typing import Optional
 
 import msgpack
@@ -51,18 +52,18 @@ class FifoServer(ai2thor.server.Server):
 
     def __init__(
         self,
-        width,
-        height,
+        width: int,
+        height: int,
         timeout: Optional[float] = 100.0,
         depth_format=ai2thor.server.DepthFormat.Meters,
-        add_depth_noise=False,
+        add_depth_noise: bool = False,
     ):
 
         self.tmp_dir = tempfile.TemporaryDirectory()
         self.server_pipe_path = os.path.join(self.tmp_dir.name, "server.pipe")
         self.client_pipe_path = os.path.join(self.tmp_dir.name, "client.pipe")
-        self.server_pipe = None
-        self.client_pipe = None
+        self.server_pipe: Optional[TextIOWrapper] = None
+        self.client_pipe: Optional[TextIOWrapper] = None
         self.raw_metadata = None
         self.raw_files = None
         self._last_action_message = None

--- a/ai2thor/fifo_server.py
+++ b/ai2thor/fifo_server.py
@@ -118,16 +118,16 @@ class FifoServer(ai2thor.server.Server):
 
         start_t = time.time()
         message = b""
+
         while message_size > 0:
             r, w, e = select.select([server_pipe], [], [], timeout)
             if server_pipe in r:
                 part = os.read(server_pipe.fileno(), message_size)
                 message_size -= len(part)
                 message = message + part
-            else:
-                continue
 
-            if time.time() - start_t > timeout:
+            cur_t = time.time()
+            if timeout is not None and cur_t - start_t > timeout:
                 break
 
         if message_size != 0:
@@ -269,6 +269,6 @@ class FifoServer(ai2thor.server.Server):
 
         if self.server_pipe is not None:
             self.server_pipe.close()
-            
+
         if self.unity_proc is not None and self.unity_proc.poll() is None:
             self.unity_proc.kill()

--- a/ai2thor/fifo_server.py
+++ b/ai2thor/fifo_server.py
@@ -265,5 +265,5 @@ class FifoServer(ai2thor.server.Server):
     def stop(self):
         self.client_pipe.close()
         self.server_pipe.close()
-        if self.unity_proc is not None and self.unity_proc.poll():
+        if self.unity_proc is not None and self.unity_proc.poll() is None:
             self.unity_proc.kill()

--- a/ai2thor/server.py
+++ b/ai2thor/server.py
@@ -6,16 +6,17 @@ Handles all communication with Unity through a Flask service.  Messages
 are sent to the controller using a pair of request/response queues.
 """
 import abc
-import atexit
+import json
 import subprocess
 import warnings
-import numpy as np
-from enum import Enum
-from ai2thor.util.depth import apply_real_noise, generate_noise_indices
-import json
-from collections.abc import Mapping
 from abc import abstractmethod
+from collections.abc import Mapping
+from enum import Enum
 from typing import Optional, Tuple, Dict, cast, List, Set
+
+import numpy as np
+
+from ai2thor.util.depth import apply_real_noise, generate_noise_indices
 
 
 class NumpyAwareEncoder(json.JSONEncoder):
@@ -761,8 +762,6 @@ class Server(abc.ABC):
         if add_depth_noise:
             assert width == height, "Noise supported with square dimension images only."
             self.noise_indices = generate_noise_indices(width)
-
-        atexit.register(lambda: self.stop())
 
     def set_init_params(self, init_params):
         self.camera_near_plane = init_params["cameraNearPlane"]

--- a/ai2thor/server.py
+++ b/ai2thor/server.py
@@ -840,5 +840,5 @@ class Server(abc.ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def receive(self):
+    def receive(self, timeout: Optional[float] = None):
         raise NotImplementedError

--- a/ai2thor/server.py
+++ b/ai2thor/server.py
@@ -741,9 +741,9 @@ class Server(abc.ABC):
         self,
         width,
         height,
+        timeout: Optional[float],
         depth_format=DepthFormat.Meters,
         add_depth_noise=False,
-        timeout: Optional[float] = 100,
     ):
         self.depth_format = depth_format
         self.add_depth_noise = add_depth_noise

--- a/ai2thor/server.py
+++ b/ai2thor/server.py
@@ -741,7 +741,7 @@ class Server(abc.ABC):
         self,
         width,
         height,
-        timeout: Optional[float] = 100.0,
+        timeout: Optional[float],
         depth_format=DepthFormat.Meters,
         add_depth_noise=False,
     ):

--- a/ai2thor/server.py
+++ b/ai2thor/server.py
@@ -6,6 +6,7 @@ Handles all communication with Unity through a Flask service.  Messages
 are sent to the controller using a pair of request/response queues.
 """
 import abc
+import atexit
 import subprocess
 import warnings
 import numpy as np
@@ -760,6 +761,8 @@ class Server(abc.ABC):
         if add_depth_noise:
             assert width == height, "Noise supported with square dimension images only."
             self.noise_indices = generate_noise_indices(width)
+
+        atexit.register(lambda: self.stop())
 
     def set_init_params(self, init_params):
         self.camera_near_plane = init_params["cameraNearPlane"]

--- a/ai2thor/server.py
+++ b/ai2thor/server.py
@@ -5,7 +5,8 @@ ai2thor.server
 Handles all communication with Unity through a Flask service.  Messages
 are sent to the controller using a pair of request/response queues.
 """
-
+import abc
+import subprocess
 import warnings
 import numpy as np
 from enum import Enum
@@ -126,7 +127,7 @@ class LazyInstanceSegmentationMasks(LazyMask):
     def _integer_color_key(self, color: List[int]) -> np.uint32:
         a = np.array(color + [self._alpha_channel_value], dtype=np.uint8)
         # mypy complains, but it is safe to modify the dtype on an ndarray
-        a.dtype = np.uint32 # type: ignore 
+        a.dtype = np.uint32 # type: ignore
         return a[0]
 
     def _load_all(self):
@@ -137,7 +138,7 @@ class LazyInstanceSegmentationMasks(LazyMask):
                     self.__getitem__(color_name)
 
         self._loaded = True
-    
+
 
     def mask(self, key: str, default: Optional[np.ndarray]=None) -> Optional[np.ndarray]:
         if key not in self.instance_colors:
@@ -178,7 +179,7 @@ class LazyClassSegmentationMasks(LazyMask):
 
         class_mask = np.zeros(self.instance_masks.instance_segmentation_frame_uint32.shape, dtype=bool)
 
-        if key == "background": 
+        if key == "background":
             # "background" is a special name for any color that wasn't included in the metadata
             # this is mainly done for backwards compatibility since we only have a handful of instances
             # of this across all scenes (e.g. FloorPlan412 - thin strip above the doorway)
@@ -208,7 +209,7 @@ class LazyDetections2D(Mapping):
     def __init__(self, instance_masks: LazyInstanceSegmentationMasks):
 
         self.instance_masks = instance_masks
-    
+
     def mask_bounding_box(self, mask: np.ndarray) -> Optional[Tuple[int, int, int, int]]:
         rows = np.any(mask, axis=1)
         cols = np.any(mask, axis=0)
@@ -231,7 +232,7 @@ class LazyDetections2D(Mapping):
             return False
 
 class LazyInstanceDetections2D(LazyDetections2D):
-    
+
     def __init__(self, instance_masks: LazyInstanceSegmentationMasks):
         super().__init__(instance_masks)
         self._detections2d : Dict[str, Optional[Tuple[int, int, int, int]]] = {}
@@ -735,19 +736,26 @@ class DepthFormat(Enum):
     Millimeters = 2
 
 
-class Server(object):
+class Server(abc.ABC):
     def __init__(
-        self, width, height, depth_format=DepthFormat.Meters, add_depth_noise=False
+        self,
+        width,
+        height,
+        depth_format=DepthFormat.Meters,
+        add_depth_noise=False,
+        timeout: Optional[float] = 100,
     ):
         self.depth_format = depth_format
         self.add_depth_noise = add_depth_noise
+        self.timeout = timeout
+
         self.noise_indices = None
         self.camera_near_plane = 0.1
         self.camera_far_plane = 20.0
         self.sequence_id = 0
         self.started = False
         self.client_token = None
-        self.unity_proc = None
+        self.unity_proc: Optional[subprocess.Popen] = None
 
         if add_depth_noise:
             assert width == height, "Noise supported with square dimension images only."
@@ -818,3 +826,19 @@ class Server(object):
             self.last_event = events[0]
 
         return self.last_event
+
+    @abstractmethod
+    def start(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def stop(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def send(self, action):
+        raise NotImplementedError
+
+    @abstractmethod
+    def receive(self):
+        raise NotImplementedError

--- a/ai2thor/server.py
+++ b/ai2thor/server.py
@@ -5,11 +5,10 @@ ai2thor.server
 Handles all communication with Unity through a Flask service.  Messages
 are sent to the controller using a pair of request/response queues.
 """
-import abc
 import json
 import subprocess
 import warnings
-from abc import abstractmethod
+from abc import abstractmethod, ABC
 from collections.abc import Mapping
 from enum import Enum
 from typing import Optional, Tuple, Dict, cast, List, Set
@@ -738,7 +737,7 @@ class DepthFormat(Enum):
     Millimeters = 2
 
 
-class Server(abc.ABC):
+class Server(ABC):
     def __init__(
         self,
         width,

--- a/ai2thor/server.py
+++ b/ai2thor/server.py
@@ -741,7 +741,7 @@ class Server(abc.ABC):
         self,
         width,
         height,
-        timeout: Optional[float],
+        timeout: Optional[float] = 100.0,
         depth_format=DepthFormat.Meters,
         add_depth_noise=False,
     ):

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -2195,9 +2195,8 @@ def test_timeout():
         c.step("Sleep", seconds=1)
         assert c.last_event.metadata["lastActionSuccess"]
 
-        with pytest.warns():
-            with pytest.raises(TimeoutError):
-                c.step("Sleep", seconds=4)
+        with pytest.raises(TimeoutError):
+            c.step("Sleep", seconds=4)
 
         # Above crash should kill the unity process
         time.sleep(1.0)

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -5,6 +5,8 @@ import random
 import re
 import copy
 import json
+import time
+
 import pytest
 import warnings
 import jsonschema
@@ -2137,7 +2139,7 @@ def test_settle_physics(fifo_controller):
     for object_id, object_metadata in first_objs.items():
         for d in (diff(object_metadata, last_objs.get(object_id, {}), tolerance=0.00001, ignore=set(["receptacleObjectIds"]))):
             diffs.append((object_id, d))
- 
+
     assert diffs == []
 
 @pytest.mark.parametrize("controller", fifo_wsgi)
@@ -2180,4 +2182,24 @@ def test_fill_liquid(controller):
         assert pot["fillLiquid"] is None
         assert not pot["isFilledWithLiquid"]
         assert pot["canFillWithLiquid"]
+
+
+def test_timeout():
+    kwargs = {
+        "server_timeout": 2.0
+    }
+    for c in [
+        build_controller(server_class=WsgiServer, **kwargs),
+        build_controller(server_class=FifoServer, **kwargs)
+    ]:
+        c.step("Sleep", seconds=1)
+        assert c.last_event.metadata["lastActionSuccess"]
+
+        with pytest.warns():
+            with pytest.raises(TimeoutError):
+                c.step("Sleep", seconds=4)
+
+        # Above crash should kill the unity process
+        time.sleep(1.0)
+        assert c.server.unity_proc.poll() is not None
 

--- a/ai2thor/wsgi_server.py
+++ b/ai2thor/wsgi_server.py
@@ -154,7 +154,7 @@ class WsgiServer(ai2thor.server.Server):
     def __init__(
         self,
         host,
-        timeout: Optional[float],
+        timeout: Optional[float] = 100.0,
         port=0,
         threaded=False,
         depth_format=ai2thor.server.DepthFormat.Meters,

--- a/ai2thor/wsgi_server.py
+++ b/ai2thor/wsgi_server.py
@@ -271,8 +271,12 @@ class WsgiServer(ai2thor.server.Server):
         self.server_thread.daemon = True
         self.server_thread.start()
 
-    def receive(self):
-        return queue_get(self.request_queue, unity_proc=self.unity_proc, timeout=self.timeout)
+    def receive(self, timeout: Optional[float] = None):
+        return queue_get(
+            self.request_queue,
+            unity_proc=self.unity_proc,
+            timeout=self.timeout if timeout is None else timeout
+        )
 
     def send(self, action):
         assert self.request_queue.empty()

--- a/ai2thor/wsgi_server.py
+++ b/ai2thor/wsgi_server.py
@@ -6,6 +6,7 @@ Handles all communication with Unity through a Flask service.  Messages
 are sent to the controller using a pair of request/response queues.
 """
 import math
+import queue
 from typing import Optional
 
 import ai2thor.server
@@ -292,7 +293,7 @@ class WsgiServer(ai2thor.server.Server):
     def stop(self):
         try:
             self.send({})
-        except AssertionError:
+        except (AssertionError, queue.Full):
             # Happens if .stop() has already been called.
             pass
 

--- a/ai2thor/wsgi_server.py
+++ b/ai2thor/wsgi_server.py
@@ -292,5 +292,5 @@ class WsgiServer(ai2thor.server.Server):
     def stop(self):
         self.send({})
         self.wsgi_server.shutdown()
-        if self.unity_proc is not None and self.unity_proc.poll():
+        if self.unity_proc is not None and self.unity_proc.poll() is None:
             self.unity_proc.kill()

--- a/ai2thor/wsgi_server.py
+++ b/ai2thor/wsgi_server.py
@@ -154,6 +154,7 @@ class WsgiServer(ai2thor.server.Server):
     def __init__(
         self,
         host,
+        timeout: Optional[float],
         port=0,
         threaded=False,
         depth_format=ai2thor.server.DepthFormat.Meters,
@@ -190,7 +191,13 @@ class WsgiServer(ai2thor.server.Server):
             request_handler=ThorRequestHandler,
         )
         # used to ensure that we are receiving frames for the action we sent
-        super().__init__(width, height, depth_format, add_depth_noise)
+        super().__init__(
+            width=width,
+            height=height,
+            timeout=timeout,
+            depth_format=depth_format,
+            add_depth_noise=add_depth_noise
+        )
 
         @app.route("/ping", methods=["get"])
         def ping():

--- a/ai2thor/wsgi_server.py
+++ b/ai2thor/wsgi_server.py
@@ -290,7 +290,12 @@ class WsgiServer(ai2thor.server.Server):
         return params
 
     def stop(self):
-        self.send({})
+        try:
+            self.send({})
+        except AssertionError:
+            # Happens if .stop() has already been called.
+            pass
+
         self.wsgi_server.shutdown()
         if self.unity_proc is not None and self.unity_proc.poll() is None:
             self.unity_proc.kill()

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -1987,6 +1987,16 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             actionFinished(true);
         }
 
+        protected IEnumerator waitForSecondsRealtime(int seconds) {
+            yield return null; // Necessary as counting happens at the end of the last frame
+            yield return new WaitForSecondsRealtime(seconds);
+            actionFinished(true);
+        }
+
+        public void Sleep(int seconds) {
+            StartCoroutine(waitForSecondsRealtime(seconds));
+        }
+
 #if UNITY_EDITOR
         // for use in Editor to test the Reset function.
         public void Reset(ServerAction action) {


### PR DESCRIPTION
We have code that times out the AI2-THOR unity process if it doesn't respond to a request in some number of seconds when using the WSGI server. Similar code did not seem to exist for the, now default, fifo server. This PR adds this timeout functionality (with tests) and adds a few small typing improvements.