### PR TITLE
Toggle Main Camera Mesh Tracking

### DIFF
--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -88,7 +88,8 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
         "UpdateThirdPartyCamera",
         "ChangeResolution",
         "CoordinateFromRaycastThirdPartyCamera",
-        "ChangeQuality"
+        "ChangeQuality",
+        "ToggleAgentMainCameraMeshTracking"
     };
     public HashSet<string> errorAllowedActions = new HashSet<string> { "Reset" };
 
@@ -824,6 +825,28 @@ public class AgentManager : MonoBehaviour, ActionInvokable {
             this.y = y;
             this.z = z;
         }
+    }
+
+    //toggles off any meshes on the agent that are tracking the position/rotation of the main camera
+    //this allows us to call things like UpdateMainCamera without parts of the agent body mesh moving
+    public void ToggleAgentMainCameraMeshTracking(bool toggleOff = true, int agentId = 0) {
+        //which agent are we talking about?
+        //default to agent 0
+        var agent = this.agents[agentId];
+
+        List<SyncTransform> st = UtilityFunctions.FindAllComponentsInChildren<SyncTransform>(agent.transform);
+
+        if(st.Count > 0) {
+            foreach (SyncTransform s in st) {
+                s.enabled = !toggleOff;
+            }
+        } else {
+            throw new InvalidOperationException(
+                $"Agent {agentId} does not have any SyncTransform components to toggle."
+            );
+        }
+
+        agent.actionFinishedEmit(success:true);
     }
 
     //allows repositioning and changing of values of agent's primary camera

--- a/unity/Assets/Scripts/DebugInputField.cs
+++ b/unity/Assets/Scripts/DebugInputField.cs
@@ -2801,6 +2801,15 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         break;
                     }
 
+                //allows us to toggle of any meshes tracking the positiong and rotation of the main camera
+                case "tamcmt": {
+                        Dictionary<string, object> action = new Dictionary<string, object>();
+                        action["action"] = "ToggleAgentMainCameraMeshTracking";
+                        action["toggleOff"] = true;
+                        CurrentActiveController().ProcessControlCommand(new DynamicServerAction(action), AManager);                        
+                        break;
+                    }
+
                 // put an object down with stationary false
                 case "putf": {
                         Dictionary<string, object> action = new Dictionary<string, object>();

--- a/unity/Assets/Scripts/UtilityFunctions.cs
+++ b/unity/Assets/Scripts/UtilityFunctions.cs
@@ -398,6 +398,27 @@ public static class UtilityFunctions {
         return corners;
     }
 
+    // Recursive method to find and return all instances of the component in the hierarchy
+    public static List<T> FindAllComponentsInChildren<T>(Transform parent) where T : Component
+    {
+        List<T> components = new List<T>();
+
+        // Check if the parent itself has the component
+        T component = parent.GetComponent<T>();
+        if (component != null)
+        {
+            components.Add(component);
+        }
+
+        // Loop through all children and collect their components recursively
+        foreach (Transform child in parent)
+        {
+            components.AddRange(FindAllComponentsInChildren<T>(child));
+        }
+
+        return components;
+    }
+
     public static List<LightParameters> GetLightPropertiesOfScene() {
         Debug.Log("we are inside GetLIghtPropertiesOfScene");
         var lightsInScene = UnityEngine.Object.FindObjectsOfType<Light>(true);


### PR DESCRIPTION
This adds a quick action that allows the agent to turn off the default syncing of certain parts of some agent body mesh and the actual main camera game object (ie: the "head" of the high level agent or the mounted camera of the stretch agent) 

Because we now allow more control over main camera positions relative to the agent body via the `UpdateMainCamera()`, this action can be used in tandem to ensure a modified main camera does not adversely affect the agent's mesh representation.