### PR TITLE
Updates to Teleport/TeleportFull and isStanding()

### DIFF
--- a/ai2thor/tests/data/arm-metadata-schema.json
+++ b/ai2thor/tests/data/arm-metadata-schema.json
@@ -462,7 +462,7 @@
           "type": "number"
         },
         "isStanding": {
-          "type": "boolean"
+          "type": ["boolean", "null"]
         },
         "inHighFrictionArea": {
           "type": "boolean"

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -1418,16 +1418,17 @@ def test_teleport_stretch(controller):
     agent = "stretch"
 
     event = controller.reset(agentMode=agent)
-    assert event.metadata["agent"]["isStanding"] is None, agent + " cannot stand so this should be None/null!"
+    assert event.metadata["agent"]["isStanding"] is None, (
+        agent + " cannot stand so this should be None/null!"
+    )
 
-    # Only degrees of freedom on the locobot
     for action in ["Teleport", "TeleportFull"]:
         event = controller.step(
             action=action,
             position=dict(x=-1.5, y=0.9, z=-1.5),
             rotation=dict(x=0, y=90, z=0),
             horizon=30,
-            standing=True,
+            standing=None,
         )
 
         print(f"Error Message: {event.metadata['errorMessage']}")

--- a/ai2thor/tests/test_unity.py
+++ b/ai2thor/tests/test_unity.py
@@ -1418,7 +1418,7 @@ def test_teleport_stretch(controller):
     agent = "stretch"
 
     event = controller.reset(agentMode=agent)
-    assert event.metadata["agent"]["isStanding"] is False, agent + " cannot stand!"
+    assert event.metadata["agent"]["isStanding"] is None, agent + " cannot stand so this should be None/null!"
 
     # Only degrees of freedom on the locobot
     for action in ["Teleport", "TeleportFull"]:

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1310,17 +1310,22 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
                 if (camera.transform.parent != null) {
                     cMetadata.parentObjectName = camera.transform.parent.name;
 
-                    cMetadata.parentRelativeThirdPartyCameraPosition =
-                        camera.transform.localPosition;
+                    cMetadata.parentRelativeThirdPartyCameraPosition = camera
+                        .transform
+                        .localPosition;
 
                     //get third party camera rotation as quaternion in parent space
-                    cMetadata.parentRelativeThirdPartyCameraRotation =
-                        camera.transform.localEulerAngles;
+                    cMetadata.parentRelativeThirdPartyCameraRotation = camera
+                        .transform
+                        .localEulerAngles;
                 } else {
                     //if not parented, default position and rotation to world coordinate space
                     cMetadata.parentObjectName = "";
                     cMetadata.parentRelativeThirdPartyCameraPosition = camera.transform.position;
-                    cMetadata.parentRelativeThirdPartyCameraRotation = camera.transform.rotation.eulerAngles;
+                    cMetadata.parentRelativeThirdPartyCameraRotation = camera
+                        .transform
+                        .rotation
+                        .eulerAngles;
                 }
 
                 //if this camera is part of the agent's hierarchy at all, get agent relative info
@@ -1337,7 +1342,7 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
                         agentSpaceCameraRotationAsQuaternion.eulerAngles;
                 } else {
                     //if this third party camera is not a child of the agent, we don't need agent-relative coordinates
-                    //Note: We don't default this to world space because in the case of a multi-agent scenario, the agent 
+                    //Note: We don't default this to world space because in the case of a multi-agent scenario, the agent
                     //to be relative to is ambiguous and UHHHHH
                     cMetadata.agentRelativeThirdPartyCameraPosition = null;
                     cMetadata.agentRelativeThirdPartyCameraRotation = null;

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -320,7 +320,7 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
                 : action.dynamicServerAction.agentInitializationParams
         );
         Debug.Log(
-            $"Initialize of AgentController. lastActionSuccess: {primaryAgent.lastActionSuccess}, errorMessage: {primaryAgent.errorMessage}, actionReturn: {primaryAgent.actionReturn}, agentState: {primaryAgent.agentState}"
+            $"Initialize of AgentController.lastAction: {primaryAgent.lastAction} lastActionSuccess: {primaryAgent.lastActionSuccess}, errorMessage: {primaryAgent.errorMessage}, actionReturn: {primaryAgent.actionReturn}, agentState: {primaryAgent.agentState}"
         );
         Time.fixedDeltaTime = action.fixedDeltaTime.GetValueOrDefault(Time.fixedDeltaTime);
         if (action.targetFrameRate > 0) {

--- a/unity/Assets/Scripts/ArmAgentController.cs
+++ b/unity/Assets/Scripts/ArmAgentController.cs
@@ -275,7 +275,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         ) {
             //non-high level agents cannot set standing
             if(standing != null) {
-                errorMessage = "Cannot set standing for stretch agent";
+                errorMessage = "Cannot set standing for arm/stretch agent";
                 actionFinishedEmit(success:false, actionReturn:null, errorMessage:errorMessage);
                 return;
             }
@@ -298,7 +298,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         ) {
             //non-high level agents cannot set standing
             if(standing != null) {
-                errorMessage = "Cannot set standing for stretch agent";
+                errorMessage = "Cannot set standing for arm/stretch agent";
                 actionFinishedEmit(success:false, actionReturn:null, errorMessage:errorMessage);
                 return;
             }
@@ -318,11 +318,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 
                 // add arm value cases
                 if (!forceAction) {
-                    if (isHandObjectColliding(ignoreAgent: true)) {
-                        throw new InvalidOperationException(
-                            "Cannot teleport due to hand object collision."
-                        );
-                    }
                     if (Arm != null && Arm.IsArmColliding()) {
                         throw new InvalidOperationException(
                             "Mid Level Arm is actively clipping with some geometry in the environment. TeleportFull fails in this position."

--- a/unity/Assets/Scripts/ArmAgentController.cs
+++ b/unity/Assets/Scripts/ArmAgentController.cs
@@ -274,9 +274,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             bool forceAction = false
         ) {
             //non-high level agents cannot set standing
-            if(standing != null) {
+            if (standing != null) {
                 errorMessage = "Cannot set standing for arm/stretch agent";
-                actionFinishedEmit(success:false, actionReturn:null, errorMessage:errorMessage);
+                actionFinishedEmit(success: false, actionReturn: null, errorMessage: errorMessage);
                 return;
             }
 
@@ -290,19 +290,19 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
         public override void TeleportFull(
-            Vector3? position = null, 
-            Vector3? rotation = null, 
-            float? horizon = null, 
-            bool? standing = null, 
+            Vector3? position = null,
+            Vector3? rotation = null,
+            float? horizon = null,
+            bool? standing = null,
             bool forceAction = false
         ) {
             //non-high level agents cannot set standing
-            if(standing != null) {
+            if (standing != null) {
                 errorMessage = "Cannot set standing for arm/stretch agent";
-                actionFinishedEmit(success:false, actionReturn:null, errorMessage:errorMessage);
+                actionFinishedEmit(success: false, actionReturn: null, errorMessage: errorMessage);
                 return;
             }
-            
+
             //cache old values in case there is a failure
             Vector3 oldPosition = transform.position;
             Quaternion oldRotation = transform.rotation;
@@ -315,7 +315,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     horizon: horizon,
                     forceAction: forceAction
                 );
-                
+
                 // add arm value cases
                 if (!forceAction) {
                     if (Arm != null && Arm.IsArmColliding()) {
@@ -329,7 +329,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     }
                     base.assertTeleportedNearGround(targetPosition: position);
                 }
-
             } catch (InvalidOperationException e) {
                 transform.position = oldPosition;
                 transform.rotation = oldRotation;

--- a/unity/Assets/Scripts/DiscreteHidenSeekAgentController.cs
+++ b/unity/Assets/Scripts/DiscreteHidenSeekAgentController.cs
@@ -268,7 +268,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     if (wasStanding == true) {
                         action.action = "Crouch";
                         PhysicsController.ProcessControlCommand(action);
-                    } else if(wasStanding == false) {
+                    } else if (wasStanding == false) {
                         action.action = "Stand";
                         PhysicsController.ProcessControlCommand(action);
                     }

--- a/unity/Assets/Scripts/DiscreteHidenSeekAgentController.cs
+++ b/unity/Assets/Scripts/DiscreteHidenSeekAgentController.cs
@@ -264,10 +264,11 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     ) && PhysicsController.ReadyForCommand
                 ) {
                     ServerAction action = new ServerAction();
-                    if (this.PhysicsController.isStanding()) {
+                    bool? wasStanding = this.PhysicsController.isStanding();
+                    if (wasStanding == true) {
                         action.action = "Crouch";
                         PhysicsController.ProcessControlCommand(action);
-                    } else {
+                    } else if(wasStanding == false) {
                         action.action = "Stand";
                         PhysicsController.ProcessControlCommand(action);
                     }

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -174,27 +174,30 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
         public bool? isStanding() {
-
             //default to not standing if this isn't literally the PhysicsRemoteFPSAgentController
             //this means the metadat for isStanding should always be false for all derived classes
-            if (this.GetType() != typeof(PhysicsRemoteFPSAgentController))
-            {
+            if (this.GetType() != typeof(PhysicsRemoteFPSAgentController)) {
                 return null;
             }
 
             //if camera is in neither the standing or crouching predetermined locations, return null
-            if(UtilityFunctions.ArePositionsApproximatelyEqual(m_Camera.transform.localPosition, standingLocalCameraPosition) == true) {
+            if (
+                UtilityFunctions.ArePositionsApproximatelyEqual(
+                    m_Camera.transform.localPosition,
+                    standingLocalCameraPosition
+                ) == true
+            ) {
                 return true;
-            } 
-             
-            else if(UtilityFunctions.ArePositionsApproximatelyEqual(m_Camera.transform.localPosition, crouchingLocalCameraPosition) == true) {
+            } else if (
+                  UtilityFunctions.ArePositionsApproximatelyEqual(
+                      m_Camera.transform.localPosition,
+                      crouchingLocalCameraPosition
+                  ) == true
+              ) {
                 return false;
-            }
-
-            else {
+            } else {
                 return null;
             }
-
         }
 
         public override MetadataWrapper generateMetadataWrapper() {
@@ -2343,7 +2346,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 bool? standState = isStanding();
                 if (standState == true) {
                     dir = new Vector3(0.0f, -1f, 0.0f);
-                } else if (standState == false){
+                } else if (standState == false) {
                     dir = new Vector3(0.0f, 1f, 0.0f);
                 }
 
@@ -6374,7 +6377,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             if (wasStanding == true) {
                 stand();
-            } else if(wasStanding == false){
+            } else if (wasStanding == false) {
                 crouch();
             }
             transform.position = oldPosition;
@@ -6638,7 +6641,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             // restore old agent pose
             if (wasStanding == true) {
                 stand();
-            } else if(wasStanding == false) {
+            } else if (wasStanding == false) {
                 crouch();
             }
             SetTransform(

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1712,15 +1712,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                             "Cannot teleport due to hand object collision."
                         );
                     }
-                    if (Arm != null && Arm.IsArmColliding()) {
-                        throw new InvalidOperationException(
-                            "Mid Level Arm is actively clipping with some geometry in the environment. TeleportFull fails in this position."
-                        );
-                    } else if (SArm != null && SArm.IsArmColliding()) {
-                        throw new InvalidOperationException(
-                            "Stretch Arm is actively clipping with some geometry in the environment. TeleportFull fails in this position."
-                        );
-                    }
                     base.assertTeleportedNearGround(targetPosition: position);
                 }
             } catch (InvalidOperationException e) {

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -174,6 +174,21 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
         public bool isStanding() {
+
+            //default to not standing if this isn't literally the PhysicsRemoteFPSAgentController
+            //this means the metadat for isStanding should always be false for all derived classes
+            if (this.GetType() != typeof(PhysicsRemoteFPSAgentController))
+            {
+                return false;
+            }
+
+            if(UtilityFunctions.ArePositionsApproximatelyEqual(m_Camera.transform.localPosition, standingLocalCameraPosition) != true &&
+             UtilityFunctions.ArePositionsApproximatelyEqual(m_Camera.transform.localPosition, crouchingLocalCameraPosition) != true) {
+                throw new InvalidOperationException(
+                    $"Camera position is not equal to standing or crouching position. camera local position: {m_Camera.transform.localPosition}, standing local position: {standingLocalCameraPosition}, crouching local position: {crouchingLocalCameraPosition}"
+                );
+            }
+
             return (m_Camera.transform.localPosition - standingLocalCameraPosition).magnitude
                 < 0.1f;
         }
@@ -1625,23 +1640,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         ////////////// TELEPORT FULL //////////////
         ///////////////////////////////////////////
 
-        // [ObsoleteAttribute(message: "This action is deprecated. Call TeleportFull(position, ...) instead.", error: false)]
-        // public void TeleportFull(
-        //     float x, float y, float z,
-        //     float rotation,
-        //     float horizon,
-        //     bool standing,
-        //     bool forceAction = false
-        // ) {
-        //     TeleportFull(
-        //         position: new Vector3(x, y, z),
-        //         rotation: new Vector3(0, rotation, 0),
-        //         horizon: horizon,
-        //         standing: standing,
-        //         forceAction: forceAction
-        //     );
-        // }
-
         [ObsoleteAttribute(
             message: "This action is deprecated. Call TeleportFull(position, ...) instead.",
             error: false
@@ -1664,24 +1662,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             );
         }
 
-        // keep undocumented until float: rotation is added to Stochastic
-        // public void TeleportFull(
-        //     Vector3 position,
-        //     float rotation,
-        //     float horizon,
-        //     bool standing,
-        //     bool forceAction = false
-        // ) {
-        //     TeleportFull(
-        //         position: position,
-        //         rotation: new Vector3(0, rotation, 0),
-        //         horizon: horizon,
-        //         standing: standing,
-        //         forceAction: forceAction
-        //     );
-        // }
-
-        // has to consider both the arm and standing
         public virtual void TeleportFull(
             Vector3? position,
             Vector3? rotation,
@@ -1763,23 +1743,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         //////////////// TELEPORT /////////////////
         ///////////////////////////////////////////
 
-        // [ObsoleteAttribute(message: "This action is deprecated. Call Teleport(position, ...) instead.", error: false)]
-        // public void Teleport(
-        //     float x, float y, float z,
-        //     float? rotation = null,
-        //     float? horizon = null,
-        //     bool? standing = null,
-        //     bool forceAction = false
-        // ) {
-        //     Teleport(
-        //         position: new Vector3(x, y, z),
-        //         rotation: rotation,
-        //         horizon: horizon,
-        //         standing: standing,
-        //         forceAction: forceAction
-        //     );
-        // }
-
         [ObsoleteAttribute(
             message: "This action is deprecated. Call Teleport(position, ...) instead.",
             error: false
@@ -1802,25 +1765,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             );
         }
 
-        // keep undocumented until float: rotation is added to Stochastic
-        // DO NOT add float: rotation to base.
-        // public void Teleport(
-        //     Vector3? position = null,
-        //     float? rotation = null,
-        //     float? horizon = null,
-        //     bool? standing = null,
-        //     bool forceAction = false
-        // ) {
-        //     Teleport(
-        //         position: position,
-        //         rotation: rotation == null ? m_Camera.transform.localEulerAngles : new Vector3(0, (float) rotation, 0),
-        //         horizon: horizon,
-        //         standing: standing,
-        //         forceAction: forceAction
-        //     );
-        // }
-
-        public void Teleport(
+        //keeping 'Teleport' for backwards compatibility
+        public virtual void Teleport(
             Vector3? position = null,
             Vector3? rotation = null,
             float? horizon = null,
@@ -1828,10 +1774,10 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             bool forceAction = false
         ) {
             TeleportFull(
-                position: position == null ? transform.position : (Vector3)position,
-                rotation: rotation == null ? transform.eulerAngles : (Vector3)rotation,
-                horizon: horizon == null ? m_Camera.transform.localEulerAngles.x : (float)horizon,
-                standing: standing == null ? isStanding() : (bool)standing,
+                position: position,
+                rotation: rotation,
+                horizon: horizon,
+                standing: standing,
                 forceAction: forceAction
             );
         }

--- a/unity/Assets/Scripts/StretchAgentController.cs
+++ b/unity/Assets/Scripts/StretchAgentController.cs
@@ -60,10 +60,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             m_Camera.GetComponent<PostProcessVolume>().enabled = true;
             m_Camera.GetComponent<PostProcessLayer>().enabled = true;
 
-            // set camera stand/crouch local positions for Tall mode
-            standingLocalCameraPosition = m_Camera.transform.localPosition;
-            crouchingLocalCameraPosition = m_Camera.transform.localPosition;
-
             // set up main camera parameters
             m_Camera.fieldOfView = 65f;
 
@@ -114,6 +110,10 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             if (setSecondaryParams.GetValueOrDefault()) {
                 CameraParameters.setCameraParameters(fp_camera_2, secondaryCameraParams);
             }
+
+            // set camera stand/crouch local positions for stretch mode even though they arent used
+            standingLocalCameraPosition = m_Camera.transform.localPosition;
+            crouchingLocalCameraPosition = m_Camera.transform.localPosition;
 
             // enable stretch arm component
             Debug.Log("initializing stretch arm");

--- a/unity/Assets/Scripts/UtilityFunctions.cs
+++ b/unity/Assets/Scripts/UtilityFunctions.cs
@@ -484,6 +484,13 @@ public static class UtilityFunctions {
         return allOfTheLights;
     }
 
+    public static bool ArePositionsApproximatelyEqual(Vector3 position1, Vector3 position2) {
+        // Compare each component (x, y, z) of the two positions to see if they are approximately equal via the epsilon value
+        return Mathf.Abs(position1.x - position2.x) < Vector3.kEpsilon
+            && Mathf.Abs(position1.y - position2.y) < Vector3.kEpsilon
+            && Mathf.Abs(position1.z - position2.z) < Vector3.kEpsilon;
+    }
+
 #if UNITY_EDITOR
 
     public static void debugGetLightPropertiesOfScene(List<LightParameters> lights) {

--- a/unity/Assets/Scripts/UtilityFunctions.cs
+++ b/unity/Assets/Scripts/UtilityFunctions.cs
@@ -484,11 +484,11 @@ public static class UtilityFunctions {
         return allOfTheLights;
     }
 
-    public static bool ArePositionsApproximatelyEqual(Vector3 position1, Vector3 position2) {
+    public static bool ArePositionsApproximatelyEqual(Vector3 position1, Vector3 position2, float epsilon = Vector3.kEpsilon) {
         // Compare each component (x, y, z) of the two positions to see if they are approximately equal via the epsilon value
-        return Mathf.Abs(position1.x - position2.x) < Vector3.kEpsilon
-            && Mathf.Abs(position1.y - position2.y) < Vector3.kEpsilon
-            && Mathf.Abs(position1.z - position2.z) < Vector3.kEpsilon;
+        return Mathf.Abs(position1.x - position2.x) < epsilon
+            && Mathf.Abs(position1.y - position2.y) < epsilon
+            && Mathf.Abs(position1.z - position2.z) < epsilon;
     }
 
 #if UNITY_EDITOR

--- a/unity/Assets/UnitTests/Procedural/Movement/TestProceduralTeleport.cs
+++ b/unity/Assets/UnitTests/Procedural/Movement/TestProceduralTeleport.cs
@@ -174,9 +174,7 @@ namespace Tests
                     { "action", "TeleportFull" },
                     { "position", new Vector3(3f, 0.91f, 1.0f) }, //adjusting Y value to be within the error (0.05) of the floor.
                     { "rotation", new Vector3(0f, 180f, 0f) },
-                    // {"forceAction", true},
                     { "horizon", -20f },
-                    { "standing", true }
                 }
             );
 

--- a/unity/Assets/UnitTests/TestThirdPartyCameraAndMainCamera.cs
+++ b/unity/Assets/UnitTests/TestThirdPartyCameraAndMainCamera.cs
@@ -524,7 +524,7 @@ namespace Tests
                 metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraRotation.z,
                 30.0000000000f
             );
-            Assert.AreEqual(result, true);         
+            Assert.AreEqual(result, true);
             Assert.AreEqual(metadata.thirdPartyCameras[0].parentObjectName, "");
             action.Clear();
 
@@ -611,50 +611,32 @@ namespace Tests
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata
-                    .thirdPartyCameras[0]
-                    .parentRelativeThirdPartyCameraPosition
-                    .x,
+                metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraPosition.x,
                 1.0000000000f
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata
-                    .thirdPartyCameras[0]
-                    .parentRelativeThirdPartyCameraPosition
-                    .y,
+                metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraPosition.y,
                 2.0000000000f
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata
-                    .thirdPartyCameras[0]
-                    .parentRelativeThirdPartyCameraPosition
-                    .z,
+                metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraPosition.z,
                 3.0000020000f
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata
-                    .thirdPartyCameras[0]
-                    .parentRelativeThirdPartyCameraRotation
-                    .x,
+                metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraRotation.x,
                 20.0000000000f
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata
-                    .thirdPartyCameras[0]
-                    .parentRelativeThirdPartyCameraRotation
-                    .y,
+                metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraRotation.y,
                 20.0000000000f
             );
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(
-                metadata
-                    .thirdPartyCameras[0]
-                    .parentRelativeThirdPartyCameraRotation
-                    .z,
+                metadata.thirdPartyCameras[0].parentRelativeThirdPartyCameraRotation.z,
                 20.0000000000f
             );
             Assert.AreEqual(result, true);

--- a/unity/Assets/UnitTests/TestThirdPartyCameraAndMainCamera.cs
+++ b/unity/Assets/UnitTests/TestThirdPartyCameraAndMainCamera.cs
@@ -329,6 +329,8 @@ namespace Tests
 
             MetadataWrapper metadata = getLastActionMetadata();
 
+            Debug.Log($"what was standing: {metadata.agent.isStanding}");
+
             result = Mathf.Approximately(metadata.worldRelativeCameraPosition.x, -1.0000000000f);
             Assert.AreEqual(result, true);
             result = Mathf.Approximately(metadata.worldRelativeCameraPosition.y, 1.5759990000f);
@@ -379,6 +381,8 @@ namespace Tests
             yield return step(action);
 
             metadata = getLastActionMetadata();
+
+            Debug.Log($"what was standing after UpdateMainCamera: {metadata.agent.isStanding}");
 
             result = Mathf.Approximately(metadata.worldRelativeCameraPosition.x, -1.5000000000f);
             Assert.AreEqual(result, true);


### PR DESCRIPTION
The purpose of these updates is to prevent an edge case where, when using an arm-typed agent, calling the Teleport action would cause the isStanding value to default in a weird way, causing the main camera of the arm-typed agent to be changed unexpectedly back to a default position that only has context for the high-level-agent. This update also catches a case where, when using the high-level agent and calling `UpdateMainCamera`, the `isStanding() return became ambiguous.

- adding an override to the Teleport/TeleportFull actions in the `ArmAgentController` class and its derived classes so that an error can be thrown if passing in the `standing` bool since arm agents don't have a concept of a standing vs crouching camera position

- updating the isStanding() helper function to return `null` in cases where the High Level Agent's main camera is not in either the hard-coded standing or crouching local position.