### PR TITLE
add SpawnBoxCollider func

### DIFF
--- a/ai2thor/controller.py
+++ b/ai2thor/controller.py
@@ -7,7 +7,6 @@ needed to control the in-game agent through ai2thor.server.
 
 """
 import atexit
-import copy
 import json
 import logging
 import math
@@ -36,10 +35,11 @@ import ai2thor.fifo_server
 import ai2thor.platform
 import ai2thor.wsgi_server
 from ai2thor._quality_settings import DEFAULT_QUALITY, QUALITY_SETTINGS
-from ai2thor.exceptions import RestartError, UnityCrashException
+from ai2thor.exceptions import UnityCrashException
 from ai2thor.hooks.metadata_hook import MetadataHook
 from ai2thor.interact import DefaultActions, InteractiveControllerPrompt
-from ai2thor.server import DepthFormat, Event, MetadataWrapper
+from ai2thor.platform import STR_PLATFORM_MAP
+from ai2thor.server import DepthFormat, MetadataWrapper
 from ai2thor.util import atomic_write, makedirs
 from ai2thor.util.lock import LockEx
 from ai2thor.util.runtime_assets import create_assets
@@ -432,6 +432,7 @@ class Controller(object):
         self.include_private_scenes = include_private_scenes
         self.x_display = None
         self.gpu_device = gpu_device
+
         cuda_visible_devices = list(
             map(
                 int,
@@ -771,7 +772,6 @@ class Controller(object):
             raise_for_failure=True,
             **self.initialization_parameters,
         )
-        print(f'Last event {self.last_event.metadata["lastActionSuccess"]} error {self.last_event.metadata["errorMessage"]}')
 
         if is_procedural:
             self.last_event = self.step(action="CreateHouse", house=scene)
@@ -1080,13 +1080,10 @@ class Controller(object):
             if len(action_as_str) > 1000:
                 action_as_str = action_as_str[:950] + " ... " + action_as_str[-50:]
             message = (
-                f"Restarting unity due to crash when when running action {action_as_str}"
+                f"Unity crashed when running {action_as_str}"
                 f" in scene {self.last_event.metadata['sceneName']}:\n{traceback.format_exc()}"
             )
-            warnings.warn(message)
-            self.start(width=self.width, height=self.height, x_display=self.x_display)
-            self.reset()
-            raise RestartError(message)
+            raise UnityCrashException(message)
         except Exception as e:
             self.server.stop()
             action_as_str = str(action)
@@ -1410,7 +1407,7 @@ class Controller(object):
         if platform is None:
             candidate_platforms = ai2thor.platform.select_platforms(request)
         else:
-            candidate_platforms = [platform]
+            candidate_platforms = [STR_PLATFORM_MAP[platform] if isinstance(platform, str) else platform]
 
         builds = self.find_platform_builds(
             candidate_platforms, request, commits, releases_dir, local_build

--- a/ai2thor/fifo_server.py
+++ b/ai2thor/fifo_server.py
@@ -6,11 +6,11 @@ Handles all communication with Unity through a Flask service.  Messages
 are sent to the controller using a pair of request/response queues.
 """
 import json
+import math
 import os
 import select
 import struct
 import tempfile
-import shutil
 import time
 from collections import defaultdict
 from enum import IntEnum, unique
@@ -44,6 +44,12 @@ class FieldType(IntEnum):
     THIRD_PARTY_FLOW = 16
     END_OF_MESSAGE = 255
 
+import signal
+
+# Define the function to be called on timeout
+def handle_fifo_connect_timeout(signum, frame):
+    raise TimeoutError("FIFO server failed to conect to Unity in time.")
+
 
 class FifoServer(ai2thor.server.Server):
     header_format = "!BI"
@@ -60,21 +66,13 @@ class FifoServer(ai2thor.server.Server):
         add_depth_noise: bool = False,
         start_unity: bool = True
     ):
-        if start_unity:
-            self.tmp_dir = tempfile.TemporaryDirectory()
+        if not start_unity:
+            raise NotImplemented
 
-            self.server_pipe_path = os.path.join(self.tmp_dir.name, "server.pipe")
-            self.client_pipe_path = os.path.join(self.tmp_dir.name, "client.pipe")
-        else:
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.server_pipe_path = os.path.join(self.tmp_dir.name, "server.pipe")
+        self.client_pipe_path = os.path.join(self.tmp_dir.name, "client.pipe")
 
-            pipe_path = os.path.join(os.getcwd(), "unity/fifo_pipe/")
-            if os.path.exists(pipe_path):
-                shutil.rmtree(pipe_path)
-            os.makedirs(pipe_path, exist_ok=True)
-            self.server_pipe_path = os.path.join(pipe_path, "server.pipe")
-            self.client_pipe_path = os.path.join(pipe_path, "client.pipe")
-
-        print("--- pipe path " + self.server_pipe_path + " client: " + self.client_pipe_path)
         self.server_pipe: Optional[TextIOWrapper] = None
         self.client_pipe: Optional[TextIOWrapper] = None
         self.raw_metadata = None
@@ -119,13 +117,15 @@ class FifoServer(ai2thor.server.Server):
             height=height,
             timeout=timeout,
             depth_format=depth_format,
-            add_depth_noise=add_depth_noise
+            add_depth_noise=add_depth_noise,
         )
 
     def _create_header(self, message_type, body):
         return struct.pack(self.header_format, message_type, len(body))
 
-    def _read_with_timeout(self, server_pipe, message_size: int, timeout: Optional[float]):
+    def _read_with_timeout(
+        self, server_pipe, message_size: int, timeout: Optional[float]
+    ):
         if timeout is None:
             return server_pipe.read(message_size)
 
@@ -144,13 +144,34 @@ class FifoServer(ai2thor.server.Server):
                 break
 
         if message_size != 0:
-            raise TimeoutError(f"Reading from AI2-THOR backend timed out (using {timeout}s) timeout.")
+            raise TimeoutError(
+                f"Reading from AI2-THOR backend timed out (using {timeout}s) timeout."
+            )
 
         return message
 
     def _recv_message(self, timeout: Optional[float]):
         if self.server_pipe is None:
-            self.server_pipe = open(self.server_pipe_path, "rb")
+            # print(f"Attempting to open server pipe {self.server_pipe_path}, path exists {os.path.exists(self.server_pipe_path)}")
+
+            if timeout is None or timeout < 0:
+                self.server_pipe = open(self.server_pipe_path, "rb")
+            else:
+                # Set the signal handler
+                signal.signal(signal.SIGALRM, handle_fifo_connect_timeout)
+
+                try:
+                    # Set an alarm for timeout seconds
+                    signal.alarm(math.ceil(timeout))
+                    # Perform the operation that could potentially hang
+                    self.server_pipe = open(self.server_pipe_path, "rb")
+                finally:
+                    # Cancel the alarm
+                    signal.alarm(0)
+                    # Reset the signal handler to the default
+                    signal.signal(signal.SIGALRM, signal.SIG_DFL)
+
+            # print("Server pipe opened by FIFO server.")
 
         metadata = None
         files = defaultdict(list)
@@ -158,7 +179,7 @@ class FifoServer(ai2thor.server.Server):
             header = self._read_with_timeout(
                 server_pipe=self.server_pipe,
                 message_size=self.header_size,
-                timeout=self.timeout if timeout is None else timeout
+                timeout=self.timeout if timeout is None else timeout,
             )  # message type + length
             if len(header) == 0:
                 self.unity_proc.wait(timeout=5)
@@ -189,7 +210,7 @@ class FifoServer(ai2thor.server.Server):
             body = self._read_with_timeout(
                 server_pipe=self.server_pipe,
                 message_size=message_length,
-                timeout=self.timeout if timeout is None else timeout
+                timeout=self.timeout if timeout is None else timeout,
             )
 
             # print("field type")
@@ -238,7 +259,6 @@ class FifoServer(ai2thor.server.Server):
         self.client_pipe.flush()
 
     def receive(self, timeout: Optional[float] = None):
-
         metadata, files = self._recv_message(
             timeout=self.timeout if timeout is None else timeout
         )
@@ -278,10 +298,22 @@ class FifoServer(ai2thor.server.Server):
 
     def stop(self):
         if self.client_pipe is not None:
-            self.client_pipe.close()
+            try:
+                self.client_pipe.close()
+            except:
+                pass
 
         if self.server_pipe is not None:
-            self.server_pipe.close()
+            try:
+                self.server_pipe.close()
+            except:
+                pass
 
         if self.unity_proc is not None and self.unity_proc.poll() is None:
-            self.unity_proc.kill()
+            try:
+                self.unity_proc.kill()
+            except:
+                pass
+
+    def __del__(self):
+        self.stop()

--- a/ai2thor/hooks/procedural_asset_hook.py
+++ b/ai2thor/hooks/procedural_asset_hook.py
@@ -8,6 +8,7 @@ controller.step to locally run some local code
 """
 import logging
 import os
+import warnings
 from typing import Dict, Any, List
 
 from ai2thor.util.runtime_assets import create_asset, get_existing_thor_asset_file_path
@@ -32,7 +33,16 @@ def get_all_asset_ids_recursively(
 
 
 def create_assets_if_not_exist(
-    controller, asset_ids, asset_directory, copy_to_dir, asset_symlink, stop_if_fail, load_file_in_unity, extension=None, verbose=False
+    controller,
+    asset_ids,
+    asset_directory,
+    copy_to_dir,
+    asset_symlink,
+    stop_if_fail,
+    load_file_in_unity,
+    extension=None,
+    verbose=False,
+    raise_for_failure=True,
 ):
     evt = controller.step(
         action="AssetsInDatabase", assetIds=asset_ids, updateProceduralLRUCache=True
@@ -53,13 +63,14 @@ def create_assets_if_not_exist(
             asset_symlink=asset_symlink,
             verbose=verbose,
             load_file_in_unity=load_file_in_unity,
-            extension=None
+            extension=None,
+            raise_for_failure=raise_for_failure,
         )
         if not evt.metadata["lastActionSuccess"]:
-            logger.info(
+            warnings.warn(
                 f"Could not create asset `{get_existing_thor_asset_file_path(out_dir=asset_dir, asset_id=asset_id)}`."
+                f"\nError: {evt.metadata['errorMessage']}"
             )
-            logger.info(f"Error: {evt.metadata['errorMessage']}")
         if stop_if_fail:
             return evt
     return evt
@@ -75,7 +86,7 @@ class ProceduralAssetHookRunner:
         stop_if_fail=False,
         asset_limit=-1,
         extension=None,
-        verbose=True
+        verbose=True,
     ):
         self.asset_directory = asset_directory
         self.asset_symlink = asset_symlink
@@ -104,7 +115,7 @@ class ProceduralAssetHookRunner:
             stop_if_fail=self.stop_if_fail,
             load_file_in_unity=self.load_file_in_unity,
             extension=self.extension,
-            verbose=self.verbose
+            verbose=self.verbose,
         )
 
     def SpawnAsset(self, action, controller):
@@ -118,7 +129,7 @@ class ProceduralAssetHookRunner:
             stop_if_fail=self.stop_if_fail,
             load_file_in_unity=self.load_file_in_unity,
             extension=self.extension,
-            verbose=self.verbose
+            verbose=self.verbose,
         )
 
     def GetHouseFromTemplate(self, action, controller):
@@ -135,7 +146,7 @@ class ProceduralAssetHookRunner:
             stop_if_fail=self.stop_if_fail,
             load_file_in_unity=self.load_file_in_unity,
             extension=self.extension,
-            verbose=self.verbose
+            verbose=self.verbose,
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     author_email="ai2thor@allenai.org",
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=[
-        "flask",
+        "Flask==2.0.1",
         "numpy",
         "pyyaml",
         "requests",
@@ -53,7 +53,7 @@ setup(
         "Pillow",
         "python-xlib",
         "opencv-python",
-        "werkzeug>=0.15.0",  # needed for unix socket support
+        "Werkzeug==2.0.1",  # needed for unix socket support
         "compress_pickle"
     ],
     setup_requires=["pytest-runner"],

--- a/tasks.py
+++ b/tasks.py
@@ -1,6 +1,7 @@
 import os
 import signal
 import sys
+import traceback
 
 if os.name != "nt":
     import fcntl
@@ -107,8 +108,8 @@ def push_build(build_archive_name, zip_data, include_private_scenes):
         s3.Object(bucket, sha256_key).put(
             Body=sha.hexdigest(), ACL=acl, ContentType="text/plain"
         )
-    except botocore.exceptions.ClientError as e:
-        logger.error("caught error uploading archive %s: %s" % (build_archive_name, e))
+    except botocore.exceptions.ClientError:
+        logger.error("caught error uploading archive %s: %s" % (build_archive_name, traceback.format_exc()))
 
     logger.info("pushed build %s to %s" % (bucket, build_archive_name))
 

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -288,6 +288,9 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
         BaseAgentComponent baseAgentComponent = GameObject.FindObjectOfType<BaseAgentComponent>();
         primaryAgent = createAgentType(typeof(StretchAgentController), baseAgentComponent);
         baseAgentComponent.StretchBodyColliders.SetActive(true);
+        if (action.useFPINCollider) {
+            primaryAgent.SpawnBoxCollider(primaryAgent.gameObject, action.colliderScaleRatio);
+        }
     }
 
     private void SetUpStretchABController(ServerAction action) {
@@ -2135,7 +2138,8 @@ public class ServerAction {
     public Vector3 rotation;
     public Vector3 position;
     public Vector3 direction;
-
+    public Vector3 colliderScaleRatio;
+    public bool useFPINCollider;
     public bool allowAgentsToIntersect = false;
     public float handDistance;// used for max distance agent's hand can move
     public List<Vector3> positions = null;

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1557,6 +1557,8 @@ public class AgentMetadata {
     public bool? isStanding = null;
 
     public bool inHighFrictionArea;
+
+    public Vector3 colliderSize;
     public AgentMetadata() { }
 }
 

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -2192,6 +2192,7 @@ public class ServerAction {
     public Vector3 direction;
     public Vector3 colliderScaleRatio;
     public bool useAbsoluteSize = false;
+    public bool useVisibleColliderBase = true;
     public bool allowAgentsToIntersect = false;
     public float handDistance;// used for max distance agent's hand can move
     public List<Vector3> positions = null;

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -2191,6 +2191,7 @@ public class ServerAction {
     public Vector3 position;
     public Vector3 direction;
     public Vector3 colliderScaleRatio;
+    public bool useAbsoluteSize = false;
     public bool allowAgentsToIntersect = false;
     public float handDistance;// used for max distance agent's hand can move
     public List<Vector3> positions = null;

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -271,6 +271,9 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
         action.snapToGrid = false;
         BaseAgentComponent baseAgentComponent = GameObject.FindObjectOfType<BaseAgentComponent>();
         primaryAgent = createAgentType(typeof(LocobotFPSAgentController), baseAgentComponent);
+        if (action.useFPINCollider) {
+            primaryAgent.SpawnBoxCollider(primaryAgent.gameObject, typeof(LocobotFPSAgentController), action.colliderScaleRatio);
+        }
     }
 
     private void SetUpDroneController(ServerAction action) {
@@ -289,7 +292,7 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
         primaryAgent = createAgentType(typeof(StretchAgentController), baseAgentComponent);
         baseAgentComponent.StretchBodyColliders.SetActive(true);
         if (action.useFPINCollider) {
-            primaryAgent.SpawnBoxCollider(primaryAgent.gameObject, action.colliderScaleRatio);
+            primaryAgent.SpawnBoxCollider(primaryAgent.gameObject, typeof(StretchAgentController), action.colliderScaleRatio);
         }
     }
 
@@ -299,6 +302,9 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
         action.snapToGrid = false;
         BaseAgentComponent baseAgentComponent = GameObject.FindObjectOfType<BaseAgentComponent>();
         primaryAgent = createAgentType(typeof(ArticulatedAgentController), baseAgentComponent);
+        if (action.useFPINCollider) {
+            primaryAgent.SpawnBoxCollider(primaryAgent.gameObject, typeof(ArticulatedAgentController), action.colliderScaleRatio);
+        }
     }
 
     // note: this doesn't take a ServerAction because we don't have to force the snpToGrid bool

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -271,9 +271,6 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
         action.snapToGrid = false;
         BaseAgentComponent baseAgentComponent = GameObject.FindObjectOfType<BaseAgentComponent>();
         primaryAgent = createAgentType(typeof(LocobotFPSAgentController), baseAgentComponent);
-        if (action.useFPINCollider) {
-            primaryAgent.SpawnBoxCollider(primaryAgent.gameObject, typeof(LocobotFPSAgentController), action.colliderScaleRatio);
-        }
     }
 
     private void SetUpDroneController(ServerAction action) {
@@ -291,9 +288,6 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
         BaseAgentComponent baseAgentComponent = GameObject.FindObjectOfType<BaseAgentComponent>();
         primaryAgent = createAgentType(typeof(StretchAgentController), baseAgentComponent);
         baseAgentComponent.StretchBodyColliders.SetActive(true);
-        if (action.useFPINCollider) {
-            primaryAgent.SpawnBoxCollider(primaryAgent.gameObject, typeof(StretchAgentController), action.colliderScaleRatio);
-        }
     }
 
     private void SetUpStretchABController(ServerAction action) {
@@ -302,9 +296,6 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
         action.snapToGrid = false;
         BaseAgentComponent baseAgentComponent = GameObject.FindObjectOfType<BaseAgentComponent>();
         primaryAgent = createAgentType(typeof(ArticulatedAgentController), baseAgentComponent);
-        if (action.useFPINCollider) {
-            primaryAgent.SpawnBoxCollider(primaryAgent.gameObject, typeof(ArticulatedAgentController), action.colliderScaleRatio);
-        }
     }
 
     // note: this doesn't take a ServerAction because we don't have to force the snpToGrid bool
@@ -2192,7 +2183,6 @@ public class ServerAction {
     public Vector3 position;
     public Vector3 direction;
     public Vector3 colliderScaleRatio;
-    public bool useFPINCollider;
     public bool allowAgentsToIntersect = false;
     public float handDistance;// used for max distance agent's hand can move
     public List<Vector3> positions = null;

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -446,8 +446,8 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
 
     private void updateCameraProperties(
         Camera camera,
-        Vector3 position,
-        Vector3 rotation,
+        Vector3? position,
+        Vector3? rotation,
         float fieldOfView,
         string skyboxColor,
         bool? orthographic,
@@ -455,7 +455,9 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
         float? nearClippingPlane,
         float? farClippingPlane,
         string antiAliasing,
-        bool agentPositionRelativeCoordinates = false
+        bool agentPositionRelativeCoordinates = false,
+        string parent = null,
+        int agentId = 0
     ) {
         if (orthographic != true && orthographicSize != null) {
             throw new InvalidOperationException(
@@ -465,24 +467,46 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
             );
         }
 
-        //note if updating the primary agent's main camera, this allows it to be detached! use at your own risk
-        if(!agentPositionRelativeCoordinates) {
-            // update the position and rotation and keep camera in world space coordinates
-            camera.transform.SetParent(null);
-            camera.gameObject.transform.position = position;
-            camera.gameObject.transform.eulerAngles = rotation;
-        } else {
-            //makes sure camera is child of agent, and reposition in agent relative space
-            if(camera.transform.parent != primaryAgent.transform) {
-                camera.transform.SetParent(primaryAgent.transform);
-                //for some reason reparenting sometimes makes the scale slightly off...
-                //so we are gonna force it to be uniform just in case cause floats suck
-                camera.transform.localScale = Vector3.one;
-            }
+        if (parent != null && parent != "agent" && parent != "world") {
+            throw new InvalidOperationException(
+                $"parent: {parent} must be one of: null, agent, or world."
+            );
+        }
 
-            //now that camera is in agent local space, assign changes relative to agent
-            camera.gameObject.transform.localPosition = position;
-            camera.gameObject.transform.localEulerAngles = rotation;
+        var agent = this.agents[agentId];
+
+        if (agentPositionRelativeCoordinates) {
+            Transform oldParent = camera.transform.parent;
+            camera.transform.SetParent(agent.transform);
+            camera.transform.localScale = Vector3.one; // Previous comment suggested that these local scale changes are necessary after reparenting
+
+            if (position.HasValue) {
+                camera.transform.localPosition = position.Value;
+            }
+            if (rotation.HasValue) {
+                camera.transform.localEulerAngles = rotation.Value;
+            }
+            camera.transform.SetParent(oldParent);
+            camera.transform.localScale = Vector3.one;
+        } else {
+            if (position.HasValue) {
+                camera.gameObject.transform.position = position.Value;
+            }
+            if (rotation.HasValue) {
+                camera.gameObject.transform.eulerAngles = rotation.Value;
+            }
+        }
+
+        if (parent == "agent") {
+            camera.transform.SetParent(agent.transform);
+            camera.transform.localScale = Vector3.one;
+        } else if (parent == "world") {
+            camera.transform.SetParent(null);
+            camera.transform.localScale = Vector3.one;
+        } else if (parent != null) {
+            throw new InvalidOperationException(
+                $"parent: {parent} must be one of: null, agent, or world."
+            );
         }
 
         // updates the camera's perspective
@@ -581,7 +605,9 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
         float? nearClippingPlane = null,
         float? farClippingPlane = null,
         string antiAliasing = "none",
-        bool attachToPrimaryAgent = false //note we can only add these cameras to the primary agent at the moment
+        bool agentPositionRelativeCoordinates = false,
+        string parent = "world",
+        int agentId = 0
     ) {
         // adds error if fieldOfView is out of bounds
         assertFovInBounds(fov: fieldOfView);
@@ -612,7 +638,9 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
             nearClippingPlane: nearClippingPlane,
             farClippingPlane: farClippingPlane,
             antiAliasing: antiAliasing,
-            agentPositionRelativeCoordinates: attachToPrimaryAgent //local pos/rot of camera will be using agent.position as the origin if this is true
+            agentPositionRelativeCoordinates: agentPositionRelativeCoordinates, //local pos/rot of camera will be using agent.position as the origin if this is true
+            parent: parent,
+            agentId: agentId
         );
     }
 
@@ -636,6 +664,12 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
         public float? x = null;
         public float? y = null;
         public float? z = null;
+
+        public OptionalVector3(float? x = null, float? y = null, float? z = null) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
     }
 
     //allows repositioning and changing of values of agent's primary camera
@@ -649,7 +683,8 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
         float? orthographicSize = null,
         float? nearClippingPlane = null,
         float? farClippingPlane = null,
-        string antiAliasing = null
+        string antiAliasing = null,
+        int agentId = 0
     ) {
         // adds error if fieldOfView is out of bounds
         if (fieldOfView != null) {
@@ -657,18 +692,18 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
         }
 
         //allow specifiying agent id later for multi agent???
-        Camera agentMainCam = primaryAgent.m_Camera;
+        var agent = this.agents[agentId];
+        Camera agentMainCam = agent.m_Camera;
 
-        // keeps positions at default values, if unspecified.
-        Vector3 oldPosition = agentMainCam.gameObject.transform.position;
+        // keeps positions/rotations at default values, if unspecified.
+        // NOTE: MUST BE LOCAL POSITION/ROTATION as agentPositionRelativeCoordinates == true
+        Vector3 oldPosition = agentMainCam.transform.localPosition;
+        Vector3 oldRotation = agentMainCam.transform.localEulerAngles;
+
         Vector3 targetPosition = parseOptionalVector3(optionalVector3: position, defaultsOnNull: oldPosition);
-
-        // keeps rotations at default values, if unspecified.
-        Vector3 oldRotation = agentMainCam.gameObject.transform.localEulerAngles;
         Vector3 targetRotation = parseOptionalVector3(optionalVector3: rotation, defaultsOnNull: oldRotation);
-
         updateCameraProperties(
-            camera: primaryAgent.m_Camera,
+            camera: agentMainCam,
             position: targetPosition,
             rotation: targetRotation,
             fieldOfView: fieldOfView == null ? agentMainCam.fieldOfView : (float)fieldOfView,
@@ -678,7 +713,9 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
             nearClippingPlane: nearClippingPlane,
             farClippingPlane: farClippingPlane,
             antiAliasing: antiAliasing,
-            agentPositionRelativeCoordinates: true //always keep main camera relative to agent so other functions like visibility don't break
+            agentPositionRelativeCoordinates: true, // always keep main camera relative to agent so other functions like visibility don't break
+            parent: null, // Should already be parented correctly
+            agentId: agentId
         );
     }
 
@@ -694,7 +731,9 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
         float? nearClippingPlane = null,
         float? farClippingPlane = null,
         string antiAliasing = null,
-        bool agentPositionRelativeCoordinates = false
+        bool agentPositionRelativeCoordinates = false,
+        string parent = null,
+        int agentId = 0
     ) {
         // adds error if fieldOfView is out of bounds
         if (fieldOfView != null) {
@@ -710,14 +749,20 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
 
         Camera thirdPartyCamera = thirdPartyCameras[thirdPartyCameraId];
 
-        // keeps positions at default values, if unspecified.
-        Vector3 oldPosition = thirdPartyCamera.gameObject.transform.position;
+        Vector3 oldPosition;
+        Vector3 oldRotation;
+        if (agentPositionRelativeCoordinates) {
+            // keeps positions/rotations at default values, if unspecified.
+            oldPosition = thirdPartyCamera.transform.localPosition;
+            oldRotation = thirdPartyCamera.transform.localEulerAngles;
+        } else {
+            // keeps positions/rotations at default values, if unspecified.
+            oldPosition = thirdPartyCamera.transform.position;
+            oldRotation = thirdPartyCamera.transform.eulerAngles;
+        }
+
         Vector3 targetPosition = parseOptionalVector3(optionalVector3: position, defaultsOnNull: oldPosition);
-
-        // keeps rotations at default values, if unspecified.
-        Vector3 oldRotation = thirdPartyCamera.gameObject.transform.localEulerAngles;
         Vector3 targetRotation = parseOptionalVector3(optionalVector3: rotation, defaultsOnNull: oldRotation);
-
         updateCameraProperties(
             camera: thirdPartyCamera,
             position: targetPosition,
@@ -729,7 +774,9 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
             nearClippingPlane: nearClippingPlane,
             farClippingPlane: farClippingPlane,
             antiAliasing: antiAliasing,
-            agentPositionRelativeCoordinates: agentPositionRelativeCoordinates
+            agentPositionRelativeCoordinates: agentPositionRelativeCoordinates,
+            parent: parent,
+            agentId: agentId
         );
     }
 

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -465,6 +465,7 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
         }
 
         var agent = this.agents[agentId];
+        // ImageSynthesis imageSynthesis = camera.gameObject.GetComponentInChildren<ImageSynthesis>();
 
         if (agentPositionRelativeCoordinates) {
             Transform oldParent = camera.transform.parent;
@@ -550,6 +551,12 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
                 postProcessLayer: camera.gameObject.GetComponentInChildren<PostProcessLayer>(),
                 antiAliasing: antiAliasing
             );
+        }
+
+        ImageSynthesis imageSynthesis = camera.gameObject.GetComponentInChildren<ImageSynthesis>();
+        if (imageSynthesis != null && imageSynthesis.enabled) {
+            imageSynthesis.OnCameraChange();
+            imageSynthesis.OnSceneChange();
         }
 
         this.activeAgent().actionFinished(success: true);
@@ -1559,6 +1566,7 @@ public class AgentMetadata {
     public bool inHighFrictionArea;
 
     public Vector3 colliderSize;
+
     public AgentMetadata() { }
 }
 

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -465,7 +465,6 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
         }
 
         var agent = this.agents[agentId];
-        // ImageSynthesis imageSynthesis = camera.gameObject.GetComponentInChildren<ImageSynthesis>();
 
         if (agentPositionRelativeCoordinates) {
             Transform oldParent = camera.transform.parent;
@@ -556,7 +555,6 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
         ImageSynthesis imageSynthesis = camera.gameObject.GetComponentInChildren<ImageSynthesis>();
         if (imageSynthesis != null && imageSynthesis.enabled) {
             imageSynthesis.OnCameraChange();
-            imageSynthesis.OnSceneChange();
         }
 
         this.activeAgent().actionFinished(success: true);

--- a/unity/Assets/Scripts/BaseAgentComponent.cs
+++ b/unity/Assets/Scripts/BaseAgentComponent.cs
@@ -30,15 +30,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         public GameObject[] TargetCircles = null;
         public GameObject[] GripperOpennessStates = new GameObject[7];
 
-        #if UNITY_EDITOR
-        //debug cache for overlap box cast to debug in OnDrawGizmos//////////////
-        public Vector3 boxCenter = Vector3.zero;
-        public Vector3 boxHalfExtents = Vector3.one;
-        public Quaternion boxOrientation = Quaternion.identity;
-        public bool drawBox = false;
-        ///////////////////////////////////////////////////
-        #endif
-
         [HideInInspector]
         public BaseFPSAgentController agent;
 
@@ -111,25 +102,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
         #if UNITY_EDITOR
         public void OnDrawGizmos() {
-            //debug draw for spawnAgentBoxCollider//////////////////////////////
-            if(drawBox) {
-                // Set the color of the Gizmo (optional)
-                Gizmos.color = Color.red;
 
-                // Calculate the world-space center of the box
-                Vector3 worldCenter = boxCenter;
-
-                // // Save the current Gizmo matrix, then set it to the box's transformation matrix
-                // Matrix4x4 originalMatrix = Gizmos.matrix;
-                Gizmos.matrix = Matrix4x4.TRS(worldCenter, boxOrientation, Vector3.one);
-
-                // Draw a wireframe cube with the given size
-                Gizmos.DrawWireCube(Vector3.zero, boxHalfExtents * 2);
-
-                // Restore the original Gizmo matrix
-                //Gizmos.matrix = originalMatrix;
-            }
-            //////////////////////////////////////////////////////////////////////
         }
         #endif
 

--- a/unity/Assets/Scripts/BaseAgentComponent.cs
+++ b/unity/Assets/Scripts/BaseAgentComponent.cs
@@ -109,6 +109,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             // body.AddForceAtPosition (m_CharacterController.velocity * 15f, hit.point, ForceMode.Acceleration);// might have to adjust the force vector scalar later
         }
 
+        #if UNITY_EDITOR
         public void OnDrawGizmos() {
             //debug draw for spawnAgentBoxCollider//////////////////////////////
             if(drawBox) {
@@ -130,6 +131,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
             //////////////////////////////////////////////////////////////////////
         }
+        #endif
 
     }
 }

--- a/unity/Assets/Scripts/BaseAgentComponent.cs
+++ b/unity/Assets/Scripts/BaseAgentComponent.cs
@@ -30,6 +30,15 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         public GameObject[] TargetCircles = null;
         public GameObject[] GripperOpennessStates = new GameObject[7];
 
+        #if UNITY_EDITOR
+        //debug cache for overlap box cast to debug in OnDrawGizmos//////////////
+        public Vector3 boxCenter = Vector3.zero;
+        public Vector3 boxHalfExtents = Vector3.one;
+        public Quaternion boxOrientation = Quaternion.identity;
+        public bool drawBox = false;
+        ///////////////////////////////////////////////////
+        #endif
+
         [HideInInspector]
         public BaseFPSAgentController agent;
 
@@ -98,6 +107,28 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             // if we touched something with a rigidbody that needs to simulate physics, generate a force at the impact point
             // body.AddForce(m_CharacterController.velocity * 15f, ForceMode.Force);
             // body.AddForceAtPosition (m_CharacterController.velocity * 15f, hit.point, ForceMode.Acceleration);// might have to adjust the force vector scalar later
+        }
+
+        public void OnDrawGizmos() {
+            //debug draw for spawnAgentBoxCollider//////////////////////////////
+            if(drawBox) {
+                // Set the color of the Gizmo (optional)
+                Gizmos.color = Color.red;
+
+                // Calculate the world-space center of the box
+                Vector3 worldCenter = boxCenter;
+
+                // // Save the current Gizmo matrix, then set it to the box's transformation matrix
+                // Matrix4x4 originalMatrix = Gizmos.matrix;
+                Gizmos.matrix = Matrix4x4.TRS(worldCenter, boxOrientation, Vector3.one);
+
+                // Draw a wireframe cube with the given size
+                Gizmos.DrawWireCube(Vector3.zero, boxHalfExtents * 2);
+
+                // Restore the original Gizmo matrix
+                //Gizmos.matrix = originalMatrix;
+            }
+            //////////////////////////////////////////////////////////////////////
         }
 
     }

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -2377,6 +2377,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             agentMeta.cameraHorizon = cameraX > 180 ? cameraX - 360 : cameraX;
             agentMeta.inHighFrictionArea = inHighFrictionArea;
 
+            GameObject nonTriggeredEncapsulatingBox = GameObject.Find("NonTriggeredEncapsulatingBox");
+            if (nonTriggeredEncapsulatingBox != null) {
+                agentMeta.colliderSize = nonTriggeredEncapsulatingBox.GetComponent<BoxCollider>().size;
+            } else {
+                agentMeta.colliderSize = new Vector3(0, 0, 0);
+            }
+
             // OTHER METADATA
             MetadataWrapper metaMessage = new MetadataWrapper();
             metaMessage.agent = agentMeta;

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -7254,6 +7254,26 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             triggeredEncapsulatingBox.transform.parent = agent.transform;
         }
 
+        public void DestroyAgentBoxCollider(ServerAction action){
+            GameObject nonTriggeredEncapsulatingBox = GameObject.Find("NonTriggeredEncapsulatingBox");
+            GameObject triggeredEncapsulatingBox = GameObject.Find("triggeredEncapsulatingBox");
+            if (nonTriggeredEncapsulatingBox != null) {
+                GameObject.Destroy(nonTriggeredEncapsulatingBox);
+            }
+            if (triggeredEncapsulatingBox != null) {
+                GameObject.Destroy(triggeredEncapsulatingBox);
+            }
+            actionFinished(true);
+            return;
+        }
+
+        public void UpdateAgentBoxCollider(ServerAction action) {
+            this.DestroyAgentBoxCollider(action);
+            this.SpawnBoxCollider(this.gameObject, this.GetType(), action.colliderScaleRatio);
+            actionFinished(true);
+            return;
+        }
+
         public void SpawnAsset(
             string assetId,
             string generatedId,

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -7247,18 +7247,18 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             Vector3 originalPosition = this.transform.position;
             Quaternion originalRotation = this.transform.rotation;
 
-            Debug.Log($"the original position of the agent is: {originalPosition:F8}");
+            //Debug.Log($"the original position of the agent is: {originalPosition:F8}");
 
             // Move the agent to a safe place and align the agent's rotation with the world coordinate system
             this.transform.position = originalPosition + agentSpawnOffset;
             this.transform.rotation = Quaternion.identity;
 
-            Debug.Log($"agent position after moving it out of the way is: {this.transform.position:F8}");
+            //Debug.Log($"agent position after moving it out of the way is: {this.transform.position:F8}");
 
             // Get the agent's bounds
             var bounds = GetAgentBounds(agent, agentType);
 
-            Debug.Log($"the global position of the agent bounds is: {bounds.center:F8}");
+            //Debug.Log($"the global position of the agent bounds is: {bounds.center:F8}");
 
             // Check if the spawned boxCollider is colliding with other objects
             int layerMask = LayerMask.GetMask("SimObjVisible", "Procedural1", "Procedural2", "Procedural3", "Procedural0");
@@ -7277,20 +7277,14 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     scaleRatio.z
                 );
             }
-            Debug.Log($"the center for the new box should be at the agent's original position but is: {newBoxCenter:F8}");
             
             #if UNITY_EDITOR
             /////////////////////////////////////////////////
-            this.baseAgentComponent.boxCenter = newBoxCenter;
-            this.baseAgentComponent.boxHalfExtents = newBoxExtents;
-            this.baseAgentComponent.boxOrientation = originalRotation;
-            this.baseAgentComponent.drawBox = false;
-
             //for visualization lets spawna cube at the center of where the boxCenter supposedly is
             GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
             cube.name = "VisualizedBoxCollider";
-            cube.transform.position = this.baseAgentComponent.boxCenter;
-            cube.transform.rotation = this.baseAgentComponent.boxOrientation;
+            cube.transform.position = newBoxCenter;
+            cube.transform.rotation = originalRotation;
 
             cube.transform.localScale = newBoxExtents * 2;
             var material = cube.GetComponent<MeshRenderer>().material;
@@ -7304,10 +7298,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             material.EnableKeyword("_ALPHABLEND_ON");
             material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
             material.renderQueue = 3000;
-
-            // cube.transform.parent = agent.transform;
-
-            Debug.Log("draw gizmos set for debug draw!");
             ////////////////////////////////////////////////
             #endif
 
@@ -7328,16 +7318,16 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             // Spawn the box collider
             Vector3 colliderSize = newBoxExtents * 2;
 
-            GameObject noneTriggeredEncapsulatingBox = new GameObject("NonTriggeredEncapsulatingBox");
-            noneTriggeredEncapsulatingBox.transform.position = newBoxCenter;
+            GameObject nonTriggeredEncapsulatingBox = new GameObject("NonTriggeredEncapsulatingBox");
+            nonTriggeredEncapsulatingBox.transform.position = newBoxCenter;
 
-            BoxCollider nonTriggeredBoxCollider = noneTriggeredEncapsulatingBox.AddComponent<BoxCollider>();
+            BoxCollider nonTriggeredBoxCollider = nonTriggeredEncapsulatingBox.AddComponent<BoxCollider>();
             nonTriggeredBoxCollider.size = colliderSize; // Scale the box to the agent's size
             nonTriggeredBoxCollider.enabled = true;
 
-            noneTriggeredEncapsulatingBox.transform.parent = agent.transform;
+            nonTriggeredEncapsulatingBox.transform.parent = agent.transform;
             // Attatching it to the parent changes the rotation so set it back to none
-            noneTriggeredEncapsulatingBox.transform.localRotation = Quaternion.identity;
+            nonTriggeredEncapsulatingBox.transform.localRotation = Quaternion.identity;
 
             GameObject triggeredEncapsulatingBox = new GameObject("triggeredEncapsulatingBox");
             triggeredEncapsulatingBox.transform.position = newBoxCenter;
@@ -7351,6 +7341,10 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             // triggeredEncapsulatingBox.transform.localRotation = Quaternion.identity;
             // Attatching it to the parent changes the rotation so set it back to identity
             triggeredEncapsulatingBox.transform.localRotation = Quaternion.identity;
+
+            //make sure to set the collision layer correctly as part of the `agent` layer so the collision matrix is happy
+            nonTriggeredEncapsulatingBox.layer = LayerMask.NameToLayer("Agent");
+            triggeredEncapsulatingBox.layer = LayerMask.NameToLayer("Agent");
 
             // Spawn the visible box if useVisibleColliderBase is true
             if (useVisibleColliderBase){

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -7291,25 +7291,26 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             return bounds;
         }
 
-        protected void HideBoxRenderers(GameObject box) {
-            foreach (Renderer r in box.GetComponentsInChildren<Renderer>()) {
-                if (r.enabled) {
-                    r.enabled = false;
-                }
-            }
-        }
-
         public void SpawnBoxCollider(GameObject agent, Type agentType, Vector3 scaleRatio) {
             var bounds = GetAgentBounds(agent, agentType);
-            GameObject box = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            box.transform.position = new Vector3(bounds.center.x, bounds.center.y, agent.transform.position.z);
-            // box.transform.localScale = new Vector3(scaleRatio.x * bounds.extents.x / 2, scaleRatio.y * bounds.size.y, scaleRatio.z * bounds.extents.z / 2); // Scale the box to the agent's size
-            box.transform.localScale = new Vector3(scaleRatio.x * bounds.extents.x * 2, scaleRatio.y * bounds.size.y, scaleRatio.z * bounds.extents.z * 2); // Scale the box to the agent's size
-            box.transform.parent = agent.transform;
-            // box.transform.localPosition = new Vector3(0, bounds.center.y - agent.transform.position.y, 0);
-            BoxCollider boxCollider = box.GetComponent<BoxCollider>();
-            boxCollider.enabled = true;
-            HideBoxRenderers(box);
+            GameObject noneTriggeredEncapsulatingBox = new GameObject("NonTriggeredEncapsulatingBox");
+            noneTriggeredEncapsulatingBox.transform.position = new Vector3(bounds.center.x, bounds.center.y, agent.transform.position.z);
+
+            BoxCollider nonTriggeredBoxCollider = noneTriggeredEncapsulatingBox.AddComponent<BoxCollider>();
+            nonTriggeredBoxCollider.size = new Vector3(scaleRatio.x * bounds.extents.x * 2, scaleRatio.y * bounds.size.y, scaleRatio.z * bounds.extents.z * 2); // Scale the box to the agent's size
+            nonTriggeredBoxCollider.enabled = true;
+
+            noneTriggeredEncapsulatingBox.transform.parent = agent.transform;
+
+            GameObject triggeredEncapsulatingBox = new GameObject("triggeredEncapsulatingBox");
+            triggeredEncapsulatingBox.transform.position = new Vector3(bounds.center.x, bounds.center.y, agent.transform.position.z);
+
+            BoxCollider triggeredBoxCollider = triggeredEncapsulatingBox.AddComponent<BoxCollider>();
+            triggeredBoxCollider.size = new Vector3(scaleRatio.x * bounds.extents.x * 2, scaleRatio.y * bounds.size.y, scaleRatio.z * bounds.extents.z * 2); // Scale the box to the agent's size
+            triggeredBoxCollider.enabled = true;
+            triggeredBoxCollider.isTrigger = true;
+
+            triggeredEncapsulatingBox.transform.parent = agent.transform;
         }
 
         public void SpawnAsset(

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -7239,34 +7239,61 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             return bounds;
         }
 
+
+
         public void spawnAgentBoxCollider(GameObject agent, Type agentType, Vector3 scaleRatio, bool useAbsoluteSize = false, bool useVisibleColliderBase = false) {
             // Store the current rotation
             Vector3 originalPosition = this.transform.position;
             Quaternion originalRotation = this.transform.rotation;
 
+            Debug.Log($"the original position of the agent is: {originalPosition:F8}");
+
             // Move the agent to a safe place and align the agent's rotation with the world coordinate system
-            this.transform.position = new Vector3(originalPosition.x + 100, originalPosition.y + 100, originalPosition.z + 100);
+            this.transform.position = new Vector3(originalPosition.x + 100f, originalPosition.y + 100f, originalPosition.z + 100f);
             this.transform.rotation = Quaternion.identity;
+
+            Debug.Log($"agent position after moving it out of the way is: {this.transform.position:F8}");
 
             // Get the agent's bounds
             var bounds = GetAgentBounds(agent, agentType);
 
-            // Move the agent back to its original position and rotation
-            this.transform.position = originalPosition;
-            this.transform.rotation = originalRotation;
+            Debug.Log($"the global position of the agent bounds is: {bounds.center:F8}");
 
             // Check if the spawned boxCollider is colliding with other objects
             int layerMask = LayerMask.GetMask("SimObjVisible", "Procedural1", "Procedural2", "Procedural3", "Procedural0");
-            Vector3 newBoxCenter = new Vector3(bounds.center.x - 100, bounds.center.y - 100, bounds.center.z - 100);
+            
+            Vector3 newBoxCenter = new Vector3(bounds.center.x - 100f, bounds.center.y - 100f, bounds.center.z - 100f);
+            Debug.Log($"the center for the new box should be at the agent's original position but is: {newBoxCenter:F8}");
+
+            #if UNITY_EDITOR
+            /////////////////////////////////////////////////
+            this.baseAgentComponent.boxCenter = newBoxCenter;
+            this.baseAgentComponent.boxHalfExtents = bounds.extents;
+            this.baseAgentComponent.boxOrientation = originalRotation;
+            this.baseAgentComponent.drawBox = true;
+
+            //for visualization lets spawna cube at the center of where the boxCenter supposedly is
+            GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.transform.position = this.baseAgentComponent.boxCenter;
+            cube.transform.rotation = this.baseAgentComponent.boxOrientation;
+            cube.transform.localScale = new Vector3(0.2f, 0.2f, 0.2f); //scale is small just so we can see it a little
+
+
+            Debug.Log("draw gizmos set for debug draw!");
+            ////////////////////////////////////////////////
+            #endif
+
             if (Physics.CheckBox(newBoxCenter, bounds.extents, originalRotation, layerMask)) {
-                errorMessage = "Spawned box collider is colliding with other objects. Cannot spawn box collider.";
-                actionFinished(false);
-                return;
+                this.transform.position = originalPosition;
+                this.transform.rotation = originalRotation;
+                throw new InvalidOperationException(
+                    "Spawned box collider is colliding with other objects. Cannot spawn box collider."
+                );
             }
 
             // Move the agent to the pose aligned with bounds' center and rotation
-            this.transform.position = new Vector3(originalPosition.x + 100, originalPosition.y + 100, originalPosition.z + 100);
-            this.transform.rotation = Quaternion.identity;
+            // this.transform.position = new Vector3(originalPosition.x + 100f, originalPosition.y + 100f, originalPosition.z + 100f);
+            // this.transform.rotation = Quaternion.identity;
 
             // Spawn the box collider
             Vector3 colliderSize = new Vector3(
@@ -7280,7 +7307,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             GameObject noneTriggeredEncapsulatingBox = new GameObject("NonTriggeredEncapsulatingBox");
             // noneTriggeredEncapsulatingBox.transform.position = new Vector3(bounds.center.x, bounds.center.y, agent.transform.position.z);
-            noneTriggeredEncapsulatingBox.transform.position = new Vector3(bounds.center.x, bounds.center.y, bounds.center.z);
+            noneTriggeredEncapsulatingBox.transform.position = bounds.center;
 
             BoxCollider nonTriggeredBoxCollider = noneTriggeredEncapsulatingBox.AddComponent<BoxCollider>();
             nonTriggeredBoxCollider.size = colliderSize; // Scale the box to the agent's size
@@ -7290,7 +7317,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             GameObject triggeredEncapsulatingBox = new GameObject("triggeredEncapsulatingBox");
             // triggeredEncapsulatingBox.transform.position = new Vector3(bounds.center.x, bounds.center.y, agent.transform.position.z);
-            triggeredEncapsulatingBox.transform.position = new Vector3(bounds.center.x, bounds.center.y, bounds.center.z);
+            triggeredEncapsulatingBox.transform.position = bounds.center;
 
             BoxCollider triggeredBoxCollider = triggeredEncapsulatingBox.AddComponent<BoxCollider>();
             triggeredBoxCollider.size = colliderSize; // Scale the box to the agent's size
@@ -8033,10 +8060,10 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             // Gizmos.color = Color.yellow;
             // Gizmos.DrawWireSphere(objectBounds.center, objectBounds.extents.magnitude);
-            foreach (var sphere in debugSpheres) {
-                Gizmos.color = sphere.color;
-                Gizmos.DrawWireSphere(sphere.worldSpaceCenter, sphere.radius);
-            }
+            // foreach (var sphere in debugSpheres) {
+            //     Gizmos.color = sphere.color;
+            //     Gizmos.DrawWireSphere(sphere.worldSpaceCenter, sphere.radius);
+            // }
         }
 #endif
 

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -7239,13 +7239,26 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             return bounds;
         }
 
-        public void SpawnBoxCollider(GameObject agent, Type agentType, Vector3 scaleRatio) {
+        public void SpawnBoxCollider(GameObject agent, Type agentType, Vector3 scaleRatio, bool useAbsoluteSize = false) {
             var bounds = GetAgentBounds(agent, agentType);
             GameObject noneTriggeredEncapsulatingBox = new GameObject("NonTriggeredEncapsulatingBox");
             noneTriggeredEncapsulatingBox.transform.position = new Vector3(bounds.center.x, bounds.center.y, agent.transform.position.z);
 
+            Vector3 colliderSize = new Vector3(
+                scaleRatio.x * bounds.extents.x * 2,
+                scaleRatio.y * bounds.size.y,
+                scaleRatio.z * bounds.extents.z * 2
+            );
+            if (useAbsoluteSize) {
+                colliderSize = new Vector3(
+                    scaleRatio.x,
+                    scaleRatio.y,
+                    scaleRatio.z
+                );
+            }
+
             BoxCollider nonTriggeredBoxCollider = noneTriggeredEncapsulatingBox.AddComponent<BoxCollider>();
-            nonTriggeredBoxCollider.size = new Vector3(scaleRatio.x * bounds.extents.x * 2, scaleRatio.y * bounds.size.y, scaleRatio.z * bounds.extents.z * 2); // Scale the box to the agent's size
+            nonTriggeredBoxCollider.size = colliderSize; // Scale the box to the agent's size
             nonTriggeredBoxCollider.enabled = true;
 
             noneTriggeredEncapsulatingBox.transform.parent = agent.transform;
@@ -7254,7 +7267,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             triggeredEncapsulatingBox.transform.position = new Vector3(bounds.center.x, bounds.center.y, agent.transform.position.z);
 
             BoxCollider triggeredBoxCollider = triggeredEncapsulatingBox.AddComponent<BoxCollider>();
-            triggeredBoxCollider.size = new Vector3(scaleRatio.x * bounds.extents.x * 2, scaleRatio.y * bounds.size.y, scaleRatio.z * bounds.extents.z * 2); // Scale the box to the agent's size
+            triggeredBoxCollider.size = colliderSize; // Scale the box to the agent's size
             triggeredBoxCollider.enabled = true;
             triggeredBoxCollider.isTrigger = true;
 
@@ -7276,7 +7289,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
         public void UpdateAgentBoxCollider(ServerAction action) {
             this.DestroyAgentBoxCollider(action);
-            this.SpawnBoxCollider(this.gameObject, this.GetType(), action.colliderScaleRatio);
+            this.SpawnBoxCollider(this.gameObject, this.GetType(), action.colliderScaleRatio, action.useAbsoluteSize);
             actionFinished(true);
             return;
         }

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -7275,15 +7275,41 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             actionFinishedEmit(true, geoList);
         }
 
-        public void SpawnBoxCollider(GameObject agent, Vector3 scaleRatio) {
-            var bounds = GetObjectSphereBounds(agent);
+        private Bounds GetAgentBounds(GameObject gameObject, Type agentType) {
+            Debug.Log(agentType);
+            Debug.Log(typeof(StretchAgentController));
+            Bounds bounds = new Bounds(gameObject.transform.position, Vector3.zero);
+            MeshRenderer[] meshRenderers = gameObject.GetComponentsInChildren<MeshRenderer>();
+            if (agentType == typeof(LocobotFPSAgentController)) {
+                meshRenderers = this.baseAgentComponent.BotVisCap.GetComponentsInChildren<MeshRenderer>();
+            } else if (agentType == typeof(StretchAgentController)) {
+                meshRenderers = this.baseAgentComponent.StretchVisCap.GetComponentsInChildren<MeshRenderer>();
+            }
+            foreach (MeshRenderer meshRenderer in meshRenderers) {
+                bounds.Encapsulate(meshRenderer.bounds);
+            }
+            return bounds;
+        }
+
+        protected void HideBoxRenderers(GameObject box) {
+            foreach (Renderer r in box.GetComponentsInChildren<Renderer>()) {
+                if (r.enabled) {
+                    r.enabled = false;
+                }
+            }
+        }
+
+        public void SpawnBoxCollider(GameObject agent, Type agentType, Vector3 scaleRatio) {
+            var bounds = GetAgentBounds(agent, agentType);
             GameObject box = GameObject.CreatePrimitive(PrimitiveType.Cube);
             box.transform.position = new Vector3(bounds.center.x, bounds.center.y, agent.transform.position.z);
-            box.transform.localScale = new Vector3(scaleRatio.x * bounds.extents.x / 2, scaleRatio.y * bounds.size.y, scaleRatio.z * bounds.extents.z / 2); // Scale the box to the agent's size
+            // box.transform.localScale = new Vector3(scaleRatio.x * bounds.extents.x / 2, scaleRatio.y * bounds.size.y, scaleRatio.z * bounds.extents.z / 2); // Scale the box to the agent's size
+            box.transform.localScale = new Vector3(scaleRatio.x * bounds.extents.x * 2, scaleRatio.y * bounds.size.y, scaleRatio.z * bounds.extents.z * 2); // Scale the box to the agent's size
             box.transform.parent = agent.transform;
-            box.transform.localPosition = new Vector3(0, bounds.center.y - agent.transform.position.y, 0);
+            // box.transform.localPosition = new Vector3(0, bounds.center.y - agent.transform.position.y, 0);
             BoxCollider boxCollider = box.GetComponent<BoxCollider>();
             boxCollider.enabled = true;
+            HideBoxRenderers(box);
         }
 
         public void SpawnAsset(

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -7275,6 +7275,17 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             actionFinishedEmit(true, geoList);
         }
 
+        public void SpawnBoxCollider(GameObject agent, Vector3 scaleRatio) {
+            var bounds = GetObjectSphereBounds(agent);
+            GameObject box = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            box.transform.position = new Vector3(bounds.center.x, bounds.center.y, agent.transform.position.z);
+            box.transform.localScale = new Vector3(scaleRatio.x * bounds.extents.x / 2, scaleRatio.y * bounds.size.y, scaleRatio.z * bounds.extents.z / 2); // Scale the box to the agent's size
+            box.transform.parent = agent.transform;
+            box.transform.localPosition = new Vector3(0, bounds.center.y - agent.transform.position.y, 0);
+            BoxCollider boxCollider = box.GetComponent<BoxCollider>();
+            boxCollider.enabled = true;
+        }
+
         public void SpawnAsset(
             string assetId,
             string generatedId,

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -368,54 +368,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);
                         break;
                     }
-                case "initb1c": {
-                        Dictionary<string, object> action = new Dictionary<string, object>();
-                        // if you want to use smaller grid size step increments, initialize with a smaller/larger gridsize here
-                        // by default the gridsize is 0.25, so only moving in increments of .25 will work
-                        // so the MoveAhead action will only take, by default, 0.25, .5, .75 etc magnitude with the default
-                        // grid size!
-                        // if (splitcommand.Length == 2) {
-                        //     action["gridSize"] = float.Parse(splitcommand[1]);
-                        // } else if (splitcommand.Length == 3) {
-                        //     action["gridSize"] = float.Parse(splitcommand[1]);
-                        //     action["agentCount"] = int.Parse(splitcommand[2]);
-                        // } else if (splitcommand.Length == 4) {
-                        //     action["gridSize"] = float.Parse(splitcommand[1]);
-                        //     action["agentCount"] = int.Parse(splitcommand[2]);
-                        //     action["makeAgentsVisible"] = int.Parse(splitcommand[3]) == 1;
-                        // }
-
-                        // action.renderNormalsImage = true;
-                        // action.renderDepthImage = true;
-                        // action.renderSemanticSegmentation = true;
-                        // action.renderInstanceSegmentation = true;
-                        // action.renderFlowImage = true;
-
-                        action["action"] = "Initialize";
-                        action["agentMode"] = "locobot";
-                        // action["gridSize"] = 0.25f;
-                        action["visibilityDistance"] = 1.5f;
-                        action["rotateStepDegrees"] = 30;
-                        // action["agentControllerType"] = "stochastic";
-                        // action["applyActionNoise"] = true;
-                        action["width"] = 400;
-                        action["height"] = 300;
-                        action["snapToGrid"] = false;
-                        action["fieldOfView"] = 90;
-                        action["gridSize"] = 0.25f;
-                        action["useFPINCollider"] = true;
-                        action["colliderScaleRatio"] = new Vector3(1.0f, 1.0f, 1.0f);
-
-
-                        action["applyActionNoise"] = true;
-                        action["continuousMode"] = true;
-                        //action["snapToGrid"] = false;
-                        //action["action"] = "Initialize";
-                        //action["fieldOfView"] = 90;
-                        //action["gridSize"] = 0.25f;
-                        CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);
-                        break;
-                    }
                 case "inita": {
                         Dictionary<string, object> action = new Dictionary<string, object>();
                         // if you want to use smaller grid size step increments, initialize with a smaller/larger gridsize here
@@ -502,58 +454,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         action["agentMode"] = "stretchab";
                         // action["agentControllerType"] = "arm";
                         action["renderInstanceSegmentation"] = true;
-
-                        // action.useMassThreshold = true;
-                        // action.massThreshold = 10f;
-
-
-                        CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);
-                        // AgentManager am = PhysicsController.gameObject.FindObjectsOfType<AgentManager>()[0];
-                        // Debug.Log("Physics scene manager = ...");
-                        // Debug.Log(physicsSceneManager);
-                        // AgentManager am = physicsSceneManager.GetComponent<AgentManager>();
-                        // Debug.Log(am);
-                        // am.Initialize(action);
-                        break;
-                    }
-                case "initabc": {
-                        Dictionary<string, object> action = new Dictionary<string, object>();
-                        // if you want to use smaller grid size step increments, initialize with a smaller/larger gridsize here
-                        // by default the gridsize is 0.25, so only moving in increments of .25 will work
-                        // so the MoveAhead action will only take, by default, 0.25, .5, .75 etc magnitude with the default
-                        // grid size!
-                        if (splitcommand.Length == 2) {
-                            action["gridSize"] = float.Parse(splitcommand[1]);
-                        } else if (splitcommand.Length == 3) {
-                            action["gridSize"] = float.Parse(splitcommand[1]);
-                            action["agentCount"] = int.Parse(splitcommand[2]);
-                        } else if (splitcommand.Length == 4) {
-                            action["gridSize"] = float.Parse(splitcommand[1]);
-                            action["agentCount"] = int.Parse(splitcommand[2]);
-                            action["makeAgentsVisible"] = int.Parse(splitcommand[3]) == 1;
-                        }
-                        // action.renderNormalsImage = true;
-                        // action.renderDepthImage = true;
-                        // action.renderClassImage = true;
-                        // action.renderObjectImage = true;
-                        // action.renderFlowImage = true;
-                        // PhysicsController.actionComplete = false;
-                        // action.rotateStepDegrees = 30;
-                        // action.ssao = "default";
-                        // action.snapToGrid = true;
-                        // action.makeAgentsVisible = false;
-                        // action.agentMode = "bot";
-                        // action.fieldOfView = 90f;
-                        // action.cameraY = 2.0f;
-                        // action.snapToGrid = true;
-                        // action.rotateStepDegrees = 45;
-                        action["action"] = "Initialize";
-
-                        action["agentMode"] = "stretchab";
-                        // action["agentControllerType"] = "arm";
-                        action["renderInstanceSegmentation"] = true;
-                        action["useFPINCollider"] = true;
-                        action["colliderScaleRatio"] = new Vector3(1.0f, 1.0f, 1.0f);
 
                         // action.useMassThreshold = true;
                         // action.massThreshold = 10f;
@@ -669,24 +569,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     action["renderDepth"] = true;
 //                  action["antiAliasing"] = "smaa";
                     action["massThreshold"] = 10.0f;
-
-                    ActionDispatcher.Dispatch(AManager, new DynamicServerAction(action));
-                    //CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);
-
-                    break;
-                }
-                case "initsc": {
-                    Dictionary<string, object> action = new Dictionary<string, object>();
-
-                    action["action"] = "Initialize";
-                    action["agentMode"] = "stretch";
-                    action["agentControllerType"] = "stretch";
-                    action["visibilityScheme"] = "Distance";
-                    action["renderInstanceSegmentation"] = true;
-                    action["renderDepth"] = true;
-                    action["massThreshold"] = 10.0f;
-                    action["useFPINCollider"] = true;
-                    action["colliderScaleRatio"] = new Vector3(1.0f, 1.0f, 1.0f);
 
                     ActionDispatcher.Dispatch(AManager, new DynamicServerAction(action));
                     //CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);
@@ -1572,6 +1454,23 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         Dictionary<string, object> action = new Dictionary<string, object>();
                         action["action"] = "SetAgentRadius";
                         action["agentRadius"] = 0.35f;
+                        CurrentActiveController().ProcessControlCommand(action);
+                        break;
+                    }
+                
+                case "sbc": {
+                        var action = new Dictionary<string, object>() {
+                            ["action"] = "UpdateAgentBoxCollider",
+                            ["colliderScaleRatio"] = new Vector3(2.0f, 1.0f, 2.0f)
+                        };
+                        CurrentActiveController().ProcessControlCommand(action);
+                        break;
+                    }
+                
+                case "dbc": {
+                        var action = new Dictionary<string, object>() {
+                            ["action"] = "DestroyAgentBoxCollider",
+                        };
                         CurrentActiveController().ProcessControlCommand(action);
                         break;
                     }

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -1467,6 +1467,16 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         break;
                     }
                 
+                case "sbca": {
+                        var action = new Dictionary<string, object>() {
+                            ["action"] = "UpdateAgentBoxCollider",
+                            ["colliderScaleRatio"] = new Vector3(0.2f, 1.0f, 0.2f),
+                            ["useAbsoluteSize"] = true
+                        };
+                        CurrentActiveController().ProcessControlCommand(action);
+                        break;
+                    }
+                
                 case "dbc": {
                         var action = new Dictionary<string, object>() {
                             ["action"] = "DestroyAgentBoxCollider",

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -2014,9 +2014,10 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 case "umc": {
                         Dictionary<string, object> action = new Dictionary<string, object>() {
                             ["action"] = "UpdateMainCamera",
-                            ["position"] = new Vector3(2, 2, 2),
+                            ["position"] = new Vector3(-1, 0.9f, 1),
                             ["rotation"] = new Vector3(15, 25, 35),
-                            ["agentPositionRelativeCoordinates"] = false
+                            ["fieldOfView"] = 120f,
+                            // ["agentPositionRelativeCoordinates"] = false
                         };
 
                         CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -598,6 +598,23 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                     break;
                 }
+                case "initfs": {
+                    Dictionary<string, object> action = new Dictionary<string, object>();
+
+                    action["action"] = "Initialize";
+                    action["agentMode"] = "stretch";
+                    action["agentControllerType"] = "stretch";
+                    action["visibilityScheme"] = "Distance";
+                    action["renderInstanceSegmentation"] = true;
+                    action["renderDepth"] = true;
+                    action["massThreshold"] = 10.0f;
+                    action["useFPINCollider"] = true;
+                    action["colliderScaleRatio"] = new Vector3(1.0f, 1.0f, 1.0f);
+
+                    ActionDispatcher.Dispatch(AManager, new DynamicServerAction(action));
+
+                    break;
+                }
                 case "obig": {
                     Dictionary<string, object> action = new Dictionary<string, object>();
 

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -359,6 +359,53 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         action["fieldOfView"] = 90;
                         action["gridSize"] = 0.25f;
 
+                        action["applyActionNoise"] = true;
+                        action["continuousMode"] = true;
+                        //action["snapToGrid"] = false;
+                        //action["action"] = "Initialize";
+                        //action["fieldOfView"] = 90;
+                        //action["gridSize"] = 0.25f;
+                        CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);
+                        break;
+                    }
+                case "initb1c": {
+                        Dictionary<string, object> action = new Dictionary<string, object>();
+                        // if you want to use smaller grid size step increments, initialize with a smaller/larger gridsize here
+                        // by default the gridsize is 0.25, so only moving in increments of .25 will work
+                        // so the MoveAhead action will only take, by default, 0.25, .5, .75 etc magnitude with the default
+                        // grid size!
+                        // if (splitcommand.Length == 2) {
+                        //     action["gridSize"] = float.Parse(splitcommand[1]);
+                        // } else if (splitcommand.Length == 3) {
+                        //     action["gridSize"] = float.Parse(splitcommand[1]);
+                        //     action["agentCount"] = int.Parse(splitcommand[2]);
+                        // } else if (splitcommand.Length == 4) {
+                        //     action["gridSize"] = float.Parse(splitcommand[1]);
+                        //     action["agentCount"] = int.Parse(splitcommand[2]);
+                        //     action["makeAgentsVisible"] = int.Parse(splitcommand[3]) == 1;
+                        // }
+
+                        // action.renderNormalsImage = true;
+                        // action.renderDepthImage = true;
+                        // action.renderSemanticSegmentation = true;
+                        // action.renderInstanceSegmentation = true;
+                        // action.renderFlowImage = true;
+
+                        action["action"] = "Initialize";
+                        action["agentMode"] = "locobot";
+                        // action["gridSize"] = 0.25f;
+                        action["visibilityDistance"] = 1.5f;
+                        action["rotateStepDegrees"] = 30;
+                        // action["agentControllerType"] = "stochastic";
+                        // action["applyActionNoise"] = true;
+                        action["width"] = 400;
+                        action["height"] = 300;
+                        action["snapToGrid"] = false;
+                        action["fieldOfView"] = 90;
+                        action["gridSize"] = 0.25f;
+                        action["useFPINCollider"] = true;
+                        action["colliderScaleRatio"] = new Vector3(1.0f, 1.0f, 1.0f);
+
 
                         action["applyActionNoise"] = true;
                         action["continuousMode"] = true;
@@ -455,6 +502,58 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         action["agentMode"] = "stretchab";
                         // action["agentControllerType"] = "arm";
                         action["renderInstanceSegmentation"] = true;
+
+                        // action.useMassThreshold = true;
+                        // action.massThreshold = 10f;
+
+
+                        CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);
+                        // AgentManager am = PhysicsController.gameObject.FindObjectsOfType<AgentManager>()[0];
+                        // Debug.Log("Physics scene manager = ...");
+                        // Debug.Log(physicsSceneManager);
+                        // AgentManager am = physicsSceneManager.GetComponent<AgentManager>();
+                        // Debug.Log(am);
+                        // am.Initialize(action);
+                        break;
+                    }
+                case "initabc": {
+                        Dictionary<string, object> action = new Dictionary<string, object>();
+                        // if you want to use smaller grid size step increments, initialize with a smaller/larger gridsize here
+                        // by default the gridsize is 0.25, so only moving in increments of .25 will work
+                        // so the MoveAhead action will only take, by default, 0.25, .5, .75 etc magnitude with the default
+                        // grid size!
+                        if (splitcommand.Length == 2) {
+                            action["gridSize"] = float.Parse(splitcommand[1]);
+                        } else if (splitcommand.Length == 3) {
+                            action["gridSize"] = float.Parse(splitcommand[1]);
+                            action["agentCount"] = int.Parse(splitcommand[2]);
+                        } else if (splitcommand.Length == 4) {
+                            action["gridSize"] = float.Parse(splitcommand[1]);
+                            action["agentCount"] = int.Parse(splitcommand[2]);
+                            action["makeAgentsVisible"] = int.Parse(splitcommand[3]) == 1;
+                        }
+                        // action.renderNormalsImage = true;
+                        // action.renderDepthImage = true;
+                        // action.renderClassImage = true;
+                        // action.renderObjectImage = true;
+                        // action.renderFlowImage = true;
+                        // PhysicsController.actionComplete = false;
+                        // action.rotateStepDegrees = 30;
+                        // action.ssao = "default";
+                        // action.snapToGrid = true;
+                        // action.makeAgentsVisible = false;
+                        // action.agentMode = "bot";
+                        // action.fieldOfView = 90f;
+                        // action.cameraY = 2.0f;
+                        // action.snapToGrid = true;
+                        // action.rotateStepDegrees = 45;
+                        action["action"] = "Initialize";
+
+                        action["agentMode"] = "stretchab";
+                        // action["agentControllerType"] = "arm";
+                        action["renderInstanceSegmentation"] = true;
+                        action["useFPINCollider"] = true;
+                        action["colliderScaleRatio"] = new Vector3(1.0f, 1.0f, 1.0f);
 
                         // action.useMassThreshold = true;
                         // action.massThreshold = 10f;
@@ -576,6 +675,24 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                     break;
                 }
+                case "initsc": {
+                    Dictionary<string, object> action = new Dictionary<string, object>();
+
+                    action["action"] = "Initialize";
+                    action["agentMode"] = "stretch";
+                    action["agentControllerType"] = "stretch";
+                    action["visibilityScheme"] = "Distance";
+                    action["renderInstanceSegmentation"] = true;
+                    action["renderDepth"] = true;
+                    action["massThreshold"] = 10.0f;
+                    action["useFPINCollider"] = true;
+                    action["colliderScaleRatio"] = new Vector3(1.0f, 1.0f, 1.0f);
+
+                    ActionDispatcher.Dispatch(AManager, new DynamicServerAction(action));
+                    //CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);
+
+                    break;
+                }
                 case "inits-cp": {
                     Dictionary<string, object> action = new Dictionary<string, object>();
 
@@ -595,23 +712,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                     ActionDispatcher.Dispatch(AManager, new DynamicServerAction(action));
                     //CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);
-
-                    break;
-                }
-                case "initfs": {
-                    Dictionary<string, object> action = new Dictionary<string, object>();
-
-                    action["action"] = "Initialize";
-                    action["agentMode"] = "stretch";
-                    action["agentControllerType"] = "stretch";
-                    action["visibilityScheme"] = "Distance";
-                    action["renderInstanceSegmentation"] = true;
-                    action["renderDepth"] = true;
-                    action["massThreshold"] = 10.0f;
-                    action["useFPINCollider"] = true;
-                    action["colliderScaleRatio"] = new Vector3(1.0f, 1.0f, 1.0f);
-
-                    ActionDispatcher.Dispatch(AManager, new DynamicServerAction(action));
 
                     break;
                 }

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -1461,7 +1461,38 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 case "sbc": {
                         var action = new Dictionary<string, object>() {
                             ["action"] = "UpdateAgentBoxCollider",
-                            ["colliderScaleRatio"] = new Vector3(2.0f, 1.0f, 2.0f)
+                            ["colliderScaleRatio"] = new Vector3(1.3f, 1.0f, 1.0f),
+                            ["useVisibleColliderBase"] = false
+                        };
+                        CurrentActiveController().ProcessControlCommand(action);
+                        break;
+                    }
+
+                case "sbc2": {
+                        var action = new Dictionary<string, object>() {
+                            ["action"] = "UpdateAgentBoxCollider",
+                            ["colliderScaleRatio"] = new Vector3(1.0f, 1.0f, 1.3f),
+                            ["useVisibleColliderBase"] = false
+                        };
+                        CurrentActiveController().ProcessControlCommand(action);
+                        break;
+                    }
+
+                case "sbcv": {
+                        var action = new Dictionary<string, object>() {
+                            ["action"] = "UpdateAgentBoxCollider",
+                            ["colliderScaleRatio"] = new Vector3(1.3f, 1.0f, 1.0f),
+                            ["useVisibleColliderBase"] = true
+                        };
+                        CurrentActiveController().ProcessControlCommand(action);
+                        break;
+                    }
+
+                case "sbcv2": {
+                        var action = new Dictionary<string, object>() {
+                            ["action"] = "UpdateAgentBoxCollider",
+                            ["colliderScaleRatio"] = new Vector3(1.0f, 1.0f, 1.3f),
+                            ["useVisibleColliderBase"] = true
                         };
                         CurrentActiveController().ProcessControlCommand(action);
                         break;
@@ -1470,7 +1501,17 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 case "sbca": {
                         var action = new Dictionary<string, object>() {
                             ["action"] = "UpdateAgentBoxCollider",
-                            ["colliderScaleRatio"] = new Vector3(0.2f, 1.0f, 0.2f),
+                            ["colliderScaleRatio"] = new Vector3(0.5f, 1.0f, 0.3f),
+                            ["useAbsoluteSize"] = true
+                        };
+                        CurrentActiveController().ProcessControlCommand(action);
+                        break;
+                    }
+                
+                case "sbca2": {
+                        var action = new Dictionary<string, object>() {
+                            ["action"] = "UpdateAgentBoxCollider",
+                            ["colliderScaleRatio"] = new Vector3(0.3f, 1.0f, 0.5f),
                             ["useAbsoluteSize"] = true
                         };
                         CurrentActiveController().ProcessControlCommand(action);

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -1461,7 +1461,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 case "sbc": {
                         var action = new Dictionary<string, object>() {
                             ["action"] = "UpdateAgentBoxCollider",
-                            ["colliderScaleRatio"] = new Vector3(1.3f, 1.0f, 1.0f),
+                            ["colliderScaleRatio"] = new Vector3(1.0f, 1.0f, 1.0f),
                             ["useVisibleColliderBase"] = false
                         };
                         CurrentActiveController().ProcessControlCommand(action);

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -1471,7 +1471,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 case "sbc2": {
                         var action = new Dictionary<string, object>() {
                             ["action"] = "UpdateAgentBoxCollider",
-                            ["colliderScaleRatio"] = new Vector3(1.0f, 1.0f, 1.3f),
+                            ["colliderScaleRatio"] = new Vector3(1.1f, 1.0f, 1.3f),
                             ["useVisibleColliderBase"] = false
                         };
                         CurrentActiveController().ProcessControlCommand(action);

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -2092,7 +2092,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                             ["action"] = "AddThirdPartyCamera",
                             ["position"] = new Vector3(1, 1, 1),
                             ["rotation"] = new Vector3(10, 20, 30),
-                            ["attachToPrimaryAgent"] = true
+                            ["attachToAgent"] = true
                         };
 
                         CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);

--- a/unity/Assets/Scripts/DroneFPSAgentController.cs
+++ b/unity/Assets/Scripts/DroneFPSAgentController.cs
@@ -351,7 +351,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
         public void TeleportFull(
-            Vector3 position, Vector3 rotation, float horizon, bool forceAction = false
+            Vector3? position, Vector3? rotation, float? horizon, bool forceAction = false
         ) {
             base.teleportFull(position: position, rotation: rotation, horizon: horizon, forceAction: forceAction);
             actionFinished(success: true);

--- a/unity/Assets/Scripts/LocobotFPSAgentController.cs
+++ b/unity/Assets/Scripts/LocobotFPSAgentController.cs
@@ -275,17 +275,17 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         ///////////////////////////////////////////
 
         [ObsoleteAttribute(message: "This action is deprecated. Call TeleportFull(position, ...) instead.", error: false)]
-        public void TeleportFull(float x, float y, float z, Vector3 rotation, float horizon, bool forceAction = false) {
+        public void TeleportFull(float x, float y, float z, Vector3? rotation, float? horizon, bool forceAction = false) {
             TeleportFull(
                 position: new Vector3(x, y, z), rotation: rotation, horizon: horizon, forceAction: forceAction
             );
         }
 
         public void TeleportFull(
-            Vector3 position, Vector3 rotation, float horizon, bool forceAction = false
+            Vector3? position, Vector3? rotation, float? horizon, bool forceAction = false
         ) {
             base.teleportFull(position: position, rotation: rotation, horizon: horizon, forceAction: forceAction);
-            base.assertTeleportedNearGround(targetPosition: position);
+            base.assertTeleportedNearGround(targetPosition: transform.position);
             actionFinished(success: true);
         }
 

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1425,9 +1425,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         [ObsoleteAttribute(message: "This action is deprecated. Call TeleportFull(position, ...) instead.", error: false)]
         public void TeleportFull(
             float x, float y, float z,
-            Vector3 rotation,
-            float horizon,
-            bool standing,
+            Vector3? rotation,
+            float? horizon,
+            bool? standing,
             bool forceAction = false
         ) {
             TeleportFull(
@@ -1458,10 +1458,10 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
         // has to consider both the arm and standing
         public void TeleportFull(
-            Vector3 position,
-            Vector3 rotation,
-            float horizon,
-            bool standing,
+            Vector3? position,
+            Vector3? rotation,
+            float? horizon,
+            bool? standing,
             bool forceAction = false
         ) {
             Debug.Log($"------- Teleport Full physicsFPS type {this.GetType()}");
@@ -1488,10 +1488,12 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     forceAction: forceAction
                 );
 
-                if (standing) {
-                    stand();
-                } else {
-                    crouch();
+                if (standing.HasValue) {
+                    if (standing.Value) {
+                        stand();
+                    } else {
+                        crouch();
+                    }
                 }
 
                 // add arm value cases

--- a/unity/Assets/Scripts/ProceduralTools.cs
+++ b/unity/Assets/Scripts/ProceduralTools.cs
@@ -2347,7 +2347,6 @@ namespace Thor.Procedural {
                 mesh.uv = uvs;
             }
             mesh.RecalculateTangents();
-            
 
             // add the mesh to the object
             meshObj.AddComponent<MeshRenderer>();
@@ -2582,10 +2581,8 @@ namespace Thor.Procedural {
             MonoBehaviour.Destroy(oldGo);
 
             if (serializable) {
-                // meshObj.AddComponent<SerializeMesh>();
                 if (returnObject) {
                     result["gameObject"] = go;
-                    //result["intermediateGameObject"] = oldGo;
                 }
             }
             return result;

--- a/unity/Assets/Scripts/StretchAgentController.cs
+++ b/unity/Assets/Scripts/StretchAgentController.cs
@@ -268,6 +268,73 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             actionFinished(true);
         }
 
+//        public void RotateCameraBase(float yawDegrees, float rollDegrees) {
+//            var target = gimbalBase;
+//            var maxDegree = maxBaseXYRotation;
+//            Debug.Log("yaw is " + yawDegrees + " and roll is " + rollDegrees);
+//            if (yawDegrees < -maxDegree || maxDegree < yawDegrees) {
+//                throw new InvalidOperationException(
+//                    $"Invalid value for `yawDegrees`: '{yawDegrees}'. Value should be between '{-maxDegree}' and '{maxDegree}'."
+//                );
+//            } else if (rollDegrees < -maxDegree || maxDegree < rollDegrees) {
+//                throw new InvalidOperationException(
+//                    $"Invalid value for `rollDegrees`: '{rollDegrees}'. Value should be between '{-maxDegree}' and '{maxDegree}'."
+//                );
+//            } else {
+//                gimbalBase.localEulerAngles = new Vector3(
+//                    gimbalBaseStartingXRotation + rollDegrees,
+//                    gimbalBaseStartingYRotation + yawDegrees,
+//                    gimbalBase.transform.localEulerAngles.z
+//                );
+//            }
+//            actionFinished(true);
+//        }
+
+        public void RotateCameraMount(float degrees, bool secondary = false) {
+            var minDegree = -80.00001f;
+            var maxDegree = 80.00001f;
+            if (degrees >= minDegree && degrees <= maxDegree) {
+
+                Camera cam;
+                if (secondary) {
+                    cam = agentManager.thirdPartyCameras[0];
+                } else {
+                    cam = m_Camera;
+                }
+                AgentManager.OptionalVector3 localEulerAngles = new AgentManager.OptionalVector3(
+                    x: degrees, y: cam.transform.localEulerAngles.y, z: cam.transform.localEulerAngles.z
+                );
+
+                int agentId = -1;
+                for (int i = 0; i < agentManager.agents.Count; i++) {
+                    if (agentManager.agents[i] == this) {
+                        agentId = i;
+                        break;
+                    }
+                }
+                if (agentId != 0) {
+                    errorMessage = "Only the primary agent can rotate the camera for now.";
+                    actionFinished(false);
+                    return;
+                }
+
+                if (secondary) {
+                    agentManager.UpdateThirdPartyCamera(
+                        thirdPartyCameraId: 0,
+                        rotation: localEulerAngles,
+                        agentPositionRelativeCoordinates: true,
+                        agentId: agentId
+                    );
+                } else {
+                    agentManager.UpdateMainCamera(rotation: localEulerAngles);
+                }
+            }
+            else {
+                errorMessage = $"Invalid value for `degrees`: '{degrees}'. Value should be between '{minDegree}' and '{maxDegree}'.";
+                actionFinished(false);
+            }
+        }
+
     }
 
 }

--- a/unity/Assets/UnitTests/TestThirdPartyCameraAndMainCamera.cs
+++ b/unity/Assets/UnitTests/TestThirdPartyCameraAndMainCamera.cs
@@ -54,7 +54,7 @@ namespace Tests {
             action["rotation"] = new Vector3(15, 20, 89);
             action["orthographic"] = true;
             action["orthographicSize"] = 5;
-            action["attachToPrimaryAgent"] = true;
+            action["attachToAgent"] = true;
             yield return step(action);
 
             Assert.NotNull(GameObject.Find("ThirdPartyCamera1"));


### PR DESCRIPTION
The newly added SpawnBoxCollider function generates a box with an active collider encapsulates the agent. Currently, it only supports the Stretch agent.

New augments:
1. `useFPINCollider`: bool. When set to True, SpawnBoxCollider is included during the initialization phase. If False, initialization proceeds as previously.
2. `colliderScaleRatio`: dict. It specifies the scale ratio of the box along each axis, for example, `{"x": 1.0, "y": 1.0, "z": 1.0}`. A value of 1.0 indicates that the box size matches the detected bounds.