### PR TITLE
Maintain contained objects when placed on stove

### DIFF
--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4431,6 +4431,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     ItemInHand.transform.localRotation = Quaternion.identity;
                     ItemInHand.GetComponent<Rigidbody>().isKinematic = true;
                     ItemInHand.GetComponent<SimObjPhysics>().isInAgentHand = false; // remove in agent hand flag
+                    
+                    // if this object is a receptacle and it has other objects inside it, drop them all together
+                    SimObjPhysics sop = ItemInHand.GetComponentInParent<SimObjPhysics>();
+                    if (sop.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.Receptacle)) {
+                        sop.DropContainedObjectsStationary(); // use stationary version so that colliders are turned back on, but kinematics remain true
+                    }
+                    
                     ItemInHand = null;
                     DefaultAgentHand();
                     actionFinished(true);


### PR DESCRIPTION
Without this, a pan with a potato in it placed on the stove will no longer logically contain the potato (i.e. the potato will be missing from `receptacleObjectIds`), even though it's clearly still sitting there in the pan. The code, including the comment about why we use the stationary drop, is copied exactly from the `PlaceObject()`, where I observed it working fine for the case of placing the pan with the potato in it onto the counter.

I don't understand all of the details of the system yet, so it's possible that the stationary drop was not the right action to take. I'm also unaware of how to write unit tests for this project, but if you can provide some guidance then I will be happy to contribute some. I did do manual testing, though, and the `receptacleObjectIds` property has been fixed for the case outlined above.

