### PR TITLE
Updating Agent Metadata and ThirdPartyCamera Metadata

### DIFF
--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1295,7 +1295,7 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
                 Camera camera = thirdPartyCameras.ToArray()[i];
                 cMetadata.thirdPartyCameraId = i;
 
-                //to be depracated at some point, will be replaced by more descriptive worldRelativeThirdPartyCamera....
+                //to be deprecated at some point, will be replaced by more descriptive worldRelativeThirdPartyCamera....
                 cMetadata.position = camera.transform.position;
                 cMetadata.rotation = camera.transform.eulerAngles;
                 //currently redundant data as it is the same as metadata.position/rotation, but more descriptive naming convention
@@ -1313,7 +1313,7 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
                     cMetadata.parentPositionRelativeThirdPartyCameraPosition =
                         camera.transform.parent.InverseTransformPoint(camera.transform.position);
 
-                    //get third party camera rotation as quaternion in world space
+                    //get third party camera rotation as quaternion in parent space
                     var parentSpaceCameraRotationAsQuaternion =
                         Quaternion.Inverse(camera.transform.parent.rotation)
                         * worldSpaceCameraRotationAsQuaternion;
@@ -1325,23 +1325,22 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
                     cMetadata.parentPositionRelativeThirdPartyCameraRotation = null;
                 }
 
-                //if this camera is part of the agent's heirarchy at all, get agent relative info
+                //if this camera is part of the agent's hierarchy at all, get agent relative info
                 if (camera.GetComponentInParent<BaseAgentComponent>() != null) {
                     GameObject agent = camera.GetComponentInParent<BaseAgentComponent>().gameObject;
 
                     cMetadata.agentPositionRelativeThirdPartyCameraPosition =
                         agent.transform.InverseTransformPoint(camera.gameObject.transform.position);
 
-                    //get third party camera rotation as quaternion in world space
                     var agentSpaceCameraRotationAsQuaternion =
                         Quaternion.Inverse(agent.transform.rotation)
                         * worldSpaceCameraRotationAsQuaternion;
-                    cMetadata.agentPositionRelativeThirdPartyCameraRotation =
+                    cMetadata.agentRotationRelativeThirdPartyCameraRotation =
                         agentSpaceCameraRotationAsQuaternion.eulerAngles;
                 } else {
                     //if this third party camera is not a child of the agent, we don't need agent-relative coordinates
                     cMetadata.agentPositionRelativeThirdPartyCameraPosition = null;
-                    cMetadata.agentPositionRelativeThirdPartyCameraRotation = null;
+                    cMetadata.agentRotationRelativeThirdPartyCameraRotation = null;
                 }
 
                 cMetadata.fieldOfView = camera.fieldOfView;
@@ -1877,12 +1876,12 @@ public class ThirdPartyCameraMetadata {
     //note these should only be returned with values
     //if the third party camera is a child of the agent
     public Vector3? agentPositionRelativeThirdPartyCameraPosition;
-    public Vector3? agentPositionRelativeThirdPartyCameraRotation;
+    public Vector3? agentRotationRelativeThirdPartyCameraRotation;
 
     //return the local space coordinates if this third party camera has a parent object, this may be the same as agentPositionRelative depending on how things are parented
     public Vector3? parentPositionRelativeThirdPartyCameraPosition;
     public Vector3? parentPositionRelativeThirdPartyCameraRotation;
-    public string parentObjectName; //if this third party camera is in a heirarchy, return the name of the parent object
+    public string parentObjectName; //if this third party camera is in a hierarchy, return the name of the parent object
 }
 
 [Serializable]
@@ -2314,7 +2313,7 @@ public struct MetadataWrapper {
     public Vector3 worldRelativeCameraPosition;
     public Vector3 worldRelativeCameraRotation;
     public Vector3 agentPositionRelativeCameraPosition;
-    public Vector3 agentPositionRelativeCameraRotation;
+    public Vector3 agentRotationRelativeCameraRotation;
     public float cameraOrthSize;
     public ThirdPartyCameraMetadata[] thirdPartyCameras;
     public bool collided;

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1307,15 +1307,18 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
 
                 //this may be the same info as the agentPositionRelative values since ThirdPartyCameras often are children of the agent
                 //but in cases where a third party camera is attached to an arm joint or the like, this can be useful
-                if(camera.transform.parent != null) {
+                if (camera.transform.parent != null) {
                     cMetadata.parentObjectName = camera.transform.parent.name;
 
-                    cMetadata.parentPositionRelativeThirdPartyCameraPosition = camera.transform.parent.InverseTransformPoint(camera.transform.position);
-                
-                    //get third party camera rotation as quaternion in world space
-                    var parentSpaceCameraRotationAsQuaternion = Quaternion.Inverse(camera.transform.parent.rotation) * worldSpaceCameraRotationAsQuaternion;
-                    cMetadata.parentPositionRelativeThirdPartyCameraRotation = parentSpaceCameraRotationAsQuaternion.eulerAngles;
+                    cMetadata.parentPositionRelativeThirdPartyCameraPosition =
+                        camera.transform.parent.InverseTransformPoint(camera.transform.position);
 
+                    //get third party camera rotation as quaternion in world space
+                    var parentSpaceCameraRotationAsQuaternion =
+                        Quaternion.Inverse(camera.transform.parent.rotation)
+                        * worldSpaceCameraRotationAsQuaternion;
+                    cMetadata.parentPositionRelativeThirdPartyCameraRotation =
+                        parentSpaceCameraRotationAsQuaternion.eulerAngles;
                 } else {
                     cMetadata.parentObjectName = "";
                     cMetadata.parentPositionRelativeThirdPartyCameraPosition = null;
@@ -1326,12 +1329,15 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
                 if (camera.GetComponentInParent<BaseAgentComponent>() != null) {
                     GameObject agent = camera.GetComponentInParent<BaseAgentComponent>().gameObject;
 
-                    cMetadata.agentPositionRelativeThirdPartyCameraPosition = agent.transform.InverseTransformPoint(camera.gameObject.transform.position);
+                    cMetadata.agentPositionRelativeThirdPartyCameraPosition =
+                        agent.transform.InverseTransformPoint(camera.gameObject.transform.position);
 
                     //get third party camera rotation as quaternion in world space
-                    var agentSpaceCameraRotationAsQuaternion = Quaternion.Inverse(agent.transform.rotation) * worldSpaceCameraRotationAsQuaternion;
-                    cMetadata.agentPositionRelativeThirdPartyCameraRotation = agentSpaceCameraRotationAsQuaternion.eulerAngles;
-
+                    var agentSpaceCameraRotationAsQuaternion =
+                        Quaternion.Inverse(agent.transform.rotation)
+                        * worldSpaceCameraRotationAsQuaternion;
+                    cMetadata.agentPositionRelativeThirdPartyCameraRotation =
+                        agentSpaceCameraRotationAsQuaternion.eulerAngles;
                 } else {
                     //if this third party camera is not a child of the agent, we don't need agent-relative coordinates
                     cMetadata.agentPositionRelativeThirdPartyCameraPosition = null;
@@ -1872,6 +1878,7 @@ public class ThirdPartyCameraMetadata {
     //if the third party camera is a child of the agent
     public Vector3? agentPositionRelativeThirdPartyCameraPosition;
     public Vector3? agentPositionRelativeThirdPartyCameraRotation;
+
     //return the local space coordinates if this third party camera has a parent object, this may be the same as agentPositionRelative depending on how things are parented
     public Vector3? parentPositionRelativeThirdPartyCameraPosition;
     public Vector3? parentPositionRelativeThirdPartyCameraRotation;

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1297,29 +1297,25 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
 
                 cMetadata.position = camera.gameObject.transform.position;
                 cMetadata.rotation = camera.gameObject.transform.eulerAngles;
+                cMetadata.worldRelativeThirdPartyCameraPosition = cMetadata.position;
+                cMetadata.worldRelativeThirdPartyCameraPosition = cMetadata.rotation;
 
-                //agent relative third party camera metadata here
-                //if the camera is a child of the base agent, then return local space values
-                if (camera.GetComponentInParent<BaseAgentComponent>()) {
-                    cMetadata.agentPositionRelativeThirdPartyCameraPosition = camera
-                        .gameObject
-                        .transform
-                        .localPosition;
-                    cMetadata.agentPositionRelativeThirdPartyCameraRotation = camera
-                        .gameObject
-                        .transform
-                        .localEulerAngles;
+                if(camera.transform.parent != null) {
+                    cMetadata.parentObjectName = camera.transform.parent.name;
+                    cMetadata.parentPositionRelativeThirdPartyCameraPosition = camera.transform.parent.InverseTransformPoint(camera.transform.position);
+                } else {
+                    cMetadata.parentObjectName = "";
+                }
+
+                if (camera.GetComponentInParent<BaseAgentComponent>() != null) {
+                    GameObject agent = camera.GetComponentInParent<BaseAgentComponent>().gameObject;
+                    cMetadata.agentPositionRelativeThirdPartyCameraPosition = agent.transform.InverseTransformPoint(camera.gameObject.transform.position);
+                    cMetadata.agentPositionRelativeThirdPartyCameraRotation = agent.transform.InverseTransformDirection(camera.gameObject.transform.forward);
                 } else {
                     //if this third party camera is not a child of the agent, then the agent relative coordinates
                     //are the same as the world coordinates so
-                    cMetadata.agentPositionRelativeThirdPartyCameraPosition = camera
-                        .gameObject
-                        .transform
-                        .position;
-                    cMetadata.agentPositionRelativeThirdPartyCameraRotation = camera
-                        .gameObject
-                        .transform
-                        .eulerAngles;
+                    cMetadata.agentPositionRelativeThirdPartyCameraPosition = null;
+                    cMetadata.agentPositionRelativeThirdPartyCameraRotation = null;
                 }
 
                 cMetadata.fieldOfView = camera.fieldOfView;
@@ -1846,14 +1842,20 @@ public class MultiAgentMetadata {
 [MessagePackObject(keyAsPropertyName: true)]
 public class ThirdPartyCameraMetadata {
     public int thirdPartyCameraId;
-    public Vector3 position;
-    public Vector3 rotation;
+    public Vector3 position; //to be deprecated
+    public Vector3 rotation; //to be deprecated
+    public Vector3 worldRelativeThirdPartyCameraPosition;
+    public Vector3 worldRelativeThirdPartyCameraRotation;
     public float fieldOfView;
 
     //note these should only be returned with values
     //if the third party camera is a child of the agent
-    public Vector3 agentPositionRelativeThirdPartyCameraPosition;
-    public Vector3 agentPositionRelativeThirdPartyCameraRotation;
+    public Vector3? agentPositionRelativeThirdPartyCameraPosition;
+    public Vector3? agentPositionRelativeThirdPartyCameraRotation;
+    //return the local space coordinates if this third party camera has a parent object, this may be the same as agentPositionRelative depending on how things are parented
+    public Vector3? parentPositionRelativeThirdPartyCameraPosition;
+    public Vector3? parentPositionRelativeThirdPartyCameraRotation;
+    public string parentObjectName; //if this third party camera is in a heirarchy, return the name of the parent object
 }
 
 [Serializable]
@@ -2280,8 +2282,10 @@ public struct MetadataWrapper {
     public ArmMetadata arm;
     public ArticulationArmMetadata articulationArm;
     public float fov;
-    public Vector3 cameraPosition;
-    public Vector3 cameraRotation;
+    public Vector3 cameraPosition; //to be deprecated
+    public Vector3 cameraRotation; //to be deprecated
+    public Vector3 worldRelativeCameraPosition;
+    public Vector3 worldRelativeCameraRotation;
     public Vector3 agentPositionRelativeCameraPosition;
     public Vector3 agentPositionRelativeCameraRotation;
     public float cameraOrthSize;

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1296,15 +1296,15 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
                 cMetadata.thirdPartyCameraId = i;
 
                 //to be depracated at some point, will be replaced by more descriptive worldRelativeThirdPartyCamera....
-                cMetadata.position = camera.gameObject.transform.position;
-                cMetadata.rotation = camera.gameObject.transform.eulerAngles;
+                cMetadata.position = camera.transform.position;
+                cMetadata.rotation = camera.transform.eulerAngles;
                 //currently redundant data as it is the same as metadata.position/rotation, but more descriptive naming convention
-                cMetadata.worldRelativeThirdPartyCameraPosition = cMetadata.position;
-                cMetadata.worldRelativeThirdPartyCameraPosition = cMetadata.rotation;
+                cMetadata.worldRelativeThirdPartyCameraPosition = camera.transform.position;
+                cMetadata.worldRelativeThirdPartyCameraRotation = camera.transform.eulerAngles;
 
                 //grab this for parent or agent relative stuff
                 var worldSpaceCameraRotationAsQuaternion = camera.transform.rotation;
-                
+
                 //this may be the same info as the agentPositionRelative values since ThirdPartyCameras often are children of the agent
                 //but in cases where a third party camera is attached to an arm joint or the like, this can be useful
                 if(camera.transform.parent != null) {

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -624,10 +624,10 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
             camera.transform.localScale = Vector3.one;
         } else {
             if (position.HasValue) {
-                camera.gameObject.transform.position = position.Value;
+                camera.transform.position = position.Value;
             }
             if (rotation.HasValue) {
-                camera.gameObject.transform.eulerAngles = rotation.Value;
+                camera.transform.eulerAngles = rotation.Value;
             }
         }
 
@@ -1311,14 +1311,11 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
                     cMetadata.parentObjectName = camera.transform.parent.name;
 
                     cMetadata.parentPositionRelativeThirdPartyCameraPosition =
-                        camera.transform.parent.InverseTransformPoint(camera.transform.position);
+                        camera.transform.localPosition;
 
                     //get third party camera rotation as quaternion in parent space
-                    var parentSpaceCameraRotationAsQuaternion =
-                        Quaternion.Inverse(camera.transform.parent.rotation)
-                        * worldSpaceCameraRotationAsQuaternion;
                     cMetadata.parentPositionRelativeThirdPartyCameraRotation =
-                        parentSpaceCameraRotationAsQuaternion.eulerAngles;
+                        camera.transform.localEulerAngles;
                 } else {
                     cMetadata.parentObjectName = "";
                     cMetadata.parentPositionRelativeThirdPartyCameraPosition = null;
@@ -1330,7 +1327,7 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
                     GameObject agent = camera.GetComponentInParent<BaseAgentComponent>().gameObject;
 
                     cMetadata.agentPositionRelativeThirdPartyCameraPosition =
-                        agent.transform.InverseTransformPoint(camera.gameObject.transform.position);
+                        agent.transform.InverseTransformPoint(camera.transform.position);
 
                     var agentSpaceCameraRotationAsQuaternion =
                         Quaternion.Inverse(agent.transform.rotation)

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1310,34 +1310,34 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
                 if (camera.transform.parent != null) {
                     cMetadata.parentObjectName = camera.transform.parent.name;
 
-                    cMetadata.parentPositionRelativeThirdPartyCameraPosition =
+                    cMetadata.parentRelativeThirdPartyCameraPosition =
                         camera.transform.localPosition;
 
                     //get third party camera rotation as quaternion in parent space
-                    cMetadata.parentPositionRelativeThirdPartyCameraRotation =
+                    cMetadata.parentRelativeThirdPartyCameraRotation =
                         camera.transform.localEulerAngles;
                 } else {
                     cMetadata.parentObjectName = "";
-                    cMetadata.parentPositionRelativeThirdPartyCameraPosition = null;
-                    cMetadata.parentPositionRelativeThirdPartyCameraRotation = null;
+                    cMetadata.parentRelativeThirdPartyCameraPosition = null;
+                    cMetadata.parentRelativeThirdPartyCameraRotation = null;
                 }
 
                 //if this camera is part of the agent's hierarchy at all, get agent relative info
                 if (camera.GetComponentInParent<BaseAgentComponent>() != null) {
                     GameObject agent = camera.GetComponentInParent<BaseAgentComponent>().gameObject;
 
-                    cMetadata.agentPositionRelativeThirdPartyCameraPosition =
+                    cMetadata.agentRelativeThirdPartyCameraPosition =
                         agent.transform.InverseTransformPoint(camera.transform.position);
 
                     var agentSpaceCameraRotationAsQuaternion =
                         Quaternion.Inverse(agent.transform.rotation)
                         * worldSpaceCameraRotationAsQuaternion;
-                    cMetadata.agentRotationRelativeThirdPartyCameraRotation =
+                    cMetadata.agentRelativeThirdPartyCameraRotation =
                         agentSpaceCameraRotationAsQuaternion.eulerAngles;
                 } else {
                     //if this third party camera is not a child of the agent, we don't need agent-relative coordinates
-                    cMetadata.agentPositionRelativeThirdPartyCameraPosition = null;
-                    cMetadata.agentRotationRelativeThirdPartyCameraRotation = null;
+                    cMetadata.agentRelativeThirdPartyCameraPosition = null;
+                    cMetadata.agentRelativeThirdPartyCameraRotation = null;
                 }
 
                 cMetadata.fieldOfView = camera.fieldOfView;
@@ -1872,12 +1872,12 @@ public class ThirdPartyCameraMetadata {
 
     //note these should only be returned with values
     //if the third party camera is a child of the agent
-    public Vector3? agentPositionRelativeThirdPartyCameraPosition;
-    public Vector3? agentRotationRelativeThirdPartyCameraRotation;
+    public Vector3? agentRelativeThirdPartyCameraPosition;
+    public Vector3? agentRelativeThirdPartyCameraRotation;
 
     //return the local space coordinates if this third party camera has a parent object, this may be the same as agentPositionRelative depending on how things are parented
-    public Vector3? parentPositionRelativeThirdPartyCameraPosition;
-    public Vector3? parentPositionRelativeThirdPartyCameraRotation;
+    public Vector3? parentRelativeThirdPartyCameraPosition;
+    public Vector3? parentRelativeThirdPartyCameraRotation;
     public string parentObjectName; //if this third party camera is in a hierarchy, return the name of the parent object
 }
 

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1317,9 +1317,10 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
                     cMetadata.parentRelativeThirdPartyCameraRotation =
                         camera.transform.localEulerAngles;
                 } else {
+                    //if not parented, default position and rotation to world coordinate space
                     cMetadata.parentObjectName = "";
-                    cMetadata.parentRelativeThirdPartyCameraPosition = null;
-                    cMetadata.parentRelativeThirdPartyCameraRotation = null;
+                    cMetadata.parentRelativeThirdPartyCameraPosition = camera.transform.position;
+                    cMetadata.parentRelativeThirdPartyCameraRotation = camera.transform.rotation.eulerAngles;
                 }
 
                 //if this camera is part of the agent's hierarchy at all, get agent relative info
@@ -1336,6 +1337,8 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
                         agentSpaceCameraRotationAsQuaternion.eulerAngles;
                 } else {
                     //if this third party camera is not a child of the agent, we don't need agent-relative coordinates
+                    //Note: We don't default this to world space because in the case of a multi-agent scenario, the agent 
+                    //to be relative to is ambiguous and UHHHHH
                     cMetadata.agentRelativeThirdPartyCameraPosition = null;
                     cMetadata.agentRelativeThirdPartyCameraRotation = null;
                 }
@@ -1876,8 +1879,8 @@ public class ThirdPartyCameraMetadata {
     public Vector3? agentRelativeThirdPartyCameraRotation;
 
     //return the local space coordinates if this third party camera has a parent object, this may be the same as agentPositionRelative depending on how things are parented
-    public Vector3? parentRelativeThirdPartyCameraPosition;
-    public Vector3? parentRelativeThirdPartyCameraRotation;
+    public Vector3 parentRelativeThirdPartyCameraPosition;
+    public Vector3 parentRelativeThirdPartyCameraRotation;
     public string parentObjectName; //if this third party camera is in a hierarchy, return the name of the parent object
 }
 

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -2629,24 +2629,20 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             metaMessage.cameraPosition = m_Camera.transform.position;
             metaMessage.cameraRotation = m_Camera.transform.eulerAngles;
-            metaMessage.worldRelativeCameraPosition = metaMessage.cameraPosition;
-            metaMessage.worldRelativeCameraRotation = metaMessage.cameraRotation;
+            metaMessage.worldRelativeCameraPosition = m_Camera.transform.position;
+            metaMessage.worldRelativeCameraRotation = m_Camera.transform.eulerAngles;
 
             //we need to transform these relative to the agent position
             //main camera's local space coordinates need to be translated to world space first
             var worldSpaceCameraPosition = m_Camera.transform.position;
             //now convert camera position to agent relative local space
-            metaMessage.agentPositionRelativeCameraPosition = transform.InverseTransformPoint(
-                worldSpaceCameraPosition
-            );
+            metaMessage.agentPositionRelativeCameraPosition = transform.InverseTransformPoint(worldSpaceCameraPosition);
             //Debug.Log($"agentRelativeCameraPosition: {metaMessage.agentPositionRelativeCameraPosition}");
 
             //ok to get local euler angles we need to do... some shenanigans lets go
             var worldSpaceCameraRotationAsQuaternion = m_Camera.transform.rotation;
-            var localSpaceCameraRotationAsQuaternion =
-                Quaternion.Inverse(transform.rotation) * worldSpaceCameraRotationAsQuaternion;
-            metaMessage.agentPositionRelativeCameraRotation =
-                localSpaceCameraRotationAsQuaternion.eulerAngles;
+            var localSpaceCameraRotationAsQuaternion = Quaternion.Inverse(transform.rotation) * worldSpaceCameraRotationAsQuaternion;
+            metaMessage.agentPositionRelativeCameraRotation = localSpaceCameraRotationAsQuaternion.eulerAngles;
             //Debug.Log($"agentRelativeCameraRotation: {metaMessage.agentPositionRelativeCameraRotation}");
 
             metaMessage.cameraOrthSize = cameraOrthSize;

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -2636,13 +2636,17 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             //main camera's local space coordinates need to be translated to world space first
             var worldSpaceCameraPosition = m_Camera.transform.position;
             //now convert camera position to agent relative local space
-            metaMessage.agentPositionRelativeCameraPosition = transform.InverseTransformPoint(worldSpaceCameraPosition);
+            metaMessage.agentPositionRelativeCameraPosition = transform.InverseTransformPoint(
+                worldSpaceCameraPosition
+            );
             //Debug.Log($"agentRelativeCameraPosition: {metaMessage.agentPositionRelativeCameraPosition}");
 
             //ok to get local euler angles we need to do... some shenanigans lets go
             var worldSpaceCameraRotationAsQuaternion = m_Camera.transform.rotation;
-            var localSpaceCameraRotationAsQuaternion = Quaternion.Inverse(transform.rotation) * worldSpaceCameraRotationAsQuaternion;
-            metaMessage.agentPositionRelativeCameraRotation = localSpaceCameraRotationAsQuaternion.eulerAngles;
+            var localSpaceCameraRotationAsQuaternion =
+                Quaternion.Inverse(transform.rotation) * worldSpaceCameraRotationAsQuaternion;
+            metaMessage.agentPositionRelativeCameraRotation =
+                localSpaceCameraRotationAsQuaternion.eulerAngles;
             //Debug.Log($"agentRelativeCameraRotation: {metaMessage.agentPositionRelativeCameraRotation}");
 
             metaMessage.cameraOrthSize = cameraOrthSize;

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -2627,8 +2627,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             metaMessage.screenWidth = Screen.width;
             metaMessage.screenHeight = Screen.height;
 
-            metaMessage.cameraPosition = m_Camera.transform.position;
-            metaMessage.cameraRotation = m_Camera.transform.eulerAngles;
+            metaMessage.cameraPosition = m_Camera.transform.position; //to be deprecated
+            metaMessage.cameraRotation = m_Camera.transform.eulerAngles; //to be deprecated
             metaMessage.worldRelativeCameraPosition = m_Camera.transform.position;
             metaMessage.worldRelativeCameraRotation = m_Camera.transform.eulerAngles;
 
@@ -2645,9 +2645,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             var worldSpaceCameraRotationAsQuaternion = m_Camera.transform.rotation;
             var localSpaceCameraRotationAsQuaternion =
                 Quaternion.Inverse(transform.rotation) * worldSpaceCameraRotationAsQuaternion;
-            metaMessage.agentPositionRelativeCameraRotation =
+            metaMessage.agentRotationRelativeCameraRotation =
                 localSpaceCameraRotationAsQuaternion.eulerAngles;
-            //Debug.Log($"agentRelativeCameraRotation: {metaMessage.agentPositionRelativeCameraRotation}");
+            //Debug.Log($"agentRelativeCameraRotation: {metaMessage.agentRotationRelativeCameraRotation}");
 
             metaMessage.cameraOrthSize = cameraOrthSize;
             cameraOrthSize = -1f;

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -2629,6 +2629,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             metaMessage.cameraPosition = m_Camera.transform.position;
             metaMessage.cameraRotation = m_Camera.transform.eulerAngles;
+            metaMessage.worldRelativeCameraPosition = metaMessage.cameraPosition;
+            metaMessage.worldRelativeCameraRotation = metaMessage.cameraRotation;
 
             //we need to transform these relative to the agent position
             //main camera's local space coordinates need to be translated to world space first

--- a/unity/Assets/Scripts/StretchAgentController.cs
+++ b/unity/Assets/Scripts/StretchAgentController.cs
@@ -739,9 +739,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                 Physics.SyncTransforms();
 
-                Collider c = UtilityFunctions.firstColliderObjectCollidingWith(
-                    go: sop.gameObject
-                );
+                Collider c = UtilityFunctions.firstColliderObjectCollidingWith(go: sop.gameObject);
                 if (c != null) {
                     SimObjPhysics collisionSop = ancestorSimObjPhysics(c.gameObject);
                     errorMessage =

--- a/unity/Assets/UnitTests/TestThirdPartyCameraAndMainCamera.cs
+++ b/unity/Assets/UnitTests/TestThirdPartyCameraAndMainCamera.cs
@@ -312,5 +312,185 @@ namespace Tests
             result = Mathf.Approximately(camera.transform.localEulerAngles.z, 0.0f);
             Assert.AreEqual(result, true);
         }
+
+        //test main camera metadata
+        [UnityTest]
+        public IEnumerator TestMainCameraMetadataReturn() 
+        {
+            bool result = false;
+            Dictionary<string, object> action = new Dictionary<string, object>();
+
+            action["action"] = "Initialize";
+            action["fieldOfView"] = 90f;
+            action["snapToGrid"] = true;
+            yield return step(action);
+
+            action.Clear();
+
+            MetadataWrapper metadata = getLastActionMetadata();
+
+            result = Mathf.Approximately(metadata.worldRelativeCameraPosition.x, -1.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.worldRelativeCameraPosition.y, 1.5759990000f);
+            Assert.AreEqual(result, true);
+            result= Mathf.Approximately(metadata.worldRelativeCameraPosition.z, 1.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.worldRelativeCameraRotation.x, 0.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.worldRelativeCameraRotation.y, 270.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.worldRelativeCameraRotation.z, 0.0000000000f);
+            Assert.AreEqual(result, true);
+
+            result = Mathf.Approximately(metadata.agentPositionRelativeCameraPosition.x, 0.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.agentPositionRelativeCameraPosition.y, 0.6750000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.agentPositionRelativeCameraPosition.z, 0.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.agentPositionRelativeCameraRotation.x, 0.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.agentPositionRelativeCameraRotation.y, 0.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.agentPositionRelativeCameraRotation.z, 0.0000000000f);
+            Assert.AreEqual(result, true);
+
+            action["action"] = "UpdateMainCamera";
+            action["position"] = new Vector3(0.5f, 0.5f, 0.5f);
+            action["rotation"] = new Vector3(30f, 10f, 12f);
+            yield return step(action);
+
+            metadata = getLastActionMetadata();
+
+            result = Mathf.Approximately(metadata.worldRelativeCameraPosition.x, -1.5000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.worldRelativeCameraPosition.y, 1.4009990000f);
+            Assert.AreEqual(result, true);
+            result= Mathf.Approximately(metadata.worldRelativeCameraPosition.z, 1.5000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.worldRelativeCameraRotation.x, 30.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.worldRelativeCameraRotation.y, 280.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.worldRelativeCameraRotation.z, 12.0000000000f);
+            Assert.AreEqual(result, true);
+
+            result = Mathf.Approximately(metadata.agentPositionRelativeCameraPosition.x, 0.5000001000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.agentPositionRelativeCameraPosition.y, 0.4999999000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.agentPositionRelativeCameraPosition.z, 0.5000002000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.agentPositionRelativeCameraRotation.x, 30.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.agentPositionRelativeCameraRotation.y, 10.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.agentPositionRelativeCameraRotation.z, 12.0000000000f);
+            Assert.AreEqual(result, true);
+        }
+
+        //test third party camera metadata
+        [UnityTest]
+        public IEnumerator TestThirdPartyCameraMetadataReturn() 
+        {
+            bool result = false;
+
+            Dictionary<string, object> action = new Dictionary<string, object>();
+
+            action["action"] = "Initialize";
+            action["fieldOfView"] = 90f;
+            action["snapToGrid"] = true;
+            yield return step(action);
+
+            action.Clear();
+
+            action["action"] = "AddThirdPartyCamera";
+            action["position"] = new Vector3(3, 2, 1);
+            action["rotation"] = new Vector3(10, 20, 30);
+            action["parent"] = "world";
+            yield return step(action);
+
+            MetadataWrapper metadata = getLastActionMetadata();
+
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.x, 3.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.y, 2.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.z, 1.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.x, 10.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.y, 20.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.z, 30.0000000000f);
+            Assert.AreEqual(result, true);
+            Assert.AreEqual(metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition, null);
+            Assert.AreEqual(metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraRotation, null);
+            Assert.AreEqual(metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraPosition, null);
+            Assert.AreEqual(metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraRotation, null);
+            Assert.AreEqual(metadata.thirdPartyCameras[0].parentObjectName, "");
+
+            action.Clear();
+
+            //use update third party camera to change camera to be attached to agent
+            action["action"] = "UpdateThirdPartyCamera";
+            action["thirdPartyCameraId"] = 0;
+            action["position"] = new Vector3(1, 2, 3);
+            action["rotation"] = new Vector3(20, 20, 20);
+            action["parent"] = "agent";
+            action["agentPositionRelativeCoordinates"] = true;
+            yield return step(action);
+
+            metadata = getLastActionMetadata();
+
+            // //world relative
+            // Debug.Log($"world relative camera pos: {metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition:F10}");
+            // Debug.Log($"world relative camera rot: {metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation:F10}");
+            // //agent relative
+            // Debug.Log($"agent relative camera pos: {metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition:F10}");
+            // Debug.Log($"agent relative camera rot: {metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraRotation:F10}");
+            // //parent relative
+            // Debug.Log($"parent relative camera rot: {metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraPosition:F10}");
+            // Debug.Log($"parent relative camera rot: {metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraRotation:F10}");
+            // Debug.Log($"parent object name: {metadata.thirdPartyCameras[0].parentObjectName}");
+
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.x, -4.0000010000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.y, 2.9009990000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.z, 2.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.x, 20.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.y, 290.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.z, 20.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition.Value.x, 1.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition.Value.y, 2.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition.Value.z, 3.0000020000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraRotation.Value.x, 20.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraRotation.Value.y, 20.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraRotation.Value.z, 20.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraPosition.Value.x, 1.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraPosition.Value.y, 2.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraPosition.Value.z, 3.0000020000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraRotation.Value.x, 20.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraRotation.Value.y, 20.0000000000f);
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraRotation.Value.z, 20.0000000000f);
+            Assert.AreEqual(result, true);
+            Assert.AreEqual(metadata.thirdPartyCameras[0].parentObjectName, "FPSController");
+        }
     }
 }

--- a/unity/Assets/UnitTests/TestThirdPartyCameraAndMainCamera.cs
+++ b/unity/Assets/UnitTests/TestThirdPartyCameraAndMainCamera.cs
@@ -479,19 +479,19 @@ namespace Tests
             );
             Assert.AreEqual(result, true);
             Assert.AreEqual(
-                metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition,
+                metadata.thirdPartyCameras[0].agentRelativeThirdPartyCameraPosition,
                 null
             );
             Assert.AreEqual(
-                metadata.thirdPartyCameras[0].agentRotationRelativeThirdPartyCameraRotation,
+                metadata.thirdPartyCameras[0].agentRelativeThirdPartyCameraRotation,
                 null
             );
             Assert.AreEqual(
-                metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraPosition,
+                metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraPosition,
                 null
             );
             Assert.AreEqual(
-                metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraRotation,
+                metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraRotation,
                 null
             );
             Assert.AreEqual(metadata.thirdPartyCameras[0].parentObjectName, "");
@@ -513,11 +513,11 @@ namespace Tests
             // Debug.Log($"world relative camera pos: {metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition:F10}");
             // Debug.Log($"world relative camera rot: {metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation:F10}");
             // //agent relative
-            // Debug.Log($"agent relative camera pos: {metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition:F10}");
-            // Debug.Log($"agent relative camera rot: {metadata.thirdPartyCameras[0].agentRotationRelativeThirdPartyCameraRotation:F10}");
+            // Debug.Log($"agent relative camera pos: {metadata.thirdPartyCameras[0].agentRelativeThirdPartyCameraPosition:F10}");
+            // Debug.Log($"agent relative camera rot: {metadata.thirdPartyCameras[0].agentRelativeThirdPartyCameraRotation:F10}");
             // //parent relative
-            // Debug.Log($"parent relative camera rot: {metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraPosition:F10}");
-            // Debug.Log($"parent relative camera rot: {metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraRotation:F10}");
+            // Debug.Log($"parent relative camera rot: {metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraPosition:F10}");
+            // Debug.Log($"parent relative camera rot: {metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraRotation:F10}");
             // Debug.Log($"parent object name: {metadata.thirdPartyCameras[0].parentObjectName}");
 
             result = Mathf.Approximately(
@@ -551,39 +551,39 @@ namespace Tests
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition.Value.x,
+                metadata.thirdPartyCameras[0].agentRelativeThirdPartyCameraPosition.Value.x,
                 1.0000000000f
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition.Value.y,
+                metadata.thirdPartyCameras[0].agentRelativeThirdPartyCameraPosition.Value.y,
                 2.0000000000f
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition.Value.z,
+                metadata.thirdPartyCameras[0].agentRelativeThirdPartyCameraPosition.Value.z,
                 3.0000020000f
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata.thirdPartyCameras[0].agentRotationRelativeThirdPartyCameraRotation.Value.x,
+                metadata.thirdPartyCameras[0].agentRelativeThirdPartyCameraRotation.Value.x,
                 20.0000000000f
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata.thirdPartyCameras[0].agentRotationRelativeThirdPartyCameraRotation.Value.y,
+                metadata.thirdPartyCameras[0].agentRelativeThirdPartyCameraRotation.Value.y,
                 20.0000000000f
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata.thirdPartyCameras[0].agentRotationRelativeThirdPartyCameraRotation.Value.z,
+                metadata.thirdPartyCameras[0].agentRelativeThirdPartyCameraRotation.Value.z,
                 20.0000000000f
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
                 metadata
                     .thirdPartyCameras[0]
-                    .parentPositionRelativeThirdPartyCameraPosition
+                    .parentRelativeThirdPartyCameraPosition
                     .Value
                     .x,
                 1.0000000000f
@@ -592,7 +592,7 @@ namespace Tests
             result = Mathf.Approximately(
                 metadata
                     .thirdPartyCameras[0]
-                    .parentPositionRelativeThirdPartyCameraPosition
+                    .parentRelativeThirdPartyCameraPosition
                     .Value
                     .y,
                 2.0000000000f
@@ -601,7 +601,7 @@ namespace Tests
             result = Mathf.Approximately(
                 metadata
                     .thirdPartyCameras[0]
-                    .parentPositionRelativeThirdPartyCameraPosition
+                    .parentRelativeThirdPartyCameraPosition
                     .Value
                     .z,
                 3.0000020000f
@@ -610,7 +610,7 @@ namespace Tests
             result = Mathf.Approximately(
                 metadata
                     .thirdPartyCameras[0]
-                    .parentPositionRelativeThirdPartyCameraRotation
+                    .parentRelativeThirdPartyCameraRotation
                     .Value
                     .x,
                 20.0000000000f
@@ -619,7 +619,7 @@ namespace Tests
             result = Mathf.Approximately(
                 metadata
                     .thirdPartyCameras[0]
-                    .parentPositionRelativeThirdPartyCameraRotation
+                    .parentRelativeThirdPartyCameraRotation
                     .Value
                     .y,
                 20.0000000000f
@@ -628,7 +628,7 @@ namespace Tests
             result = Mathf.Approximately(
                 metadata
                     .thirdPartyCameras[0]
-                    .parentPositionRelativeThirdPartyCameraRotation
+                    .parentRelativeThirdPartyCameraRotation
                     .Value
                     .z,
                 20.0000000000f

--- a/unity/Assets/UnitTests/TestThirdPartyCameraAndMainCamera.cs
+++ b/unity/Assets/UnitTests/TestThirdPartyCameraAndMainCamera.cs
@@ -315,7 +315,7 @@ namespace Tests
 
         //test main camera metadata
         [UnityTest]
-        public IEnumerator TestMainCameraMetadataReturn() 
+        public IEnumerator TestMainCameraMetadataReturn()
         {
             bool result = false;
             Dictionary<string, object> action = new Dictionary<string, object>();
@@ -333,7 +333,7 @@ namespace Tests
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(metadata.worldRelativeCameraPosition.y, 1.5759990000f);
             Assert.AreEqual(result, true);
-            result= Mathf.Approximately(metadata.worldRelativeCameraPosition.z, 1.0000000000f);
+            result = Mathf.Approximately(metadata.worldRelativeCameraPosition.z, 1.0000000000f);
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(metadata.worldRelativeCameraRotation.x, 0.0000000000f);
             Assert.AreEqual(result, true);
@@ -342,17 +342,35 @@ namespace Tests
             result = Mathf.Approximately(metadata.worldRelativeCameraRotation.z, 0.0000000000f);
             Assert.AreEqual(result, true);
 
-            result = Mathf.Approximately(metadata.agentPositionRelativeCameraPosition.x, 0.0000000000f);
+            result = Mathf.Approximately(
+                metadata.agentPositionRelativeCameraPosition.x,
+                0.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.agentPositionRelativeCameraPosition.y, 0.6750000000f);
+            result = Mathf.Approximately(
+                metadata.agentPositionRelativeCameraPosition.y,
+                0.6750000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.agentPositionRelativeCameraPosition.z, 0.0000000000f);
+            result = Mathf.Approximately(
+                metadata.agentPositionRelativeCameraPosition.z,
+                0.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.agentPositionRelativeCameraRotation.x, 0.0000000000f);
+            result = Mathf.Approximately(
+                metadata.agentPositionRelativeCameraRotation.x,
+                0.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.agentPositionRelativeCameraRotation.y, 0.0000000000f);
+            result = Mathf.Approximately(
+                metadata.agentPositionRelativeCameraRotation.y,
+                0.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.agentPositionRelativeCameraRotation.z, 0.0000000000f);
+            result = Mathf.Approximately(
+                metadata.agentPositionRelativeCameraRotation.z,
+                0.0000000000f
+            );
             Assert.AreEqual(result, true);
 
             action["action"] = "UpdateMainCamera";
@@ -366,7 +384,7 @@ namespace Tests
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(metadata.worldRelativeCameraPosition.y, 1.4009990000f);
             Assert.AreEqual(result, true);
-            result= Mathf.Approximately(metadata.worldRelativeCameraPosition.z, 1.5000000000f);
+            result = Mathf.Approximately(metadata.worldRelativeCameraPosition.z, 1.5000000000f);
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(metadata.worldRelativeCameraRotation.x, 30.0000000000f);
             Assert.AreEqual(result, true);
@@ -375,23 +393,41 @@ namespace Tests
             result = Mathf.Approximately(metadata.worldRelativeCameraRotation.z, 12.0000000000f);
             Assert.AreEqual(result, true);
 
-            result = Mathf.Approximately(metadata.agentPositionRelativeCameraPosition.x, 0.5000001000f);
+            result = Mathf.Approximately(
+                metadata.agentPositionRelativeCameraPosition.x,
+                0.5000001000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.agentPositionRelativeCameraPosition.y, 0.4999999000f);
+            result = Mathf.Approximately(
+                metadata.agentPositionRelativeCameraPosition.y,
+                0.4999999000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.agentPositionRelativeCameraPosition.z, 0.5000002000f);
+            result = Mathf.Approximately(
+                metadata.agentPositionRelativeCameraPosition.z,
+                0.5000002000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.agentPositionRelativeCameraRotation.x, 30.0000000000f);
+            result = Mathf.Approximately(
+                metadata.agentPositionRelativeCameraRotation.x,
+                30.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.agentPositionRelativeCameraRotation.y, 10.0000000000f);
+            result = Mathf.Approximately(
+                metadata.agentPositionRelativeCameraRotation.y,
+                10.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.agentPositionRelativeCameraRotation.z, 12.0000000000f);
+            result = Mathf.Approximately(
+                metadata.agentPositionRelativeCameraRotation.z,
+                12.0000000000f
+            );
             Assert.AreEqual(result, true);
         }
 
         //test third party camera metadata
         [UnityTest]
-        public IEnumerator TestThirdPartyCameraMetadataReturn() 
+        public IEnumerator TestThirdPartyCameraMetadataReturn()
         {
             bool result = false;
 
@@ -412,22 +448,52 @@ namespace Tests
 
             MetadataWrapper metadata = getLastActionMetadata();
 
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.x, 3.0000000000f);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.x,
+                3.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.y, 2.0000000000f);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.y,
+                2.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.z, 1.0000000000f);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.z,
+                1.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.x, 10.0000000000f);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.x,
+                10.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.y, 20.0000000000f);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.y,
+                20.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.z, 30.0000000000f);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.z,
+                30.0000000000f
+            );
             Assert.AreEqual(result, true);
-            Assert.AreEqual(metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition, null);
-            Assert.AreEqual(metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraRotation, null);
-            Assert.AreEqual(metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraPosition, null);
-            Assert.AreEqual(metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraRotation, null);
+            Assert.AreEqual(
+                metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition,
+                null
+            );
+            Assert.AreEqual(
+                metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraRotation,
+                null
+            );
+            Assert.AreEqual(
+                metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraPosition,
+                null
+            );
+            Assert.AreEqual(
+                metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraRotation,
+                null
+            );
             Assert.AreEqual(metadata.thirdPartyCameras[0].parentObjectName, "");
 
             action.Clear();
@@ -454,41 +520,119 @@ namespace Tests
             // Debug.Log($"parent relative camera rot: {metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraRotation:F10}");
             // Debug.Log($"parent object name: {metadata.thirdPartyCameras[0].parentObjectName}");
 
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.x, -4.0000010000f);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.x,
+                -4.0000010000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.y, 2.9009990000f);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.y,
+                2.9009990000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.z, 2.0000000000f);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.z,
+                2.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.x, 20.0000000000f);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.x,
+                20.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.y, 290.0000000000f);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.y,
+                290.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.z, 20.0000000000f);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.z,
+                20.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition.Value.x, 1.0000000000f);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition.Value.x,
+                1.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition.Value.y, 2.0000000000f);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition.Value.y,
+                2.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition.Value.z, 3.0000020000f);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition.Value.z,
+                3.0000020000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraRotation.Value.x, 20.0000000000f);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraRotation.Value.x,
+                20.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraRotation.Value.y, 20.0000000000f);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraRotation.Value.y,
+                20.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraRotation.Value.z, 20.0000000000f);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraRotation.Value.z,
+                20.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraPosition.Value.x, 1.0000000000f);
+            result = Mathf.Approximately(
+                metadata
+                    .thirdPartyCameras[0]
+                    .parentPositionRelativeThirdPartyCameraPosition
+                    .Value
+                    .x,
+                1.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraPosition.Value.y, 2.0000000000f);
+            result = Mathf.Approximately(
+                metadata
+                    .thirdPartyCameras[0]
+                    .parentPositionRelativeThirdPartyCameraPosition
+                    .Value
+                    .y,
+                2.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraPosition.Value.z, 3.0000020000f);
+            result = Mathf.Approximately(
+                metadata
+                    .thirdPartyCameras[0]
+                    .parentPositionRelativeThirdPartyCameraPosition
+                    .Value
+                    .z,
+                3.0000020000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraRotation.Value.x, 20.0000000000f);
+            result = Mathf.Approximately(
+                metadata
+                    .thirdPartyCameras[0]
+                    .parentPositionRelativeThirdPartyCameraRotation
+                    .Value
+                    .x,
+                20.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraRotation.Value.y, 20.0000000000f);
+            result = Mathf.Approximately(
+                metadata
+                    .thirdPartyCameras[0]
+                    .parentPositionRelativeThirdPartyCameraRotation
+                    .Value
+                    .y,
+                20.0000000000f
+            );
             Assert.AreEqual(result, true);
-            result = Mathf.Approximately(metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraRotation.Value.z, 20.0000000000f);
+            result = Mathf.Approximately(
+                metadata
+                    .thirdPartyCameras[0]
+                    .parentPositionRelativeThirdPartyCameraRotation
+                    .Value
+                    .z,
+                20.0000000000f
+            );
             Assert.AreEqual(result, true);
             Assert.AreEqual(metadata.thirdPartyCameras[0].parentObjectName, "FPSController");
         }

--- a/unity/Assets/UnitTests/TestThirdPartyCameraAndMainCamera.cs
+++ b/unity/Assets/UnitTests/TestThirdPartyCameraAndMainCamera.cs
@@ -448,6 +448,7 @@ namespace Tests
 
             MetadataWrapper metadata = getLastActionMetadata();
 
+            // World Relative Position
             result = Mathf.Approximately(
                 metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraPosition.x,
                 3.0000000000f
@@ -463,6 +464,7 @@ namespace Tests
                 1.0000000000f
             );
             Assert.AreEqual(result, true);
+            // World Relative Rotation
             result = Mathf.Approximately(
                 metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation.x,
                 10.0000000000f
@@ -478,6 +480,7 @@ namespace Tests
                 30.0000000000f
             );
             Assert.AreEqual(result, true);
+            //Agent Relative Position
             Assert.AreEqual(
                 metadata.thirdPartyCameras[0].agentRelativeThirdPartyCameraPosition,
                 null
@@ -486,16 +489,39 @@ namespace Tests
                 metadata.thirdPartyCameras[0].agentRelativeThirdPartyCameraRotation,
                 null
             );
-            Assert.AreEqual(
-                metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraPosition,
-                null
+            //Parent Relative Position
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraPosition.x,
+                3.0000000000f
             );
-            Assert.AreEqual(
-                metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraRotation,
-                null
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraPosition.y,
+                2.0000000000f
             );
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraPosition.z,
+                1.0000000000f
+            );
+            Assert.AreEqual(result, true);
+            //Parent Relative Rotation
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraRotation.x,
+                10.0000000000f
+            );
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraRotation.y,
+                20.0000000000f
+            );
+            Assert.AreEqual(result, true);
+            result = Mathf.Approximately(
+                metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraRotation.z,
+                30.0000000000f
+            );
+            Assert.AreEqual(result, true);         
             Assert.AreEqual(metadata.thirdPartyCameras[0].parentObjectName, "");
-
             action.Clear();
 
             //use update third party camera to change camera to be attached to agent
@@ -584,7 +610,6 @@ namespace Tests
                 metadata
                     .thirdPartyCameras[0]
                     .parentRelativeThirdPartyCameraPosition
-                    .Value
                     .x,
                 1.0000000000f
             );
@@ -593,7 +618,6 @@ namespace Tests
                 metadata
                     .thirdPartyCameras[0]
                     .parentRelativeThirdPartyCameraPosition
-                    .Value
                     .y,
                 2.0000000000f
             );
@@ -602,7 +626,6 @@ namespace Tests
                 metadata
                     .thirdPartyCameras[0]
                     .parentRelativeThirdPartyCameraPosition
-                    .Value
                     .z,
                 3.0000020000f
             );
@@ -611,7 +634,6 @@ namespace Tests
                 metadata
                     .thirdPartyCameras[0]
                     .parentRelativeThirdPartyCameraRotation
-                    .Value
                     .x,
                 20.0000000000f
             );
@@ -620,7 +642,6 @@ namespace Tests
                 metadata
                     .thirdPartyCameras[0]
                     .parentRelativeThirdPartyCameraRotation
-                    .Value
                     .y,
                 20.0000000000f
             );
@@ -629,7 +650,6 @@ namespace Tests
                 metadata
                     .thirdPartyCameras[0]
                     .parentRelativeThirdPartyCameraRotation
-                    .Value
                     .z,
                 20.0000000000f
             );

--- a/unity/Assets/UnitTests/TestThirdPartyCameraAndMainCamera.cs
+++ b/unity/Assets/UnitTests/TestThirdPartyCameraAndMainCamera.cs
@@ -358,17 +358,17 @@ namespace Tests
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata.agentPositionRelativeCameraRotation.x,
+                metadata.agentRotationRelativeCameraRotation.x,
                 0.0000000000f
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata.agentPositionRelativeCameraRotation.y,
+                metadata.agentRotationRelativeCameraRotation.y,
                 0.0000000000f
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata.agentPositionRelativeCameraRotation.z,
+                metadata.agentRotationRelativeCameraRotation.z,
                 0.0000000000f
             );
             Assert.AreEqual(result, true);
@@ -409,17 +409,17 @@ namespace Tests
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata.agentPositionRelativeCameraRotation.x,
+                metadata.agentRotationRelativeCameraRotation.x,
                 30.0000000000f
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata.agentPositionRelativeCameraRotation.y,
+                metadata.agentRotationRelativeCameraRotation.y,
                 10.0000000000f
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata.agentPositionRelativeCameraRotation.z,
+                metadata.agentRotationRelativeCameraRotation.z,
                 12.0000000000f
             );
             Assert.AreEqual(result, true);
@@ -483,7 +483,7 @@ namespace Tests
                 null
             );
             Assert.AreEqual(
-                metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraRotation,
+                metadata.thirdPartyCameras[0].agentRotationRelativeThirdPartyCameraRotation,
                 null
             );
             Assert.AreEqual(
@@ -514,7 +514,7 @@ namespace Tests
             // Debug.Log($"world relative camera rot: {metadata.thirdPartyCameras[0].worldRelativeThirdPartyCameraRotation:F10}");
             // //agent relative
             // Debug.Log($"agent relative camera pos: {metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraPosition:F10}");
-            // Debug.Log($"agent relative camera rot: {metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraRotation:F10}");
+            // Debug.Log($"agent relative camera rot: {metadata.thirdPartyCameras[0].agentRotationRelativeThirdPartyCameraRotation:F10}");
             // //parent relative
             // Debug.Log($"parent relative camera rot: {metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraPosition:F10}");
             // Debug.Log($"parent relative camera rot: {metadata.thirdPartyCameras[0].parentPositionRelativeThirdPartyCameraRotation:F10}");
@@ -566,17 +566,17 @@ namespace Tests
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraRotation.Value.x,
+                metadata.thirdPartyCameras[0].agentRotationRelativeThirdPartyCameraRotation.Value.x,
                 20.0000000000f
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraRotation.Value.y,
+                metadata.thirdPartyCameras[0].agentRotationRelativeThirdPartyCameraRotation.Value.y,
                 20.0000000000f
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata.thirdPartyCameras[0].agentPositionRelativeThirdPartyCameraRotation.Value.z,
+                metadata.thirdPartyCameras[0].agentRotationRelativeThirdPartyCameraRotation.Value.z,
                 20.0000000000f
             );
             Assert.AreEqual(result, true);


### PR DESCRIPTION
This updates agent main camera and third party camera returned metadata to be more descriptive and have parity with each other in terms of naming convention and what values are returned. The idea is any camera, main or third party, will always return their position and rotation coordinates in world space and relative to the agent. Third party cameras additionally return position and rotation relative to any parent they might have as third party cameras may be attached to specific segments of articulated agents at some point.

This also fixes a silent bug where third party camera values may have not been correctly being calculated relative to the agent in some circumstances.

metadata now has

- **_worldRelativeCameraPosition_** - New metadata added. same as AgentMetadata.cameraPosition which returns the position of the camera in world coordinates.
- **_worldRelativeCameraRotation_** - New metadata added. same as AgentMetadata.cameraRotation which returns the rotation of the camera in world coordinates
- agentPositionRelativeCameraPosition - this already existed, returns position of the camera relative to the AgentMetadata.position
- agentPositionRelativeCameraRotation - this already existed, returns rotation of the camera relative to the AgentMetadata.position

ThirdPartyCameraMetadata has been updated as well

- **_worldRelativeThirdPartyCameraPosition_** - newly added. the same as ThirdPartyCameraMetadata.position but with more descriptive name
- **_worldRelativeThirdPartyCameraRotation_** - newly added. the same as ThirdPartyCameraMetadata.rotation but with a more descriptive name
- **_agentPositionRelativeThirdPartyCameraPosition_** - newly added. If this third party camera is attached to an agent, returns the position of this camera relative to that agent. Null otherwise.
- **_agentPositionRelativeThirdPartyCameraRotation_** - newly added. If this third party camera is attached to an agent, returns the rotation of this camera relative to that agent, null otherwise
- **_parentPositionRelativeThirdPartyCameraPosition_** - newly added, if this third party camera is the child of some other object, returns the position of this camera relative to that object. Null otherwise. This allows us to track which joint a camera may be attached to for agents with joints and the like.
- **_parentPositionRelativeThirdPartyCameraRotation_** - newly added, if this third party camera is the child of some other object, returns the rotation of this camera relative to that object. Null otherwise. This allows us to track which joint a camera may be attached to for agents with joints and the like.
- **_parentObjectName_** - newly added, if this third party camera has a parent object (which could also be the agent) returns the string name of that object.