### PR TITLE
Update to shortest path error message

### DIFF
--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -612,7 +612,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             } else {
                 this.maxDownwardLookAngle = action.maxDownwardLookAngle;
             }
-            
+
             this.InitializeBody(action);
             m_Camera.GetComponent<FirstPersonCharacterCull>().SwitchRenderersToHide(this.VisibilityCapsule);
 
@@ -4903,6 +4903,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             Quaternion startRotation,
             float allowedError
         ) {
+            Debug.Log("now calling getShortestPath");
             SimObjPhysics sop = getSimObjectFromTypeOrId(objectType, objectId);
             var path = GetSimObjectNavMeshTarget(sop, startPosition, startRotation, allowedError);
             // VisualizePath(startPosition, path);
@@ -4916,6 +4917,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             string objectId = null,
             float allowedError = DefaultAllowedErrorInShortestPath
         ) {
+            Debug.Log("calling GetShortestPath with both pos and rot");
             getShortestPath(objectType, objectId, position, Quaternion.Euler(rotation), allowedError);
         }
 
@@ -4925,6 +4927,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             string objectId = null,
             float allowedError = DefaultAllowedErrorInShortestPath
         ) {
+            Debug.Log("calling GetShortestPath with just pos and maybe objectType???");
             getShortestPath(objectType, objectId, position, Quaternion.Euler(Vector3.zero), allowedError);
         }
 
@@ -4933,6 +4936,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             string objectId = null,
             float allowedError = DefaultAllowedErrorInShortestPath
         ) {
+            Debug.Log("calling GetShortestPath with only objectType no position");
             getShortestPath(objectType, objectId, this.transform.position, this.transform.rotation, allowedError);
         }
 
@@ -5111,6 +5115,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             float gridMultiplier = 1.0f,
             int maxStepCount = 10000
         ) {
+
+            Debug.Log("calling getReachablePositionToObjectVisible");
             CapsuleCollider cc = GetComponent<CapsuleCollider>();
             float sw = m_CharacterController.skinWidth;
             Queue<Vector3> pointsQueue = new Queue<Vector3>();
@@ -5211,7 +5217,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             Vector3[] reachablePos = new Vector3[goodPoints.Count];
             goodPoints.CopyTo(reachablePos);
 #if UNITY_EDITOR
-            Debug.Log(reachablePos.Length);
+            Debug.Log($"number of reachable positions found: {reachablePos.Length}");
 #endif
             return false;
         }
@@ -5223,6 +5229,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             float allowedError,
             bool visualize = false
         ) {
+            Debug.Log($"calling GetSimObjectNavMeshTarget");
             var targetTransform = targetSOP.transform;
             var targetSimObject = targetTransform.GetComponentInChildren<SimObjPhysics>();
             var agentTransform = this.transform;
@@ -5236,7 +5243,11 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             agentTransform.position = initialPosition;
             agentTransform.rotation = initialRotation;
 
-            getReachablePositionToObjectVisible(targetSimObject, out fixedPosition);
+            bool uhhh = false;
+            uhhh = getReachablePositionToObjectVisible(targetSimObject, out fixedPosition);
+
+            Debug.Log("what did getReachablePositionToObjectVisible return?: " + uhhh);
+            Debug.Log($"ok is fixedPosition updated or not uhhhh: {fixedPosition}");
 
             agentTransform.position = originalAgentPosition;
             agentTransform.rotation = originalAgentRotation;
@@ -5263,16 +5274,19 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
         protected float getFloorY(float x, float start_y, float z) {
+            Debug.Log($"trying to pass in {x}, {start_y} and {z}");
             int layerMask = ~LayerMask.GetMask("Agent", "SimObjInvisible");
 
             float y = start_y;
             RaycastHit hit;
             Ray ray = new Ray(new Vector3(x, y, z), -transform.up);
             if (!Physics.Raycast(ray, out hit, 100f, layerMask)) {
+                Debug.Log("what did we hit?: " + hit.transform.name);
                 throw new InvalidOperationException(
                     "Raycast could not find the floor!"
                 );
             }
+            Debug.Log("what was hit?: " + hit.point);
             return hit.point.y;
         }
 
@@ -5294,6 +5308,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             UnityEngine.AI.NavMeshPath path,
             float allowedError
         ) {
+            Debug.Log($"start vector3 is {start}");
+            Debug.Log($"target vector3 is {target}");
+
             float floorY = Math.Min(
                 getFloorY(start.x, start.y, start.z),
                 getFloorY(target.x, target.y, target.z)

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -3166,9 +3166,15 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     }
 
                 // Will fail if navmeshes are not setup
-                case "shortest_path": {
+                case "sp": {
                         Dictionary<string, object> action = new Dictionary<string, object>();
                         action["action"] = "GetShortestPath";
+                        action["objectType"] = "Bowl";
+                        //for spraybottle on FloorPlan_Train9_5
+                        //action["position"] = new Vector3(7.149451732635498f, 0.9009996652603146f, -2.4680588245391846f);
+
+                        //for bowl on FloorPlan_Train1_3
+                        action["position"] = new Vector3(5.039496421813965f, 0.9009997248649597f, -3.127098560333252f);
 
                         // pass in a min range, max range, delay
                         if (splitcommand.Length > 1) {

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -280,16 +280,16 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         // by default the gridsize is 0.25, so only moving in increments of .25 will work
                         // so the MoveAhead action will only take, by default, 0.25, .5, .75 etc magnitude with the default
                         // grid size!
-                        if (splitcommand.Length == 2) {
-                            action["gridSize"] = float.Parse(splitcommand[1]);
-                        } else if (splitcommand.Length == 3) {
-                            action["gridSize"] = float.Parse(splitcommand[1]);
-                            action["agentCount"] = int.Parse(splitcommand[2]);
-                        } else if (splitcommand.Length == 4) {
-                            action["gridSize"] = float.Parse(splitcommand[1]);
-                            action["agentCount"] = int.Parse(splitcommand[2]);
-                            action["makeAgentsVisible"] = int.Parse(splitcommand[3]) == 1;
-                        }
+                        // if (splitcommand.Length == 2) {
+                        //     action["gridSize"] = float.Parse(splitcommand[1]);
+                        // } else if (splitcommand.Length == 3) {
+                        //     action["gridSize"] = float.Parse(splitcommand[1]);
+                        //     action["agentCount"] = int.Parse(splitcommand[2]);
+                        // } else if (splitcommand.Length == 4) {
+                        //     action["gridSize"] = float.Parse(splitcommand[1]);
+                        //     action["agentCount"] = int.Parse(splitcommand[2]);
+                        //     action["makeAgentsVisible"] = int.Parse(splitcommand[3]) == 1;
+                        // }
 
                         // action.renderNormalsImage = true;
                         // action.renderDepthImage = true;
@@ -300,21 +300,69 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         action["action"] = "Initialize";
                         action["agentMode"] = "locobot";
                         // action["gridSize"] = 0.25f;
-                        // action["visibilityDistance"] = 1.0f;
-                        action["rotateStepDegrees"] = 45;
+                        action["visibilityDistance"] = 1.0f;
+                        action["rotateStepDegrees"] = 30;
                         // action["agentControllerType"] = "stochastic";
                         // action["applyActionNoise"] = true;
-                        // action["snapToGrid"] = false;
-                        // action["fieldOfView"] = 90;
-                        // action["gridSize"] = 0.25f;
+                        action["width"] = 400;
+                        action["height"] = 300;
+                        action["snapToGrid"] = false;
+                        action["fieldOfView"] = 79;
+                        action["gridSize"] = 0.25f;
 
 
                         action["applyActionNoise"] = true;
+                        action["continuousMode"] = true;
+                        //action["snapToGrid"] = false;
+                        //action["action"] = "Initialize";
+                        //action["fieldOfView"] = 90;
+                        //action["gridSize"] = 0.25f;
+                        CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);
+                        break;
+                    }
+                case "initb1": {
+                        Dictionary<string, object> action = new Dictionary<string, object>();
+                        // if you want to use smaller grid size step increments, initialize with a smaller/larger gridsize here
+                        // by default the gridsize is 0.25, so only moving in increments of .25 will work
+                        // so the MoveAhead action will only take, by default, 0.25, .5, .75 etc magnitude with the default
+                        // grid size!
+                        // if (splitcommand.Length == 2) {
+                        //     action["gridSize"] = float.Parse(splitcommand[1]);
+                        // } else if (splitcommand.Length == 3) {
+                        //     action["gridSize"] = float.Parse(splitcommand[1]);
+                        //     action["agentCount"] = int.Parse(splitcommand[2]);
+                        // } else if (splitcommand.Length == 4) {
+                        //     action["gridSize"] = float.Parse(splitcommand[1]);
+                        //     action["agentCount"] = int.Parse(splitcommand[2]);
+                        //     action["makeAgentsVisible"] = int.Parse(splitcommand[3]) == 1;
+                        // }
 
-                        action["snapToGrid"] = false;
+                        // action.renderNormalsImage = true;
+                        // action.renderDepthImage = true;
+                        // action.renderSemanticSegmentation = true;
+                        // action.renderInstanceSegmentation = true;
+                        // action.renderFlowImage = true;
+
                         action["action"] = "Initialize";
+                        action["agentMode"] = "locobot";
+                        // action["gridSize"] = 0.25f;
+                        action["visibilityDistance"] = 1.5f;
+                        action["rotateStepDegrees"] = 30;
+                        // action["agentControllerType"] = "stochastic";
+                        // action["applyActionNoise"] = true;
+                        action["width"] = 400;
+                        action["height"] = 300;
+                        action["snapToGrid"] = false;
                         action["fieldOfView"] = 90;
                         action["gridSize"] = 0.25f;
+
+
+                        action["applyActionNoise"] = true;
+                        action["continuousMode"] = true;
+                        //action["snapToGrid"] = false;
+                        //action["action"] = "Initialize";
+                        //action["fieldOfView"] = 90;
+                        //action["gridSize"] = 0.25f;
                         CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);
                         break;
                     }
@@ -3170,6 +3218,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         Dictionary<string, object> action = new Dictionary<string, object>();
                         action["action"] = "GetShortestPath";
                         action["objectType"] = "Bowl";
+                        action["allowedError"] = 0.05f;
                         //for spraybottle on FloorPlan_Train9_5
                         //action["position"] = new Vector3(7.149451732635498f, 0.9009996652603146f, -2.4680588245391846f);
 


### PR DESCRIPTION
Updating an edge case where a target object is not visible to the agent in any place on the navigation path due to agent parameters. Sometimes, different combinations of `gridSize` and `fieldOfView` and `visibilityDistance` may lead to objects being unable to be found when trying to path to them via the shortest path action.

This update adds a more detailed exception to be thrown when this happens, as the previous exception was caught too late and pointed to an unrelated error that wasn't actually happening.